### PR TITLE
38417830: ani2psl API call is crushing cNode if the incorrect ANI address is passed

### DIFF
--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#       http://www.gnu.org/software/autoconf-archive/ax_boost_base.html
+#      https://www.gnu.org/software/autoconf-archive/ax_boost_base.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -33,7 +33,15 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 26
+#serial 49
+
+# example boost program (need to pass version)
+m4_define([_AX_BOOST_BASE_PROGRAM],
+          [AC_LANG_PROGRAM([[
+#include <boost/version.hpp>
+]],[[
+(void) ((void)sizeof(char[1 - 2*!!((BOOST_VERSION) < ($1))]));
+]])])
 
 AC_DEFUN([AX_BOOST_BASE],
 [
@@ -44,110 +52,123 @@ AC_ARG_WITH([boost],
      or disable it (ARG=no)
      @<:@ARG=yes@:>@ ])],
     [
-    if test "$withval" = "no"; then
-        want_boost="no"
-    elif test "$withval" = "yes"; then
-        want_boost="yes"
-        ac_boost_path=""
-    else
-        want_boost="yes"
-        ac_boost_path="$withval"
-    fi
+     AS_CASE([$withval],
+       [no],[want_boost="no";_AX_BOOST_BASE_boost_path=""],
+       [yes],[want_boost="yes";_AX_BOOST_BASE_boost_path=""],
+       [want_boost="yes";_AX_BOOST_BASE_boost_path="$withval"])
     ],
     [want_boost="yes"])
 
 
 AC_ARG_WITH([boost-libdir],
-        AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
-        [Force given directory for boost libraries. Note that this will override library path detection, so use this parameter only if default library detection fails and you know exactly where your boost libraries are located.]),
-        [
-        if test -d "$withval"
-        then
-                ac_boost_lib_path="$withval"
-        else
-                AC_MSG_ERROR(--with-boost-libdir expected directory name)
-        fi
-        ],
-        [ac_boost_lib_path=""]
-)
+  [AS_HELP_STRING([--with-boost-libdir=LIB_DIR],
+    [Force given directory for boost libraries.
+     Note that this will override library path detection,
+     so use this parameter only if default library detection fails
+     and you know exactly where your boost libraries are located.])],
+  [
+   AS_IF([test -d "$withval"],
+         [_AX_BOOST_BASE_boost_lib_path="$withval"],
+    [AC_MSG_ERROR([--with-boost-libdir expected directory name])])
+  ],
+  [_AX_BOOST_BASE_boost_lib_path=""])
 
-if test "x$want_boost" = "xyes"; then
-    boost_lib_version_req=ifelse([$1], ,1.20.0,$1)
-    boost_lib_version_req_shorten=`expr $boost_lib_version_req : '\([[0-9]]*\.[[0-9]]*\)'`
-    boost_lib_version_req_major=`expr $boost_lib_version_req : '\([[0-9]]*\)'`
-    boost_lib_version_req_minor=`expr $boost_lib_version_req : '[[0-9]]*\.\([[0-9]]*\)'`
-    boost_lib_version_req_sub_minor=`expr $boost_lib_version_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
-    if test "x$boost_lib_version_req_sub_minor" = "x" ; then
-        boost_lib_version_req_sub_minor="0"
-        fi
-    WANT_BOOST_VERSION=`expr $boost_lib_version_req_major \* 100000 \+  $boost_lib_version_req_minor \* 100 \+ $boost_lib_version_req_sub_minor`
-    AC_MSG_CHECKING(for boostlib >= $boost_lib_version_req)
+BOOST_LDFLAGS=""
+BOOST_CPPFLAGS=""
+AS_IF([test "x$want_boost" = "xyes"],
+      [_AX_BOOST_BASE_RUNDETECT([$1],[$2],[$3])])
+AC_SUBST(BOOST_CPPFLAGS)
+AC_SUBST(BOOST_LDFLAGS)
+])
+
+
+# convert a version string in $2 to numeric and affect to polymorphic var $1
+AC_DEFUN([_AX_BOOST_BASE_TONUMERICVERSION],[
+  AS_IF([test "x$2" = "x"],[_AX_BOOST_BASE_TONUMERICVERSION_req="1.20.0"],[_AX_BOOST_BASE_TONUMERICVERSION_req="$2"])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_shorten=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\.[[0-9]]*\)'`
+  _AX_BOOST_BASE_TONUMERICVERSION_req_major=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '\([[0-9]]*\)'`
+  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_major" = "x"],
+        [AC_MSG_ERROR([You should at least specify libboost major version])])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.\([[0-9]]*\)'`
+  AS_IF([test "x$_AX_BOOST_BASE_TONUMERICVERSION_req_minor" = "x"],
+        [_AX_BOOST_BASE_TONUMERICVERSION_req_minor="0"])
+  _AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req : '[[0-9]]*\.[[0-9]]*\.\([[0-9]]*\)'`
+  AS_IF([test "X$_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor" = "X"],
+        [_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor="0"])
+  _AX_BOOST_BASE_TONUMERICVERSION_RET=`expr $_AX_BOOST_BASE_TONUMERICVERSION_req_major \* 100000 \+  $_AX_BOOST_BASE_TONUMERICVERSION_req_minor \* 100 \+ $_AX_BOOST_BASE_TONUMERICVERSION_req_sub_minor`
+  AS_VAR_SET($1,$_AX_BOOST_BASE_TONUMERICVERSION_RET)
+])
+
+dnl Run the detection of boost should be run only if $want_boost
+AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
+    _AX_BOOST_BASE_TONUMERICVERSION(WANT_BOOST_VERSION,[$1])
     succeeded=no
 
+
+    AC_REQUIRE([AC_CANONICAL_HOST])
     dnl On 64-bit systems check for system libraries in both lib64 and lib.
     dnl The former is specified by FHS, but e.g. Debian does not adhere to
     dnl this (as it rises problems for generic multi-arch support).
     dnl The last entry in the list is chosen by default when no libraries
     dnl are found, e.g. when only header-only libraries are installed!
-    libsubdirs="lib"
-    ax_arch=`uname -m`
-    case $ax_arch in
-      x86_64)
-        libsubdirs="lib64 libx32 lib lib64"
-        ;;
-      ppc64|s390x|sparc64|aarch64|ppc64le)
-        libsubdirs="lib64 lib lib64 ppc64le"
-        ;;
-    esac
+    AS_CASE([${host_cpu}],
+      [x86_64],[libsubdirs="lib64 libx32 lib lib64"],
+      [mips*64*],[libsubdirs="lib64 lib32 lib lib64"],
+      [ppc64|powerpc64|s390x|sparc64|aarch64|ppc64le|powerpc64le|riscv64|e2k],[libsubdirs="lib64 lib lib64"],
+      [libsubdirs="lib"]
+    )
 
     dnl allow for real multi-arch paths e.g. /usr/lib/x86_64-linux-gnu. Give
     dnl them priority over the other paths since, if libs are found there, they
     dnl are almost assuredly the ones desired.
-    AC_REQUIRE([AC_CANONICAL_HOST])
-    libsubdirs="lib/${host_cpu}-${host_os} $libsubdirs"
-
-    case ${host_cpu} in
-      i?86)
-        libsubdirs="lib/i386-${host_os} $libsubdirs"
-        ;;
-    esac
-
-    dnl some arches may advertise a cpu type that doesn't line up with their
-    dnl prefix's cpu type. For example, uname may report armv7l while libs are
-    dnl installed to /usr/lib/arm-linux-gnueabihf. Try getting the compiler's
-    dnl value for an extra chance of finding the correct path.
-    libsubdirs="lib/`$CXX -dumpmachine 2>/dev/null` $libsubdirs"
+    AS_CASE([${host_cpu}],
+      [i?86],[multiarch_libsubdir="lib/i386-${host_os}"],
+      [armv7l],[multiarch_libsubdir="lib/arm-${host_os}"],
+      [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
+    )
 
     dnl first we check the system location for boost libraries
     dnl this location ist chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
-    if test "$ac_boost_path" != ""; then
-        BOOST_CPPFLAGS="-I$ac_boost_path/include"
-        for ac_boost_path_tmp in $libsubdirs; do
-                if test -d "$ac_boost_path"/"$ac_boost_path_tmp" ; then
-                        BOOST_LDFLAGS="-L$ac_boost_path/$ac_boost_path_tmp"
-                        break
-                fi
-        done
-    elif test "$cross_compiling" != yes; then
-        for ac_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
-            if test -d "$ac_boost_path_tmp/include/boost" && test -r "$ac_boost_path_tmp/include/boost"; then
-                for libsubdir in $libsubdirs ; do
-                    if ls "$ac_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+    AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
+        AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_boost_path/include"])
+         AS_IF([test -d "$_AX_BOOST_BASE_boost_path/include" && test -r "$_AX_BOOST_BASE_boost_path/include"],[
+           AC_MSG_RESULT([yes])
+           BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include"
+           for _AX_BOOST_BASE_boost_path_tmp in $multiarch_libsubdir $libsubdirs; do
+                AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) lib path in "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp"])
+                AS_IF([test -d "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" && test -r "$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp" ],[
+                        AC_MSG_RESULT([yes])
+                        BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path/$_AX_BOOST_BASE_boost_path_tmp";
+                        break;
+                ],
+      [AC_MSG_RESULT([no])])
+           done],[
+      AC_MSG_RESULT([no])])
+    ],[
+        if test X"$cross_compiling" = Xyes; then
+            search_libsubdirs=$multiarch_libsubdir
+        else
+            search_libsubdirs="$multiarch_libsubdir $libsubdirs"
+        fi
+        for _AX_BOOST_BASE_boost_path_tmp in /usr /usr/local /opt /opt/local ; do
+            if test -d "$_AX_BOOST_BASE_boost_path_tmp/include/boost" && test -r "$_AX_BOOST_BASE_boost_path_tmp/include/boost" ; then
+                for libsubdir in $search_libsubdirs ; do
+                    if ls "$_AX_BOOST_BASE_boost_path_tmp/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
                 done
-                BOOST_LDFLAGS="-L$ac_boost_path_tmp/$libsubdir"
-                BOOST_CPPFLAGS="-I$ac_boost_path_tmp/include"
+                BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path_tmp/$libsubdir"
+                BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path_tmp/include"
                 break;
             fi
         done
-    fi
+    ])
 
     dnl overwrite ld flags if we have required special directory with
     dnl --with-boost-libdir parameter
-    if test "$ac_boost_lib_path" != ""; then
-       BOOST_LDFLAGS="-L$ac_boost_lib_path"
-    fi
+    AS_IF([test "x$_AX_BOOST_BASE_boost_lib_path" != "x"],
+          [BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_lib_path"])
 
+    AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION)])
     CPPFLAGS_SAVED="$CPPFLAGS"
     CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
     export CPPFLAGS
@@ -158,15 +179,7 @@ if test "x$want_boost" = "xyes"; then
 
     AC_REQUIRE([AC_PROG_CXX])
     AC_LANG_PUSH(C++)
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    @%:@include <boost/version.hpp>
-    ]], [[
-    #if BOOST_VERSION >= $WANT_BOOST_VERSION
-    // Everything is okay
-    #else
-    #  error Boost version is too old
-    #endif
-    ]])],[
+        AC_COMPILE_IFELSE([_AX_BOOST_BASE_PROGRAM($WANT_BOOST_VERSION)],[
         AC_MSG_RESULT(yes)
     succeeded=yes
     found_system=yes
@@ -178,40 +191,50 @@ if test "x$want_boost" = "xyes"; then
 
     dnl if we found no boost with system layout we search for boost libraries
     dnl built and installed without the --layout=system option or for a staged(not installed) version
-    if test "x$succeeded" != "xyes"; then
+    if test "x$succeeded" != "xyes" ; then
         CPPFLAGS="$CPPFLAGS_SAVED"
         LDFLAGS="$LDFLAGS_SAVED"
         BOOST_CPPFLAGS=
-        BOOST_LDFLAGS=
+        if test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
+            BOOST_LDFLAGS=
+        fi
         _version=0
-        if test "$ac_boost_path" != ""; then
-            if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
-                for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
-                    _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+        if test -n "$_AX_BOOST_BASE_boost_path" ; then
+            if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path"; then
+                for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
+                    _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
                     V_CHECK=`expr $_version_tmp \> $_version`
-                    if test "$V_CHECK" = "1" ; then
+                    if test "x$V_CHECK" = "x1" ; then
                         _version=$_version_tmp
                     fi
                     VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
-                    BOOST_CPPFLAGS="-I$ac_boost_path/include/boost-$VERSION_UNDERSCORE"
+                    BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path/include/boost-$VERSION_UNDERSCORE"
                 done
                 dnl if nothing found search for layout used in Windows distributions
                 if test -z "$BOOST_CPPFLAGS"; then
-                    if test -d "$ac_boost_path/boost" && test -r "$ac_boost_path/boost"; then
-                        BOOST_CPPFLAGS="-I$ac_boost_path"
+                    if test -d "$_AX_BOOST_BASE_boost_path/boost" && test -r "$_AX_BOOST_BASE_boost_path/boost"; then
+                        BOOST_CPPFLAGS="-I$_AX_BOOST_BASE_boost_path"
                     fi
+                fi
+                dnl if we found something and BOOST_LDFLAGS was unset before
+                dnl (because "$_AX_BOOST_BASE_boost_lib_path" = ""), set it here.
+                if test -n "$BOOST_CPPFLAGS" && test -z "$BOOST_LDFLAGS"; then
+                    for libsubdir in $libsubdirs ; do
+                        if ls "$_AX_BOOST_BASE_boost_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
+                    done
+                    BOOST_LDFLAGS="-L$_AX_BOOST_BASE_boost_path/$libsubdir"
                 fi
             fi
         else
-            if test "$cross_compiling" != yes; then
-                for ac_boost_path in /usr /usr/local /opt /opt/local ; do
-                    if test -d "$ac_boost_path" && test -r "$ac_boost_path"; then
-                        for i in `ls -d $ac_boost_path/include/boost-* 2>/dev/null`; do
-                            _version_tmp=`echo $i | sed "s#$ac_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
+            if test "x$cross_compiling" != "xyes" ; then
+                for _AX_BOOST_BASE_boost_path in /usr /usr/local /opt /opt/local ; do
+                    if test -d "$_AX_BOOST_BASE_boost_path" && test -r "$_AX_BOOST_BASE_boost_path" ; then
+                        for i in `ls -d $_AX_BOOST_BASE_boost_path/include/boost-* 2>/dev/null`; do
+                            _version_tmp=`echo $i | sed "s#$_AX_BOOST_BASE_boost_path##" | sed 's/\/include\/boost-//' | sed 's/_/./'`
                             V_CHECK=`expr $_version_tmp \> $_version`
-                            if test "$V_CHECK" = "1" ; then
+                            if test "x$V_CHECK" = "x1" ; then
                                 _version=$_version_tmp
-                                best_path=$ac_boost_path
+                                best_path=$_AX_BOOST_BASE_boost_path
                             fi
                         done
                     fi
@@ -219,7 +242,7 @@ if test "x$want_boost" = "xyes"; then
 
                 VERSION_UNDERSCORE=`echo $_version | sed 's/\./_/'`
                 BOOST_CPPFLAGS="-I$best_path/include/boost-$VERSION_UNDERSCORE"
-                if test "$ac_boost_lib_path" = ""; then
+                if test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
                     for libsubdir in $libsubdirs ; do
                         if ls "$best_path/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
                     done
@@ -227,7 +250,7 @@ if test "x$want_boost" = "xyes"; then
                 fi
             fi
 
-            if test "x$BOOST_ROOT" != "x"; then
+            if test -n "$BOOST_ROOT" ; then
                 for libsubdir in $libsubdirs ; do
                     if ls "$BOOST_ROOT/stage/$libsubdir/libboost_"* >/dev/null 2>&1 ; then break; fi
                 done
@@ -236,7 +259,7 @@ if test "x$want_boost" = "xyes"; then
                     stage_version=`echo $version_dir | sed 's/boost_//' | sed 's/_/./g'`
                         stage_version_shorten=`expr $stage_version : '\([[0-9]]*\.[[0-9]]*\)'`
                     V_CHECK=`expr $stage_version_shorten \>\= $_version`
-                    if test "$V_CHECK" = "1" -a "$ac_boost_lib_path" = "" ; then
+                    if test "x$V_CHECK" = "x1" && test -z "$_AX_BOOST_BASE_boost_lib_path" ; then
                         AC_MSG_NOTICE(We will use a staged boost library from $BOOST_ROOT)
                         BOOST_CPPFLAGS="-I$BOOST_ROOT"
                         BOOST_LDFLAGS="-L$BOOST_ROOT/stage/$libsubdir"
@@ -251,15 +274,7 @@ if test "x$want_boost" = "xyes"; then
         export LDFLAGS
 
         AC_LANG_PUSH(C++)
-            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        @%:@include <boost/version.hpp>
-        ]], [[
-        #if BOOST_VERSION >= $WANT_BOOST_VERSION
-        // Everything is okay
-        #else
-        #  error Boost version is too old
-        #endif
-        ]])],[
+            AC_COMPILE_IFELSE([_AX_BOOST_BASE_PROGRAM($WANT_BOOST_VERSION)],[
             AC_MSG_RESULT(yes)
         succeeded=yes
         found_system=yes
@@ -268,17 +283,15 @@ if test "x$want_boost" = "xyes"; then
         AC_LANG_POP([C++])
     fi
 
-    if test "$succeeded" != "yes" ; then
-        if test "$_version" = "0" ; then
-            AC_MSG_NOTICE([[We could not detect the boost libraries (version $boost_lib_version_req_shorten or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
+    if test "x$succeeded" != "xyes" ; then
+        if test "x$_version" = "x0" ; then
+            AC_MSG_NOTICE([[We could not detect the boost libraries (version $1 or higher). If you have a staged boost library (still not installed) please specify \$BOOST_ROOT in your environment and do not give a PATH to --with-boost option.  If you are sure you have boost installed, then check your version number looking in <boost/version.hpp>. See http://randspringer.de/boost for more documentation.]])
         else
             AC_MSG_NOTICE([Your boost libraries seems to old (version $_version).])
         fi
         # execute ACTION-IF-NOT-FOUND (if present):
         ifelse([$3], , :, [$3])
     else
-        AC_SUBST(BOOST_CPPFLAGS)
-        AC_SUBST(BOOST_LDFLAGS)
         AC_DEFINE(HAVE_BOOST,,[define if the Boost library is available])
         # execute ACTION-IF-FOUND (if present):
         ifelse([$2], , :, [$2])
@@ -286,6 +299,5 @@ if test "x$want_boost" = "xyes"; then
 
     CPPFLAGS="$CPPFLAGS_SAVED"
     LDFLAGS="$LDFLAGS_SAVED"
-fi
 
 ])

--- a/build-aux/m4/ax_boost_chrono.m4
+++ b/build-aux/m4/ax_boost_chrono.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#      http://www.gnu.org/software/autoconf-archive/ax_boost_chrono.html
+#     https://www.gnu.org/software/autoconf-archive/ax_boost_chrono.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -8,7 +8,7 @@
 #
 # DESCRIPTION
 #
-#   Test for System library from the Boost C++ libraries. The macro requires
+#   Test for Chrono library from the Boost C++ libraries. The macro requires
 #   a preceding call to AX_BOOST_BASE. Further documentation is available at
 #   <http://randspringer.de/boost/index.html>.
 #
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 5
 
 AC_DEFUN([AX_BOOST_CHRONO],
 [
@@ -68,7 +68,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 			 CXXFLAGS_SAVE=$CXXFLAGS
 
 			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/chrono.hpp>]],
-                                   [[boost::chrono::system_clock::time_point time;]])],
+                                   [[boost::chrono::system_clock::time_point* time = new boost::chrono::system_clock::time_point; delete time;]])],
                    ax_cv_boost_chrono=yes, ax_cv_boost_chrono=no)
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
@@ -81,7 +81,6 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
 			LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_chrono_lib" = "x"; then
-                ax_lib=
                 for libextension in `ls $BOOSTLIBDIR/libboost_chrono*.so* $BOOSTLIBDIR/libboost_chrono*.dylib* $BOOSTLIBDIR/libboost_chrono*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_chrono.*\)\.so.*$;\1;' -e 's;^lib\(boost_chrono.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_chrono.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -106,7 +105,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_chrono library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Chrono library!)
             fi
 			if test "x$link_chrono" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_boost_filesystem.m4
+++ b/build-aux/m4/ax_boost_filesystem.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#    http://www.gnu.org/software/autoconf-archive/ax_boost_filesystem.html
+#   https://www.gnu.org/software/autoconf-archive/ax_boost_filesystem.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 26
+#serial 28
 
 AC_DEFUN([AX_BOOST_FILESYSTEM],
 [
@@ -80,7 +80,6 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 		if test "x$ax_cv_boost_filesystem" = "xyes"; then
 			AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-            ax_lib=
             if test "x$ax_boost_user_filesystem_lib" = "x"; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
@@ -105,7 +104,7 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_filesystem library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Filesystem library!)
             fi
 			if test "x$link_filesystem" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_boost_program_options.m4
+++ b/build-aux/m4/ax_boost_program_options.m4
@@ -1,6 +1,6 @@
-# ============================================================================
-#  http://www.gnu.org/software/autoconf-archive/ax_boost_program_options.html
-# ============================================================================
+# =============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_boost_program_options.html
+# =============================================================================
 #
 # SYNOPSIS
 #
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 24
+#serial 26
 
 AC_DEFUN([AX_BOOST_PROGRAM_OPTIONS],
 [
@@ -96,7 +96,7 @@ AC_DEFUN([AX_BOOST_PROGRAM_OPTIONS],
                   done
                 fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_program_options library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Program_Options library!)
             fi
 				if test "x$link_program_options" != "xyes"; then
 					AC_MSG_ERROR([Could not link against [$ax_lib] !])

--- a/build-aux/m4/ax_boost_system.m4
+++ b/build-aux/m4/ax_boost_system.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#      http://www.gnu.org/software/autoconf-archive/ax_boost_system.html
+#     https://www.gnu.org/software/autoconf-archive/ax_boost_system.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 18
+#serial 20
 
 AC_DEFUN([AX_BOOST_SYSTEM],
 [
@@ -84,7 +84,6 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 
 			LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_system_lib" = "x"; then
-                ax_lib=
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -109,7 +108,7 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_system library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::System library!)
             fi
 			if test "x$link_system" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_boost_thread.m4
+++ b/build-aux/m4/ax_boost_thread.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#      http://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
+#     https://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -30,73 +30,96 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 27
+#serial 33
 
 AC_DEFUN([AX_BOOST_THREAD],
 [
-	AC_ARG_WITH([boost-thread],
-	AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
-                   [use the Thread library from boost - it is possible to specify a certain library for the linker
-                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+    AC_ARG_WITH([boost-thread],
+    AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost -
+                    it is possible to specify a certain library for the linker
+                    e.g. --with-boost-thread=boost_thread-gcc-mt ]),
         [
-        if test "$withval" = "no"; then
-			want_boost="no"
-        elif test "$withval" = "yes"; then
+        if test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_thread_lib=""
         else
-		    want_boost="yes"
-		ax_boost_user_thread_lib="$withval"
-		fi
+            want_boost="yes"
+            ax_boost_user_thread_lib="$withval"
+        fi
         ],
         [want_boost="yes"]
-	)
+    )
 
-	if test "x$want_boost" = "xyes"; then
+    if test "x$want_boost" = "xyes"; then
         AC_REQUIRE([AC_PROG_CC])
         AC_REQUIRE([AC_CANONICAL_BUILD])
-		CPPFLAGS_SAVED="$CPPFLAGS"
-		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-		export CPPFLAGS
+        CPPFLAGS_SAVED="$CPPFLAGS"
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
 
-		LDFLAGS_SAVED="$LDFLAGS"
-		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-		export LDFLAGS
+        LDFLAGS_SAVED="$LDFLAGS"
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
 
         AC_CACHE_CHECK(whether the Boost::Thread library is available,
-					   ax_cv_boost_thread,
+                       ax_cv_boost_thread,
         [AC_LANG_PUSH([C++])
-			 CXXFLAGS_SAVE=$CXXFLAGS
+             CXXFLAGS_SAVE=$CXXFLAGS
 
-			 if test "x$host_os" = "xsolaris" ; then
-				 CXXFLAGS="-pthreads $CXXFLAGS"
-			 elif test "x$host_os" = "xmingw32" ; then
-				 CXXFLAGS="-mthreads $CXXFLAGS"
-			 else
-				CXXFLAGS="-pthread $CXXFLAGS"
-			 fi
-			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
-                                   [[boost::thread_group thrds;
-                                   return 0;]])],
-                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
-			 CXXFLAGS=$CXXFLAGS_SAVE
+             case "x$host_os" in
+                 xsolaris )
+                     CXXFLAGS="-pthreads $CXXFLAGS"
+                     break;
+                     ;;
+                 xmingw32 )
+                     CXXFLAGS="-mthreads $CXXFLAGS"
+                     break;
+                     ;;
+                 *android* )
+                     break;
+                     ;;
+                 * )
+                     CXXFLAGS="-pthread $CXXFLAGS"
+                     break;
+                     ;;
+             esac
+
+             AC_COMPILE_IFELSE([
+                 AC_LANG_PROGRAM(
+                     [[@%:@include <boost/thread/thread.hpp>]],
+                     [[boost::thread_group thrds;
+                       return 0;]])],
+                 ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+             CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
-		])
-		if test "x$ax_cv_boost_thread" = "xyes"; then
-           if test "x$host_os" = "xsolaris" ; then
-			  BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
-		   elif test "x$host_os" = "xmingw32" ; then
-			  BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
-		   else
-			  BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
-		   fi
+        ])
+        if test "x$ax_cv_boost_thread" = "xyes"; then
+            case "x$host_os" in
+                xsolaris )
+                    BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+                    break;
+                    ;;
+                xmingw32 )
+                    BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+                    break;
+                    ;;
+                *android* )
+                    break;
+                    ;;
+                * )
+                    BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+                    break;
+                    ;;
+            esac
 
-			AC_SUBST(BOOST_CPPFLAGS)
+            AC_SUBST(BOOST_CPPFLAGS)
 
-			AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            AC_DEFINE(HAVE_BOOST_THREAD,,
+                      [define if the Boost::Thread library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
-			LDFLAGS_SAVE=$LDFLAGS
+            LDFLAGS_SAVE=$LDFLAGS
                         case "x$host_os" in
                           *bsd* )
                                LDFLAGS="-pthread $LDFLAGS"
@@ -104,47 +127,61 @@ AC_DEFUN([AX_BOOST_THREAD],
                           ;;
                         esac
             if test "x$ax_boost_user_thread_lib" = "x"; then
-                ax_lib=
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                    AC_CHECK_LIB($ax_lib, exit,
+                                 [link_thread="yes"; break],
                                  [link_thread="no"])
-				done
+                done
                 if test "x$link_thread" != "xyes"; then
                 for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                    AC_CHECK_LIB($ax_lib, exit,
+                                 [link_thread="yes"; break],
                                  [link_thread="no"])
-				done
+                done
                 fi
 
             else
                for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
-				      AC_CHECK_LIB($ax_lib, exit,
-                                   [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                      AC_CHECK_LIB($ax_lib, exit,
+                                   [link_thread="yes"; break],
                                    [link_thread="no"])
                   done
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_thread library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Thread library!)
             fi
-			if test "x$link_thread" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
-                        else
-                           case "x$host_os" in
-                              *bsd* )
-				BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
-                              break;
-                              ;;
-                           esac
+            if test "x$link_thread" = "xno"; then
+                AC_MSG_ERROR(Could not link against $ax_lib !)
+            else
+                BOOST_THREAD_LIB="-l$ax_lib"
+                case "x$host_os" in
+                    *bsd* )
+                        BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                        break;
+                        ;;
+                    xsolaris )
+                        BOOST_THREAD_LIB="$BOOST_THREAD_LIB -lpthread"
+                        break;
+                        ;;
+                    xmingw32 )
+                        break;
+                        ;;
+                    *android* )
+                        break;
+                        ;;
+                    * )
+                        BOOST_THREAD_LIB="$BOOST_THREAD_LIB -lpthread"
+                        break;
+                        ;;
+                esac
+                AC_SUBST(BOOST_THREAD_LIB)
+            fi
+        fi
 
-			fi
-		fi
-
-		CPPFLAGS="$CPPFLAGS_SAVED"
-	LDFLAGS="$LDFLAGS_SAVED"
-	fi
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+    fi
 ])

--- a/build-aux/m4/ax_boost_unit_test_framework.m4
+++ b/build-aux/m4/ax_boost_unit_test_framework.m4
@@ -1,6 +1,6 @@
-# ================================================================================
-#  http://www.gnu.org/software/autoconf-archive/ax_boost_unit_test_framework.html
-# ================================================================================
+# =================================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_boost_unit_test_framework.html
+# =================================================================================
 #
 # SYNOPSIS
 #
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 19
+#serial 22
 
 AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
 [
@@ -66,7 +66,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
         [AC_LANG_PUSH([C++])
 			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/test/unit_test.hpp>]],
                                     [[using boost::unit_test::test_suite;
-							 test_suite* test= BOOST_TEST_SUITE( "Unit test example 1" ); return 0;]])],
+							 test_suite* test= BOOST_TEST_SUITE( "Unit test example 1" ); if (test == NULL) { return 1; } else { return 0; }]])],
                    ax_cv_boost_unit_test_framework=yes, ax_cv_boost_unit_test_framework=no)
          AC_LANG_POP([C++])
 		])
@@ -76,7 +76,6 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
 
             if test "x$ax_boost_user_unit_test_framework_lib" = "x"; then
 			saved_ldflags="${LDFLAGS}"
-                ax_lib=
                 for monitor_library in `ls $BOOSTLIBDIR/libboost_unit_test_framework*.so* $BOOSTLIBDIR/libboost_unit_test_framework*.dylib* $BOOSTLIBDIR/libboost_unit_test_framework*.a* 2>/dev/null` ; do
                     if test -r $monitor_library ; then
                        libextension=`echo $monitor_library | sed 's,.*/,,' | sed -e 's;^lib\(boost_unit_test_framework.*\)\.so.*$;\1;' -e 's;^lib\(boost_unit_test_framework.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_unit_test_framework.*\)\.a.*$;\1;'`
@@ -125,7 +124,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                done
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_unit_test_framework library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Unit_Test_Framework library!)
             fi
 			if test "x$link_unit_test_framework" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_check_compile_flag.m4
+++ b/build-aux/m4/ax_check_compile_flag.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -29,33 +29,12 @@
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
 #
-#   This program is free software: you can redistribute it and/or modify it
-#   under the terms of the GNU General Public License as published by the
-#   Free Software Foundation, either version 3 of the License, or (at your
-#   option) any later version.
-#
-#   This program is distributed in the hope that it will be useful, but
-#   WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-#   Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#   As a special exception, the respective Autoconf Macro's copyright owner
-#   gives unlimited permission to copy, distribute and modify the configure
-#   scripts that are the output of Autoconf when processing the Macro. You
-#   need not follow the terms of the GNU General Public License when using
-#   or distributing such scripts, even though portions of the text of the
-#   Macro appear in them. The GNU General Public License (GPL) does govern
-#   all other use of the material that constitutes the Autoconf Macro.
-#
-#   This special exception to the GPL applies to versions of the Autoconf
-#   Macro released by the Autoconf Archive. When you make and distribute a
-#   modified version of the Autoconf Macro, you may extend this special
-#   exception to the GPL to apply to your modified version as well.
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
 
-#serial 4
+#serial 6
 
 AC_DEFUN([AX_CHECK_COMPILE_FLAG],
 [AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF

--- a/build-aux/m4/ax_check_link_flag.m4
+++ b/build-aux/m4/ax_check_link_flag.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#    http://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -29,33 +29,12 @@
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
 #
-#   This program is free software: you can redistribute it and/or modify it
-#   under the terms of the GNU General Public License as published by the
-#   Free Software Foundation, either version 3 of the License, or (at your
-#   option) any later version.
-#
-#   This program is distributed in the hope that it will be useful, but
-#   WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-#   Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#   As a special exception, the respective Autoconf Macro's copyright owner
-#   gives unlimited permission to copy, distribute and modify the configure
-#   scripts that are the output of Autoconf when processing the Macro. You
-#   need not follow the terms of the GNU General Public License when using
-#   or distributing such scripts, even though portions of the text of the
-#   Macro appear in them. The GNU General Public License (GPL) does govern
-#   all other use of the material that constitutes the Autoconf Macro.
-#
-#   This special exception to the GPL applies to versions of the Autoconf
-#   Macro released by the Autoconf Archive. When you make and distribute a
-#   modified version of the Autoconf Macro, you may extend this special
-#   exception to the GPL to apply to your modified version as well.
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
 
-#serial 4
+#serial 6
 
 AC_DEFUN([AX_CHECK_LINK_FLAG],
 [AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF

--- a/build-aux/m4/ax_check_preproc_flag.m4
+++ b/build-aux/m4/ax_check_preproc_flag.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_check_preproc_flag.html
+#  https://www.gnu.org/software/autoconf-archive/ax_check_preproc_flag.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -29,33 +29,12 @@
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
 #
-#   This program is free software: you can redistribute it and/or modify it
-#   under the terms of the GNU General Public License as published by the
-#   Free Software Foundation, either version 3 of the License, or (at your
-#   option) any later version.
-#
-#   This program is distributed in the hope that it will be useful, but
-#   WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
-#   Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-#   As a special exception, the respective Autoconf Macro's copyright owner
-#   gives unlimited permission to copy, distribute and modify the configure
-#   scripts that are the output of Autoconf when processing the Macro. You
-#   need not follow the terms of the GNU General Public License when using
-#   or distributing such scripts, even though portions of the text of the
-#   Macro appear in them. The GNU General Public License (GPL) does govern
-#   all other use of the material that constitutes the Autoconf Macro.
-#
-#   This special exception to the GPL applies to versions of the Autoconf
-#   Macro released by the Autoconf Archive. When you make and distribute a
-#   modified version of the Autoconf Macro, you may extend this special
-#   exception to the GPL to apply to your modified version as well.
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
 
-#serial 4
+#serial 6
 
 AC_DEFUN([AX_CHECK_PREPROC_FLAG],
 [AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF

--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -16,7 +16,7 @@
 #   The second argument, if specified, indicates whether you insist on an
 #   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
 #   -std=c++11).  If neither is specified, you get whatever works, with
-#   preference for an extended mode.
+#   preference for no added switch, and then for an extended mode.
 #
 #   The third argument, if specified 'mandatory' or if left unspecified,
 #   indicates that baseline support for the specified C++ standard is
@@ -33,21 +33,24 @@
 #   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
 #   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
+#   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 12
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
 
 AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
-  m4_if([$1], [11], [],
-        [$1], [14], [],
-        [$1], [17], [m4_fatal([support for C++17 not yet implemented in AX_CXX_COMPILE_STDCXX])],
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -57,26 +60,23 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
         [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
         [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
-  m4_if([$4], [], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [default], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [nodefault], [ax_cxx_compile_cxx$1_try_default=false],
-        [m4_fatal([invalid fourth argument `$4' to AX_CXX_COMPILE_STDCXX])])
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 
-  m4_if([$4], [nodefault], [], [dnl
-  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-  ax_cv_cxx_compile_cxx$1,
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-    [ax_cv_cxx_compile_cxx$1=yes],
-    [ax_cv_cxx_compile_cxx$1=no])])
-  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
-    ac_success=yes
-  fi])
+  m4_if([$2], [], [dnl
+    AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+		   ax_cv_cxx_compile_cxx$1,
+      [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+        [ax_cv_cxx_compile_cxx$1=yes],
+        [ax_cv_cxx_compile_cxx$1=no])])
+    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+      ac_success=yes
+    fi])
 
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then
-    for switch in -std=gnu++$1 -std=gnu++0x; do
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                      $cachevar,
@@ -102,22 +102,27 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
     dnl Cray's crayCC needs "-h std=c++11"
-    for switch in -std=c++$1 -std=c++0x +std=c++$1 "-h std=c++$1"; do
-      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
-      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
-                     $cachevar,
-        [ac_save_CXX="$CXX"
-         CXX="$CXX $switch"
-         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-          [eval $cachevar=yes],
-          [eval $cachevar=no])
-         CXX="$ac_save_CXX"])
-      if eval test x\$$cachevar = xyes; then
-        CXX="$CXX $switch"
-        if test -n "$CXXCPP" ; then
-          CXXCPP="$CXXCPP $switch"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
         fi
-        ac_success=yes
+      done
+      if test x$ac_success = xyes; then
         break
       fi
     done
@@ -154,6 +159,11 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
 )
 
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
 
 dnl  Tests for new features in C++11
 
@@ -191,11 +201,13 @@ namespace cxx11
 
     struct Base
     {
+      virtual ~Base() {}
       virtual void f() {}
     };
 
     struct Derived : public Base
     {
+      virtual ~Derived() override {}
       virtual void f() override {}
     };
 
@@ -524,7 +536,7 @@ namespace cxx14
 
   }
 
-  namespace test_digit_seperators
+  namespace test_digit_separators
   {
 
     constexpr auto ten_million = 100'000'000;
@@ -564,5 +576,387 @@ namespace cxx14
 }  // namespace cxx14
 
 #endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus < 201703L
 
 ]])

--- a/build-aux/m4/ax_gcc_func_attribute.m4
+++ b/build-aux/m4/ax_gcc_func_attribute.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_gcc_func_attribute.html
+#  https://www.gnu.org/software/autoconf-archive/ax_gcc_func_attribute.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -38,9 +38,11 @@
 #    dllimport
 #    error
 #    externally_visible
+#    fallthrough
 #    flatten
 #    format
 #    format_arg
+#    gnu_format
 #    gnu_inline
 #    hot
 #    ifunc
@@ -53,6 +55,8 @@
 #    nothrow
 #    optimize
 #    pure
+#    sentinel
+#    sentinel_position
 #    unused
 #    used
 #    visibility
@@ -61,9 +65,9 @@
 #    weak
 #    weakref
 #
-#   Unsuppored function attributes will be tested with a prototype returning
-#   an int and not accepting any arguments and the result of the check might
-#   be wrong or meaningless so use with care.
+#   Unsupported function attributes will be tested with a prototype
+#   returning an int and not accepting any arguments and the result of the
+#   check might be wrong or meaningless so use with care.
 #
 # LICENSE
 #
@@ -74,7 +78,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 3
+#serial 13
 
 AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
     AS_VAR_PUSHDEF([ac_var], [ax_cv_have_func_attribute_$1])
@@ -128,11 +132,17 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
                 [externally_visible], [
                     int foo( void ) __attribute__(($1));
                 ],
+                [fallthrough], [
+                    void foo( int x ) {switch (x) { case 1: __attribute__(($1)); case 2: break ; }};
+                ],
                 [flatten], [
                     int foo( void ) __attribute__(($1));
                 ],
                 [format], [
                     int foo(const char *p, ...) __attribute__(($1(printf, 1, 2)));
+                ],
+                [gnu_format], [
+                    int foo(const char *p, ...) __attribute__((format(gnu_printf, 1, 2)));
                 ],
                 [format_arg], [
                     char *foo(const char *p) __attribute__(($1(1)));
@@ -175,6 +185,15 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
                 [pure], [
                     int foo( void ) __attribute__(($1));
                 ],
+                [sentinel], [
+                    int foo(void *p, ...) __attribute__(($1));
+                ],
+                [sentinel_position], [
+                    int foo(void *p, ...) __attribute__(($1(1)));
+                ],
+                [returns_nonnull], [
+                    void *foo( void ) __attribute__(($1));
+                ],
                 [unused], [
                     int foo( void ) __attribute__(($1));
                 ],
@@ -209,7 +228,7 @@ AC_DEFUN([AX_GCC_FUNC_ATTRIBUTE], [
             dnl GCC doesn't exit with an error if an unknown attribute is
             dnl provided but only outputs a warning, so accept the attribute
             dnl only if no warning were issued.
-            [AS_IF([test -s conftest.err],
+            [AS_IF([grep -- -Wattributes conftest.err],
                 [AS_VAR_SET([ac_var], [no])],
                 [AS_VAR_SET([ac_var], [yes])])],
             [AS_VAR_SET([ac_var], [no])])

--- a/build-aux/m4/ax_pthread.m4
+++ b/build-aux/m4/ax_pthread.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#        http://www.gnu.org/software/autoconf-archive/ax_pthread.html
+#        https://www.gnu.org/software/autoconf-archive/ax_pthread.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -14,20 +14,24 @@
 #   flags that are needed. (The user can also force certain compiler
 #   flags/libs to be tested by setting these environment variables.)
 #
-#   Also sets PTHREAD_CC to any special C compiler that is needed for
-#   multi-threaded programs (defaults to the value of CC otherwise). (This
-#   is necessary on AIX to use the special cc_r compiler alias.)
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
 #
 #   NOTE: You are assumed to not only compile your program with these flags,
 #   but also to link with them as well. For example, you might link with
 #   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
 #
 #   If you are only building threaded programs, you may wish to use these
 #   variables in your default LIBS, CFLAGS, and CC:
 #
 #     LIBS="$PTHREAD_LIBS $LIBS"
 #     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
 #     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
 #
 #   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
 #   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
@@ -55,6 +59,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   Copyright (c) 2019 Marc Stevens <marc.stevens@cwi.nl>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -67,7 +72,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -82,11 +87,11 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 22
+#serial 30
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
-AC_REQUIRE([AC_CANONICAL_HOST])
+AC_REQUIRE([AC_CANONICAL_TARGET])
 AC_REQUIRE([AC_PROG_CC])
 AC_REQUIRE([AC_PROG_SED])
 AC_LANG_PUSH([C])
@@ -100,22 +105,23 @@ ax_pthread_ok=no
 # etcetera environment variables, and if threads linking works using
 # them:
 if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
-	ax_pthread_save_CC="$CC"
-	ax_pthread_save_CFLAGS="$CFLAGS"
-	ax_pthread_save_LIBS="$LIBS"
-	AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
-	CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
-	LIBS="$PTHREAD_LIBS $LIBS"
-	AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
-	AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
-	AC_MSG_RESULT([$ax_pthread_ok])
-	if test "x$ax_pthread_ok" = "xno"; then
-		PTHREAD_LIBS=""
-		PTHREAD_CFLAGS=""
-	fi
-	CC="$ax_pthread_save_CC"
-	CFLAGS="$ax_pthread_save_CFLAGS"
-	LIBS="$ax_pthread_save_LIBS"
+        ax_pthread_save_CC="$CC"
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test "x$ax_pthread_ok" = "xno"; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        CC="$ax_pthread_save_CC"
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
 fi
 
 # We must check for the threads library under a number of different
@@ -123,10 +129,12 @@ fi
 # (e.g. DEC) have both -lpthread and -lpthreads, where one of the
 # libraries is broken (non-POSIX).
 
-# Create a list of thread flags to try.  Items starting with a "-" are
-# C compiler flags, and other items are library names, except for "none"
-# which indicates that we try without any flags at all, and "pthread-config"
-# which is a program returning the flags for the Pth emulation library.
+# Create a list of thread flags to try. Items with a "," contain both
+# C compiler flags (before ",") and linker flags (after ","). Other items
+# starting with a "-" are C compiler flags, and remaining items are
+# library names, except for "none" which indicates that we try without
+# any flags at all, and "pthread-config" which is a program returning
+# the flags for the Pth emulation library.
 
 ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
 
@@ -150,79 +158,53 @@ ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --
 # --thread-safe: KAI C++
 # pthread-config: use pthread-config program (for GNU Pth library)
 
-case $host_os in
+case $target_os in
 
-	freebsd*)
+        freebsd*)
 
-	# -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
-	# lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+        # -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+        # lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
 
-	ax_pthread_flags="-kthread lthread $ax_pthread_flags"
-	;;
+        ax_pthread_flags="-kthread lthread $ax_pthread_flags"
+        ;;
 
-	hpux*)
+        hpux*)
 
-	# From the cc(1) man page: "[-mt] Sets various -D flags to enable
-	# multi-threading and also sets -lpthread."
+        # From the cc(1) man page: "[-mt] Sets various -D flags to enable
+        # multi-threading and also sets -lpthread."
 
-	ax_pthread_flags="-mt -pthread pthread $ax_pthread_flags"
-	;;
+        ax_pthread_flags="-mt -pthread pthread $ax_pthread_flags"
+        ;;
 
-	openedition*)
+        openedition*)
 
-	# IBM z/OS requires a feature-test macro to be defined in order to
-	# enable POSIX threads at all, so give the user a hint if this is
-	# not set. (We don't define these ourselves, as they can affect
-	# other portions of the system API in unpredictable ways.)
+        # IBM z/OS requires a feature-test macro to be defined in order to
+        # enable POSIX threads at all, so give the user a hint if this is
+        # not set. (We don't define these ourselves, as they can affect
+        # other portions of the system API in unpredictable ways.)
 
-	AC_EGREP_CPP([AX_PTHREAD_ZOS_MISSING],
-	    [
-#	     if !defined(_OPEN_THREADS) && !defined(_UNIX03_THREADS)
-	     AX_PTHREAD_ZOS_MISSING
-#	     endif
-	    ],
-	    [AC_MSG_WARN([IBM z/OS requires -D_OPEN_THREADS or -D_UNIX03_THREADS to enable pthreads support.])])
-	;;
+        AC_EGREP_CPP([AX_PTHREAD_ZOS_MISSING],
+            [
+#            if !defined(_OPEN_THREADS) && !defined(_UNIX03_THREADS)
+             AX_PTHREAD_ZOS_MISSING
+#            endif
+            ],
+            [AC_MSG_WARN([IBM z/OS requires -D_OPEN_THREADS or -D_UNIX03_THREADS to enable pthreads support.])])
+        ;;
 
-	solaris*)
+        solaris*)
 
-	# On Solaris (at least, for some versions), libc contains stubbed
-	# (non-functional) versions of the pthreads routines, so link-based
-	# tests will erroneously succeed. (N.B.: The stubs are missing
-	# pthread_cleanup_push, or rather a function called by this macro,
-	# so we could check for that, but who knows whether they'll stub
-	# that too in a future libc.)  So we'll check first for the
-	# standard Solaris way of linking pthreads (-mt -lpthread).
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed. (N.B.: The stubs are missing
+        # pthread_cleanup_push, or rather a function called by this macro,
+        # so we could check for that, but who knows whether they'll stub
+        # that too in a future libc.)  So we'll check first for the
+        # standard Solaris way of linking pthreads (-mt -lpthread).
 
-	ax_pthread_flags="-mt,pthread pthread $ax_pthread_flags"
-	;;
+        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
+        ;;
 esac
-
-# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
-
-AS_IF([test "x$GCC" = "xyes"],
-      [ax_pthread_flags="-pthread -pthreads $ax_pthread_flags"])
-
-# The presence of a feature test macro requesting re-entrant function
-# definitions is, on some systems, a strong hint that pthreads support is
-# correctly enabled
-
-case $host_os in
-	darwin* | hpux* | linux* | osf* | solaris*)
-	ax_pthread_check_macro="_REENTRANT"
-	;;
-
-	aix* | freebsd*)
-	ax_pthread_check_macro="_THREAD_SAFE"
-	;;
-
-	*)
-	ax_pthread_check_macro="--"
-	;;
-esac
-AS_IF([test "x$ax_pthread_check_macro" = "x--"],
-      [ax_pthread_check_cond=0],
-      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
 
 # Are we compiling with Clang?
 
@@ -231,255 +213,310 @@ AC_CACHE_CHECK([whether $CC is Clang],
     [ax_cv_PTHREAD_CLANG=no
      # Note that Autoconf sets GCC=yes for Clang as well as GCC
      if test "x$GCC" = "xyes"; then
-	AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
-	    [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
-#	     if defined(__clang__) && defined(__llvm__)
-	     AX_PTHREAD_CC_IS_CLANG
-#	     endif
-	    ],
-	    [ax_cv_PTHREAD_CLANG=yes])
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
      fi
     ])
 ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
 
-ax_pthread_clang_warning=no
+
+# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
+
+# Note that for GCC and Clang -pthread generally implies -lpthread,
+# except when -nostdlib is passed.
+# This is problematic using libtool to build C++ shared libraries with pthread:
+# [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25460
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=661333
+# [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
+# To solve this, first try -pthread together with -lpthread for GCC
+
+AS_IF([test "x$GCC" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
+
+# Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
+
+AS_IF([test "x$ax_pthread_clang" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread"])
+
+
+# The presence of a feature test macro requesting re-entrant function
+# definitions is, on some systems, a strong hint that pthreads support is
+# correctly enabled
+
+case $target_os in
+        darwin* | hpux* | linux* | osf* | solaris*)
+        ax_pthread_check_macro="_REENTRANT"
+        ;;
+
+        aix*)
+        ax_pthread_check_macro="_THREAD_SAFE"
+        ;;
+
+        *)
+        ax_pthread_check_macro="--"
+        ;;
+esac
+AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+      [ax_pthread_check_cond=0],
+      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
+
+
+if test "x$ax_pthread_ok" = "xno"; then
+for ax_pthread_try_flag in $ax_pthread_flags; do
+
+        case $ax_pthread_try_flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                *,*)
+                PTHREAD_CFLAGS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\1/"`
+                PTHREAD_LIBS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\2/"`
+                AC_MSG_CHECKING([whether pthreads work with "$PTHREAD_CFLAGS" and "$PTHREAD_LIBS"])
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $ax_pthread_try_flag])
+                PTHREAD_CFLAGS="$ax_pthread_try_flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
+                AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$ax_pthread_try_flag])
+                PTHREAD_LIBS="-l$ax_pthread_try_flag"
+                ;;
+        esac
+
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+#                       if $ax_pthread_check_cond
+#                        error "$ax_pthread_check_macro must be defined"
+#                       endif
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+            [ax_pthread_ok=yes],
+            [])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        AC_MSG_RESULT([$ax_pthread_ok])
+        AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
 
 # Clang needs special handling, because older versions handle the -pthread
 # option in a rather... idiosyncratic way
 
 if test "x$ax_pthread_clang" = "xyes"; then
 
-	# Clang takes -pthread; it has never supported any other flag
+        # Clang takes -pthread; it has never supported any other flag
 
-	# (Note 1: This will need to be revisited if a system that Clang
-	# supports has POSIX threads in a separate library.  This tends not
-	# to be the way of modern systems, but it's conceivable.)
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
 
-	# (Note 2: On some systems, notably Darwin, -pthread is not needed
-	# to get POSIX threads support; the API is always present and
-	# active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
-	# -pthread does define _REENTRANT, and while the Darwin headers
-	# ignore this macro, third-party headers might not.)
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
 
-	PTHREAD_CFLAGS="-pthread"
-	PTHREAD_LIBS=
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
 
-	ax_pthread_ok=yes
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
 
-	# However, older versions of Clang make a point of warning the user
-	# that, in an invocation where only linking and no compilation is
-	# taking place, the -pthread option has no effect ("argument unused
-	# during compilation").  They expect -pthread to be passed in only
-	# when source code is being compiled.
-	#
-	# Problem is, this is at odds with the way Automake and most other
-	# C build frameworks function, which is that the same flags used in
-	# compilation (CFLAGS) are also used in linking.  Many systems
-	# supported by AX_PTHREAD require exactly this for POSIX threads
-	# support, and in fact it is often not straightforward to specify a
-	# flag that is used only in the compilation phase and not in
-	# linking.  Such a scenario is extremely rare in practice.
-	#
-	# Even though use of the -pthread flag in linking would only print
-	# a warning, this can be a nuisance for well-run software projects
-	# that build with -Werror.  So if the active version of Clang has
-	# this misfeature, we search for an option to squash it.
-
-	AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
-	    [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
-	    [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
-	     # Create an alternate version of $ac_link that compiles and
-	     # links in two steps (.c -> .o, .o -> exe) instead of one
-	     # (.c -> exe), because the warning occurs only in the second
-	     # step
-	     ax_pthread_save_ac_link="$ac_link"
-	     ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-	     ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
-	     ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
-	     ax_pthread_save_CFLAGS="$CFLAGS"
-	     for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
-		AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
-		CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
-		ac_link="$ax_pthread_save_ac_link"
-		AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-		    [ac_link="$ax_pthread_2step_ac_link"
-		     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-			 [break])
-		    ])
-	     done
-	     ac_link="$ax_pthread_save_ac_link"
-	     CFLAGS="$ax_pthread_save_CFLAGS"
-	     AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
-	     ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
-	    ])
-
-	case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
-		no | unknown) ;;
-		*) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
-	esac
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
 
 fi # $ax_pthread_clang = yes
 
-if test "x$ax_pthread_ok" = "xno"; then
-for ax_pthread_try_flag in $ax_pthread_flags; do
 
-	case $ax_pthread_try_flag in
-		none)
-		AC_MSG_CHECKING([whether pthreads work without any flags])
-		;;
-
-		-mt,pthread)
-		AC_MSG_CHECKING([whether pthreads work with -mt -lpthread])
-		PTHREAD_CFLAGS="-mt"
-		PTHREAD_LIBS="-lpthread"
-		;;
-
-		-*)
-		AC_MSG_CHECKING([whether pthreads work with $ax_pthread_try_flag])
-		PTHREAD_CFLAGS="$ax_pthread_try_flag"
-		;;
-
-		pthread-config)
-		AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
-		AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
-		PTHREAD_CFLAGS="`pthread-config --cflags`"
-		PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
-		;;
-
-		*)
-		AC_MSG_CHECKING([for the pthreads library -l$ax_pthread_try_flag])
-		PTHREAD_LIBS="-l$ax_pthread_try_flag"
-		;;
-	esac
-
-	ax_pthread_save_CFLAGS="$CFLAGS"
-	ax_pthread_save_LIBS="$LIBS"
-	CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
-	LIBS="$PTHREAD_LIBS $LIBS"
-
-	# Check for various functions.  We must include pthread.h,
-	# since some functions may be macros.  (On the Sequent, we
-	# need a special flag -Kthread to make this header compile.)
-	# We check for pthread_join because it is in -lpthread on IRIX
-	# while pthread_create is in libc.  We check for pthread_attr_init
-	# due to DEC craziness with -lpthreads.  We check for
-	# pthread_cleanup_push because it is one of the few pthread
-	# functions on Solaris that doesn't have a non-functional libc stub.
-	# We try pthread_create on general principles.
-
-	AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
-#			if $ax_pthread_check_cond
-#			 error "$ax_pthread_check_macro must be defined"
-#			endif
-			static void routine(void *a) { a = 0; }
-			static void *start_routine(void *a) { return a; }],
-		       [pthread_t th; pthread_attr_t attr;
-			pthread_create(&th, 0, start_routine, 0);
-			pthread_join(th, 0);
-			pthread_attr_init(&attr);
-			pthread_cleanup_push(routine, 0);
-			pthread_cleanup_pop(0) /* ; */])],
-	    [ax_pthread_ok=yes],
-	    [])
-
-	CFLAGS="$ax_pthread_save_CFLAGS"
-	LIBS="$ax_pthread_save_LIBS"
-
-	AC_MSG_RESULT([$ax_pthread_ok])
-	AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
-
-	PTHREAD_LIBS=""
-	PTHREAD_CFLAGS=""
-done
-fi
 
 # Various other checks:
 if test "x$ax_pthread_ok" = "xyes"; then
-	ax_pthread_save_CFLAGS="$CFLAGS"
-	ax_pthread_save_LIBS="$LIBS"
-	CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
-	LIBS="$PTHREAD_LIBS $LIBS"
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
 
-	# Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
-	AC_CACHE_CHECK([for joinable pthread attribute],
-	    [ax_cv_PTHREAD_JOINABLE_ATTR],
-	    [ax_cv_PTHREAD_JOINABLE_ATTR=unknown
-	     for ax_pthread_attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
-		 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
-						 [int attr = $ax_pthread_attr; return attr /* ; */])],
-				[ax_cv_PTHREAD_JOINABLE_ATTR=$ax_pthread_attr; break],
-				[])
-	     done
-	    ])
-	AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
-	       test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
-	       test "x$ax_pthread_joinable_attr_defined" != "xyes"],
-	      [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
-				  [$ax_cv_PTHREAD_JOINABLE_ATTR],
-				  [Define to necessary symbol if this constant
-				   uses a non-standard name on your system.])
-	       ax_pthread_joinable_attr_defined=yes
-	      ])
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_CACHE_CHECK([for joinable pthread attribute],
+            [ax_cv_PTHREAD_JOINABLE_ATTR],
+            [ax_cv_PTHREAD_JOINABLE_ATTR=unknown
+             for ax_pthread_attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+                 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                                                 [int attr = $ax_pthread_attr; return attr /* ; */])],
+                                [ax_cv_PTHREAD_JOINABLE_ATTR=$ax_pthread_attr; break],
+                                [])
+             done
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
+               test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
+               test "x$ax_pthread_joinable_attr_defined" != "xyes"],
+              [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
+                                  [$ax_cv_PTHREAD_JOINABLE_ATTR],
+                                  [Define to necessary symbol if this constant
+                                   uses a non-standard name on your system.])
+               ax_pthread_joinable_attr_defined=yes
+              ])
 
-	AC_CACHE_CHECK([whether more special flags are required for pthreads],
-	    [ax_cv_PTHREAD_SPECIAL_FLAGS],
-	    [ax_cv_PTHREAD_SPECIAL_FLAGS=no
-	     case $host_os in
-	     solaris*)
-	     ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
-	     ;;
-	     esac
-	    ])
-	AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
-	       test "x$ax_pthread_special_flags_added" != "xyes"],
-	      [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
-	       ax_pthread_special_flags_added=yes])
+        AC_CACHE_CHECK([whether more special flags are required for pthreads],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS=no
+             case $target_os in
+             solaris*)
+             ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
+             ;;
+             esac
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
+               test "x$ax_pthread_special_flags_added" != "xyes"],
+              [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
+               ax_pthread_special_flags_added=yes])
 
-	AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
-	    [ax_cv_PTHREAD_PRIO_INHERIT],
-	    [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
-					     [[int i = PTHREAD_PRIO_INHERIT;]])],
-			    [ax_cv_PTHREAD_PRIO_INHERIT=yes],
-			    [ax_cv_PTHREAD_PRIO_INHERIT=no])
-	    ])
-	AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
-	       test "x$ax_pthread_prio_inherit_defined" != "xyes"],
-	      [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
-	       ax_pthread_prio_inherit_defined=yes
-	      ])
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            [ax_cv_PTHREAD_PRIO_INHERIT],
+            [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
+                                             [[int i = PTHREAD_PRIO_INHERIT;
+                                               return i;]])],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
+               test "x$ax_pthread_prio_inherit_defined" != "xyes"],
+              [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
+               ax_pthread_prio_inherit_defined=yes
+              ])
 
-	CFLAGS="$ax_pthread_save_CFLAGS"
-	LIBS="$ax_pthread_save_LIBS"
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
 
-	# More AIX lossage: compile with *_r variant
-	if test "x$GCC" != "xyes"; then
-	    case $host_os in
-		aix*)
-		AS_CASE(["x/$CC"],
-		    [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
-		    [#handle absolute path differently from PATH based program lookup
-		     AS_CASE(["x$CC"],
-			 [x/*],
-			 [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
-			 [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
-		;;
-	    esac
-	fi
+        # More AIX lossage: compile with *_r variant
+        if test "x$GCC" != "xyes"; then
+            case $target_os in
+                aix*)
+                AS_CASE(["x/$CC"],
+                    [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
+                    [#handle absolute path differently from PATH based program lookup
+                     AS_CASE(["x$CC"],
+                         [x/*],
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
+                ;;
+            esac
+        fi
 fi
 
 test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
 
 AC_SUBST([PTHREAD_LIBS])
 AC_SUBST([PTHREAD_CFLAGS])
 AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
 
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
 if test "x$ax_pthread_ok" = "xyes"; then
-	ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
-	:
+        ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
+        :
 else
-	ax_pthread_ok=no
-	$2
+        ax_pthread_ok=no
+        $2
 fi
 AC_LANG_POP
 ])dnl AX_PTHREAD

--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,8 @@ case $host in
      lt_cv_deplibs_check_method="pass_all"
   ;;
 esac
-dnl Require C++11 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
+dnl Require C++17 compiler (no GNU extensions)
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory], [nodefault])
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 

--- a/src/Makefile.gtest.include
+++ b/src/Makefile.gtest.include
@@ -17,6 +17,7 @@ pastel_gtest_SOURCES += \
 	wallet/gtest/test_wallet_zkeys.cpp
 endif
 pastel_gtest_SOURCES += \
+	gtest/test_block.cpp \
 	gtest/test_tautology.cpp \
 	gtest/test_deprecation.cpp \
 	gtest/test_equihash.cpp \
@@ -45,7 +46,8 @@ pastel_gtest_SOURCES += \
 	gtest/test_pedersen_hash.cpp \
 	gtest/test_checkblock.cpp \
 	gtest/test_zip32.cpp \
-	gtest/test_mnode_governance.cpp
+	gtest/test_mnode_governance.cpp \
+	gtest/test_mnode_rpc.cpp
 if ENABLE_WALLET
 pastel_gtest_SOURCES += \
 	wallet/gtest/test_wallet.cpp

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -397,13 +397,14 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& strInput)
     UniValue keysObj = registers["privatekeys"];
     fGivenKeys = true;
 
-    for (size_t kidx = 0; kidx < keysObj.size(); kidx++) {
+    std::string sKeyError;
+    for (size_t kidx = 0; kidx < keysObj.size(); kidx++)
+    {
         if (!keysObj[kidx].isStr())
             throw std::runtime_error("privatekey not a std::string");
-        CKey key = DecodeSecret(keysObj[kidx].getValStr());
-        if (!key.IsValid()) {
-            throw std::runtime_error("privatekey not valid");
-        }
+        const CKey key = DecodeSecret(keysObj[kidx].getValStr(), sKeyError);
+        if (!key.IsValid())
+            throw std::runtime_error(tinyformat::format("privatekey not valid, %s", sKeyError.c_str()));
         tempKeystore.AddKey(key);
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -309,7 +309,7 @@ class CMainParams : public CChainParams {
 public:
     CMainParams() {
         strNetworkID = "main";
-        network = CBaseChainParams::MAIN;
+        network = CBaseChainParams::Network::MAIN;
         strCurrencyUnits = "PSL";
         bip44CoinType = 133; // As registered in https://github.com/patoshilabs/slips/blob/master/slip-0044.md
         consensus.nSubsidyHalvingInterval = 840000;
@@ -363,25 +363,25 @@ public:
         vSeeds.push_back(CDNSSeedData("pastel.network", "dnsseed.pastel.network"));
 
         // guarantees the first 2 characters, when base58 encoded, are "Pt"
-        base58Prefixes[PUBKEY_ADDRESS]     = {0x0c,0xe3};
+        base58Prefixes[to_integral_type(Base58Type::PUBKEY_ADDRESS)] = {0x0c, 0xe3};
         // guarantees the first 2 characters, when base58 encoded, are "pt"
-        base58Prefixes[SCRIPT_ADDRESS]     = {0x1a,0xF6};
+        base58Prefixes[to_integral_type(Base58Type::SCRIPT_ADDRESS)] = {0x1a, 0xF6};
         // the first character, when base58 encoded, is "5" or "K" or "L" (as in Bitcoin)
-        base58Prefixes[SECRET_KEY]         = {0x80};
+        base58Prefixes[to_integral_type(Base58Type::SECRET_KEY)] = {0x80};
         // do not rely on these BIP32 prefixes; they are not specified and may change
-        base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x88,0xB2,0x1E};
-        base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x88,0xAD,0xE4};
+        base58Prefixes[to_integral_type(Base58Type::EXT_PUBLIC_KEY)] = {0x04, 0x88, 0xB2, 0x1E};
+        base58Prefixes[to_integral_type(Base58Type::EXT_SECRET_KEY)] = {0x04, 0x88, 0xAD, 0xE4};
         // guarantees the first 2 characters, when base58 encoded, are "Pz"
-        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x09,0x05};
+        base58Prefixes[to_integral_type(Base58Type::ZCPAYMENT_ADDRRESS)] = {0x09, 0x05};
         // guarantees the first 4 characters, when base58 encoded, are "Px"
-        base58Prefixes[ZCVIEWING_KEY]      = {0x09,0x01};
+        base58Prefixes[to_integral_type(Base58Type::ZCVIEWING_KEY)] = {0x09, 0x01};
         // guarantees the first 2 characters, when base58 encoded, are "Ps"
-        base58Prefixes[ZCSPENDING_KEY]     = {0x9A,0x90};
+        base58Prefixes[to_integral_type(Base58Type::ZCSPENDING_KEY)] = {0x9A, 0x90};
 
-        bech32HRPs[SAPLING_PAYMENT_ADDRESS]      = "ps";
-        bech32HRPs[SAPLING_FULL_VIEWING_KEY]     = "pviews";
-        bech32HRPs[SAPLING_INCOMING_VIEWING_KEY] = "pivks";
-        bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-extended-key-main";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_PAYMENT_ADDRESS)] = "ps";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_FULL_VIEWING_KEY)] = "pviews";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_INCOMING_VIEWING_KEY)] = "pivks";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_EXTENDED_SPEND_KEY)] = "p-secret-extended-key-main";
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
@@ -391,17 +391,15 @@ public:
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = false;
 
-        checkpointData = (CCheckpointData) {
-            boost::assign::map_list_of
+        checkpointData.mapCheckpoints = boost::assign::map_list_of
             (0, consensus.hashGenesisBlock)
-            (2700, uint256S("00005558df2a688c6d53c7b78001074515d33cd29589a311f8c6aa4db2df4e44")),
-            1612317919,      // * UNIX timestamp of last checkpoint block
-            3588,                  // * total number of transactions between genesis and last checkpoint
+            (2700, uint256S("00005558df2a688c6d53c7b78001074515d33cd29589a311f8c6aa4db2df4e44"));
+        checkpointData.nTimeLastCheckpoint = 1612317919; // * UNIX timestamp of last checkpoint block
+        checkpointData.nTransactionsLastCheckpoint = 3588; // * total number of transactions between genesis and last checkpoint
                                 //   (the tx=... number in the UpdateTip debug.log lines - "UpdateTip: new best=... tx=...")
-            800                 // * estimated number of transactions per day after checkpoint
+        checkpointData.fTransactionsPerDay = 800; // * estimated number of transactions per day after checkpoint
                                 //   total number of tx / (checkpoint block height / (24 * 24))
                                 //after first checkpoint math is = 765, but I'm setting 800
-        };
     }
 };
 static CMainParams mainParams;
@@ -413,7 +411,7 @@ class CTestNetParams : public CChainParams {
 public:
     CTestNetParams() {
         strNetworkID = "test";
-        network = CBaseChainParams::TESTNET;
+        network = CBaseChainParams::Network::TESTNET;
         strCurrencyUnits = "LSP";
         bip44CoinType = 1;
         consensus.nSubsidyHalvingInterval = 840000;
@@ -466,25 +464,25 @@ public:
         vSeeds.push_back(CDNSSeedData("pastel.network", "dnsseed.testnet.pastel.network"));
 
         // guarantees the first 2 characters, when base58 encoded, are "tP"
-        base58Prefixes[PUBKEY_ADDRESS]     = {0x1C,0xEF};
+        base58Prefixes[to_integral_type(Base58Type::PUBKEY_ADDRESS)] = {0x1C, 0xEF};
         // guarantees the first 2 characters, when base58 encoded, are "tt"
-        base58Prefixes[SCRIPT_ADDRESS]     = {0x1D,0x37};
+        base58Prefixes[to_integral_type(Base58Type::SCRIPT_ADDRESS)] = {0x1D, 0x37};
         // the first character, when base58 encoded, is "9" or "c" (as in Bitcoin)
-        base58Prefixes[SECRET_KEY]         = {0xEF};
+        base58Prefixes[to_integral_type(Base58Type::SECRET_KEY)] = {0xEF};
         // do not rely on these BIP32 prefixes; they are not specified and may change
-        base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x35,0x87,0xCF};
-        base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x35,0x83,0x94};
+        base58Prefixes[to_integral_type(Base58Type::EXT_PUBLIC_KEY)] = {0x04, 0x35, 0x87, 0xCF};
+        base58Prefixes[to_integral_type(Base58Type::EXT_SECRET_KEY)] = {0x04, 0x35, 0x83, 0x94};
         // guarantees the first 2 characters, when base58 encoded, are "tZ"
-        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x14,0x3A};
+        base58Prefixes[to_integral_type(Base58Type::ZCPAYMENT_ADDRRESS)] = {0x14, 0x3A};
         // guarantees the first 4 characters, when base58 encoded, are "tX"
-        base58Prefixes[ZCVIEWING_KEY]      = {0x14,0x37};
+        base58Prefixes[to_integral_type(Base58Type::ZCVIEWING_KEY)] = {0x14, 0x37};
         // guarantees the first 2 characters, when base58 encoded, are "tQ" OR "tS"
-        base58Prefixes[ZCSPENDING_KEY]     = {0x05,0xFE};
+        base58Prefixes[to_integral_type(Base58Type::ZCSPENDING_KEY)] = {0x05, 0xFE};
 
-        bech32HRPs[SAPLING_PAYMENT_ADDRESS]      = "ptestsapling";
-        bech32HRPs[SAPLING_FULL_VIEWING_KEY]     = "pviewtestsapling";
-        bech32HRPs[SAPLING_INCOMING_VIEWING_KEY] = "pivktestsapling";
-        bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-extended-key-test";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_PAYMENT_ADDRESS)] = "ptestsapling";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_FULL_VIEWING_KEY)] = "pviewtestsapling";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_INCOMING_VIEWING_KEY)] = "pivktestsapling";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_EXTENDED_SPEND_KEY)] = "p-secret-extended-key-test";
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
@@ -495,15 +493,12 @@ public:
         fTestnetToBeDeprecatedFieldRPC = true;
 
 
-        checkpointData = (CCheckpointData) {
-            boost::assign::map_list_of
-            (0, consensus.hashGenesisBlock),
-            genesis.nTime,      // * UNIX timestamp of last checkpoint block
-            0,                  // * total number of transactions between genesis and last checkpoint
+        checkpointData.mapCheckpoints = boost::assign::map_list_of(0, consensus.hashGenesisBlock);
+        checkpointData.nTimeLastCheckpoint = genesis.nTime; // * UNIX timestamp of last checkpoint block
+        checkpointData.nTransactionsLastCheckpoint = 0;     // * total number of transactions between genesis and last checkpoint
                                 //   (the tx=... number in the SetBestChain debug.log lines)
-            250                 // * estimated number of transactions per day after checkpoint
+        checkpointData.fTransactionsPerDay = 250;           // * estimated number of transactions per day after checkpoint
                                 //   total number of tx / (checkpoint block height / (24 * 24))
-        };
     }
 };
 static CTestNetParams testNetParams;
@@ -515,7 +510,7 @@ class CRegTestParams : public CChainParams {
 public:
     CRegTestParams() {
         strNetworkID = "regtest";
-        network = CBaseChainParams::REGTEST;
+        network = CBaseChainParams::Network::REGTEST;
         strCurrencyUnits = "REG";
         bip44CoinType = 1;
         consensus.nSubsidyHalvingInterval = 150;
@@ -568,25 +563,25 @@ public:
 
         // These prefixes are the same as the testnet prefixes
         // guarantees the first 2 characters, when base58 encoded, are "tP"
-        base58Prefixes[PUBKEY_ADDRESS]     = {0x1C,0xEF};
+        base58Prefixes[to_integral_type(Base58Type::PUBKEY_ADDRESS)] = {0x1C, 0xEF};
         // guarantees the first 2 characters, when base58 encoded, are "tt"
-        base58Prefixes[SCRIPT_ADDRESS]     = {0x1D,0x37};
+        base58Prefixes[to_integral_type(Base58Type::SCRIPT_ADDRESS)]     = {0x1D,0x37};
         // the first character, when base58 encoded, is "9" or "c" (as in Bitcoin)
-        base58Prefixes[SECRET_KEY]         = {0xEF};
+        base58Prefixes[to_integral_type(Base58Type::SECRET_KEY)]         = {0xEF};
         // do not rely on these BIP32 prefixes; they are not specified and may change
-        base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x35,0x87,0xCF};
-        base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x35,0x83,0x94};
+        base58Prefixes[to_integral_type(Base58Type::EXT_PUBLIC_KEY)]     = {0x04,0x35,0x87,0xCF};
+        base58Prefixes[to_integral_type(Base58Type::EXT_SECRET_KEY)]     = {0x04,0x35,0x83,0x94};
         // guarantees the first 2 characters, when base58 encoded, are "tZ"
-        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x14,0x3A};
+        base58Prefixes[to_integral_type(Base58Type::ZCPAYMENT_ADDRRESS)] = {0x14,0x3A};
         // guarantees the first 4 characters, when base58 encoded, are "tX"
-        base58Prefixes[ZCVIEWING_KEY]      = {0x14,0x37};
+        base58Prefixes[to_integral_type(Base58Type::ZCVIEWING_KEY)]      = {0x14,0x37};
         // guarantees the first 2 characters, when base58 encoded, are "tQ" OR "tS"
-        base58Prefixes[ZCSPENDING_KEY]     = {0x05,0xFE};
+        base58Prefixes[to_integral_type(Base58Type::ZCSPENDING_KEY)]     = {0x05,0xFE};
 
-        bech32HRPs[SAPLING_PAYMENT_ADDRESS]      = "pzregtestsapling";
-        bech32HRPs[SAPLING_FULL_VIEWING_KEY]     = "pviewregtestsapling";
-        bech32HRPs[SAPLING_INCOMING_VIEWING_KEY] = "pivkregtestsapling";
-        bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-extended-key-regtest";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_PAYMENT_ADDRESS)] = "pzregtestsapling";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_FULL_VIEWING_KEY)]     = "pviewregtestsapling";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_INCOMING_VIEWING_KEY)] = "pivkregtestsapling";
+        bech32HRPs[to_integral_type(Bech32Type::SAPLING_EXTENDED_SPEND_KEY)]   = "p-secret-extended-key-regtest";
 
         fMiningRequiresPeers = false;
         fDefaultConsistencyChecks = true;
@@ -594,13 +589,10 @@ public:
         fMineBlocksOnDemand = true;
         fTestnetToBeDeprecatedFieldRPC = false;
 
-        checkpointData = (CCheckpointData){
-            boost::assign::map_list_of
-            (0, consensus.hashGenesisBlock),
-            genesis.nTime,
-            0,
-            0
-        };
+        checkpointData.mapCheckpoints = boost::assign::map_list_of(0, consensus.hashGenesisBlock);
+        checkpointData.nTimeLastCheckpoint = genesis.nTime;
+        checkpointData.nTransactionsLastCheckpoint = 0;
+        checkpointData.fTransactionsPerDay = 0;
     }
 
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)
@@ -619,13 +611,17 @@ const CChainParams &Params() {
 }
 
 CChainParams &Params(CBaseChainParams::Network network) {
-    switch (network) {
-        case CBaseChainParams::MAIN:
+    switch (network)
+    {
+        case CBaseChainParams::Network::MAIN:
             return mainParams;
-        case CBaseChainParams::TESTNET:
+
+        case CBaseChainParams::Network::TESTNET:
             return testNetParams;
-        case CBaseChainParams::REGTEST:
+
+        case CBaseChainParams::Network::REGTEST:
             return regTestParams;
+
         default:
             assert(false && "Unimplemented network");
             return mainParams;
@@ -640,7 +636,7 @@ void SelectParams(CBaseChainParams::Network network) {
 bool SelectParamsFromCommandLine()
 {
     CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
+    if (network == CBaseChainParams::Network::MAX_NETWORK_TYPES)
         return false;
 
     SelectParams(network);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -1,15 +1,13 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_CHAINPARAMS_H
-#define BITCOIN_CHAINPARAMS_H
-
 #include "chainparamsbase.h"
 #include "consensus/params.h"
 #include "primitives/block.h"
 #include "protocol.h"
+#include "enum_util.h"
 
 #include <vector>
 
@@ -42,8 +40,9 @@ struct CCheckpointData {
 class CChainParams
 {
 public:
-    enum Base58Type {
-        PUBKEY_ADDRESS,
+    enum struct Base58Type : uint32_t
+    {
+        PUBKEY_ADDRESS = 0,
         SCRIPT_ADDRESS,
         SECRET_KEY,
         EXT_PUBLIC_KEY,
@@ -56,8 +55,9 @@ public:
         MAX_BASE58_TYPES
     };
 
-    enum Bech32Type {
-        SAPLING_PAYMENT_ADDRESS,
+    enum struct Bech32Type : uint32_t
+    {
+        SAPLING_PAYMENT_ADDRESS = 0,
         SAPLING_FULL_VIEWING_KEY,
         SAPLING_INCOMING_VIEWING_KEY,
         SAPLING_EXTENDED_SPEND_KEY,
@@ -68,38 +68,41 @@ public:
     const Consensus::Params& GetConsensus() const { return consensus; }
     const CMessageHeader::MessageStartChars& MessageStart() const { return pchMessageStart; }
     const std::vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
-    int GetDefaultPort() const { return nDefaultPort; }
+    int GetDefaultPort() const noexcept { return nDefaultPort; }
 
-    const CBlock& GenesisBlock() const { return genesis; }
+    const CBlock& GenesisBlock() const noexcept { return genesis; }
     /** Make miner wait to have peers to avoid wasting work */
-    bool MiningRequiresPeers() const { return fMiningRequiresPeers; }
+    bool MiningRequiresPeers() const noexcept { return fMiningRequiresPeers; }
     /** Default value for -checkmempool and -checkblockindex argument */
-    bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
+    bool DefaultConsistencyChecks() const noexcept { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
-    bool RequireStandard() const { return fRequireStandard; }
-    int64_t PruneAfterHeight() const { return nPruneAfterHeight; }
-    unsigned int EquihashN() const { return nEquihashN; }
-    unsigned int EquihashK() const { return nEquihashK; }
-    std::string CurrencyUnits() const { return strCurrencyUnits; }
-    uint32_t BIP44CoinType() const { return bip44CoinType; }
+    bool RequireStandard() const noexcept { return fRequireStandard; }
+    int64_t PruneAfterHeight() const noexcept { return nPruneAfterHeight; }
+    unsigned int EquihashN() const noexcept { return nEquihashN; }
+    unsigned int EquihashK() const noexcept { return nEquihashK; }
+    std::string CurrencyUnits() const noexcept { return strCurrencyUnits; }
+    uint32_t BIP44CoinType() const noexcept { return bip44CoinType; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
-    bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
+    bool MineBlocksOnDemand() const noexcept { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
-    bool TestnetToBeDeprecatedFieldRPC() const { return fTestnetToBeDeprecatedFieldRPC; }
+    bool TestnetToBeDeprecatedFieldRPC() const noexcept { return fTestnetToBeDeprecatedFieldRPC; }
     /** Return the BIP70 network string (main, test or regtest) */
-    std::string NetworkIDString() const { return strNetworkID; }    
-    const std::vector<CDNSSeedData>& DNSSeeds() const { return vSeeds; }
-    const std::vector<unsigned char>& Base58Prefix(Base58Type type) const { return base58Prefixes[type]; }
-    const std::string& Bech32HRP(Bech32Type type) const { return bech32HRPs[type]; }
-    const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
-    const CCheckpointData& Checkpoints() const { return checkpointData; }
+    std::string NetworkIDString() const noexcept { return strNetworkID; }    
+    const std::vector<CDNSSeedData>& DNSSeeds() const noexcept { return vSeeds; }
+    const std::vector<unsigned char>& Base58Prefix(const Base58Type type) const noexcept { return base58Prefixes[to_integral_type(type)]; }
+    const std::string& Bech32HRP(const Bech32Type type) const noexcept { return bech32HRPs[to_integral_type(type)]; }
+    const std::vector<SeedSpec6>& FixedSeeds() const noexcept { return vFixedSeeds; }
+    const CCheckpointData& Checkpoints() const noexcept { return checkpointData; }
 
-    bool IsMainNet() const {return network == CBaseChainParams::MAIN;}
-    bool IsTestNet() const {return network == CBaseChainParams::TESTNET;}
-    bool IsRegTest() const {return network == CBaseChainParams::REGTEST;}
+    bool IsMainNet() const noexcept { return network == CBaseChainParams::Network::MAIN; }
+    bool IsTestNet() const noexcept { return network == CBaseChainParams::Network::TESTNET; }
+    bool IsRegTest() const noexcept { return network == CBaseChainParams::Network::REGTEST; }
 
 protected:
-    CChainParams() {}
+    CChainParams()
+    {
+        memset(&pchMessageStart, 0, sizeof(pchMessageStart));
+    }
 
     Consensus::Params consensus;
     CMessageHeader::MessageStartChars pchMessageStart;
@@ -110,12 +113,12 @@ protected:
     unsigned int nEquihashN = 0;
     unsigned int nEquihashK = 0;
     std::vector<CDNSSeedData> vSeeds;
-    std::vector<unsigned char> base58Prefixes[MAX_BASE58_TYPES];
-    std::string bech32HRPs[MAX_BECH32_TYPES];
+    std::vector<unsigned char> base58Prefixes[to_integral_type(Base58Type::MAX_BASE58_TYPES)];
+    std::string bech32HRPs[to_integral_type(Bech32Type::MAX_BECH32_TYPES)];
     std::string strNetworkID;
-    CBaseChainParams::Network network;
+    CBaseChainParams::Network network = CBaseChainParams::Network::MAIN;
     std::string strCurrencyUnits;
-    uint32_t bip44CoinType;
+    uint32_t bip44CoinType = 0;
     CBlock genesis;
     std::vector<SeedSpec6> vFixedSeeds;
     bool fMiningRequiresPeers = false;
@@ -148,5 +151,3 @@ bool SelectParamsFromCommandLine();
  * Allows modifying the network upgrade regtest parameters.
  */
 void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight);
-
-#endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -73,16 +73,20 @@ const CBaseChainParams& BaseParams()
 
 void SelectBaseParams(CBaseChainParams::Network network)
 {
-    switch (network) {
-    case CBaseChainParams::MAIN:
+    switch (network)
+    {
+    case CBaseChainParams::Network::MAIN:
         pCurrentBaseParams = &mainParams;
         break;
-    case CBaseChainParams::TESTNET:
+
+    case CBaseChainParams::Network::TESTNET:
         pCurrentBaseParams = &testNetParams;
         break;
-    case CBaseChainParams::REGTEST:
+
+    case CBaseChainParams::Network::REGTEST:
         pCurrentBaseParams = &regTestParams;
         break;
+
     default:
         assert(false && "Unimplemented network");
         return;
@@ -95,18 +99,18 @@ CBaseChainParams::Network NetworkIdFromCommandLine()
     bool fTestNet = GetBoolArg("-testnet", false);
 
     if (fTestNet && fRegTest)
-        return CBaseChainParams::MAX_NETWORK_TYPES;
+        return CBaseChainParams::Network::MAX_NETWORK_TYPES;
     if (fRegTest)
-        return CBaseChainParams::REGTEST;
+        return CBaseChainParams::Network::REGTEST;
     if (fTestNet)
-        return CBaseChainParams::TESTNET;
-    return CBaseChainParams::MAIN;
+        return CBaseChainParams::Network::TESTNET;
+    return CBaseChainParams::Network::MAIN;
 }
 
 bool SelectBaseParamsFromCommandLine()
 {
     CBaseChainParams::Network network = NetworkIdFromCommandLine();
-    if (network == CBaseChainParams::MAX_NETWORK_TYPES)
+    if (network == CBaseChainParams::Network::MAX_NETWORK_TYPES)
         return false;
 
     SelectBaseParams(network);
@@ -115,5 +119,5 @@ bool SelectBaseParamsFromCommandLine()
 
 bool AreBaseParamsConfigured()
 {
-    return pCurrentBaseParams != NULL;
+    return pCurrentBaseParams != nullptr;
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -15,7 +15,8 @@
 class CBaseChainParams
 {
 public:
-    enum Network {
+    enum class Network
+    {
         MAIN,
         TESTNET,
         REGTEST,

--- a/src/compat.h
+++ b/src/compat.h
@@ -89,7 +89,7 @@ typedef u_int SOCKET;
 #define THREAD_PRIORITY_ABOVE_NORMAL    (-2)
 #endif
 
-#if HAVE_DECL_STRNLEN == 0
+#if defined(HAVE_DECL_STRNLEN) && (HAVE_DECL_STRNLEN == 0)
 size_t strnlen( const char *start, size_t max_len);
 #endif // HAVE_DECL_STRNLEN
 

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -19,6 +19,7 @@ extern "C" void* memcpy(void* a, const void* b, size_t c)
     return memmove(a, b, c);
 }
 
+#ifdef __GLIBC__
 extern "C" void __chk_fail(void) __attribute__((__noreturn__));
 extern "C" FDELT_TYPE __fdelt_warn(FDELT_TYPE a)
 {
@@ -27,3 +28,4 @@ extern "C" FDELT_TYPE __fdelt_warn(FDELT_TYPE a)
     return a / __NFDBITS;
 }
 extern "C" FDELT_TYPE __fdelt_chk(FDELT_TYPE) __attribute__((weak, alias("__fdelt_warn")));
+#endif // __GLIBC__

--- a/src/detect_cpp_standard.h
+++ b/src/detect_cpp_standard.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#ifdef _MSC_VER
+#  if _MSC_VER >= 1700 // Visual Studio 2012
+#    ifdef __cplusplus
+#      ifndef _HAS_CPP11_FEATURES
+#        define _HAS_CPP11_FEATURES
+#      endif
+#      if _MSC_VER >= 1900 // Visual Studio 2015
+#        ifndef _HAS_CPP14_FEATURES
+#          define _HAS_CPP14_FEATURES
+#        endif
+#      endif
+#        if _MSC_VER >= 1910 // Visual Studio 2017
+#          ifndef _HAS_CPP17_FEATURES
+#          define _HAS_CPP17_FEATURES
+#        endif
+#      endif
+#      if _MSC_VER >= 1920 // Visual Studio 2019
+#        ifndef _HAS_CPP20_FEATURES
+#          define _HAS_CPP20_FEATURES
+#        endif
+#      endif
+#    endif // __cplusplus
+#  endif // _MSC_VER >= 1700
+#endif // _WIN32_
+
+// _MSVC_LANG predefined macro specifies the C++ language standard targeted by the compiler
+#ifdef _MSVC_LANG
+#  if _MSVC_LANG >= 201402L
+#     ifndef _FORCED_CPP14_FEATURES
+#       define _FORCED_CPP14_FEATURES
+#     endif
+#     if _MSVC_LANG > 201402L
+#       ifndef _FORCED_CPP17_FEATURES
+#         define _FORCED_CPP17_FEATURES
+#       endif
+#       if _MSVC_LANG > 201703L
+#          ifndef _FORCED_CPP20_FEATURES
+#            define _FORCED_CPP20_FEATURES
+#          endif
+#       endif 
+#     endif
+#  endif
+#endif // _MSVC_LANG
+
+// __GXX_EXPERIMENTAL_CXX0X__ is defined only with c++0x option
+// gcc version >= 4.7 will have __cpluscplus defined as 201103L
+#if defined(__GNUG__) || defined(__CLANG__) // g++ compiler
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (defined(__cplusplus) && (__cplusplus >= 201103L))
+// check C++xx features
+# if (__cplusplus >= 201703L)
+#   if (__cplusplus > 201703L)
+#      ifndef _HAS_CPP20_FEATURES
+#         define _HAS_CPP20_FEATURES
+#      endif
+#      ifndef _FORCED_CPP20_FEATURES
+#         define _FORCED_CPP20_FEATURES
+#      endif
+#   endif
+#   ifndef _HAS_CPP17_FEATURES
+#     define _HAS_CPP17_FEATURES
+#   endif
+#   ifndef _FORCED_CPP17_FEATURES
+#     define _FORCED_CPP17_FEATURES
+#   endif
+# endif
+# if (__cplusplus >= 201402L)
+#   ifndef _HAS_CPP14_FEATURES
+#     define _HAS_CPP14_FEATURES
+#   endif
+#   ifndef _FORCED_CPP14_FEATURES
+#     define _FORCED_CPP14_FEATURES
+#   endif
+# endif
+# ifndef _HAS_CPP11_FEATURES
+#   define _HAS_CPP11_FEATURES
+# endif
+#endif // __GXX_EXPERIMENTAL_CXX0X__ || _cplusplus >= 201103L
+#endif // __GNUG__
+

--- a/src/enum_util.h
+++ b/src/enum_util.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "detect_cpp_standard.h"
+#ifdef _HAS_CPP11_FEATURES
+#include <type_traits>
+#endif
+
+// use to_integral_type to convert enum class to underlying type
+#ifdef _FORCED_CPP14_FEATURES
+// c++14
+template<typename _EnumClass>
+constexpr auto to_integral_type(const _EnumClass e)
+{
+	return static_cast<std::underlying_type_t<_EnumClass>>(e);
+}
+#elif defined(_HAS_CPP11_FEATURES)
+// c++11
+template<typename _EnumClass>
+#if defined(_MSC_VER) && (_MSC_VER <= 1700)
+auto
+#else
+const auto
+#endif
+to_integral_type(const _EnumClass e) -> typename std::underlying_type<_EnumClass>::type
+{
+	return static_cast<typename std::underlying_type<_EnumClass>::type>(e);
+}
+#endif

--- a/src/gtest/test_block.cpp
+++ b/src/gtest/test_block.cpp
@@ -1,13 +1,17 @@
 #include <gtest/gtest.h>
 
 #include "primitives/block.h"
+#include "version.h"
 
 
 TEST(block_tests, header_size_is_expected) {
     // Dummy header with an empty Equihash solution.
     CBlockHeader header;
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    // CBlockHeader without nSolution is 140 bytes
+    // nSolution size serialized using WriteCompactSize
+    //   for nSize < 253 -> writes as uint8_t
     ss << header;
 
-    ASSERT_EQ(ss.size(), CBlockHeader::HEADER_SIZE);
+    ASSERT_EQ(ss.size(), CBlockHeader::EMPTY_HEADER_SIZE + 1);
 }

--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -38,7 +38,7 @@ TEST(CheckBlock, VersionTooLow) {
 // Test that a Sprout tx with negative version is still rejected
 // by CheckBlock under Sprout consensus rules.
 TEST(CheckBlock, BlockSproutRejectsBadVersion) {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     CMutableTransaction mtx;
     mtx.vin.resize(1);
@@ -71,7 +71,7 @@ TEST(CheckBlock, BlockSproutRejectsBadVersion) {
 class ContextualCheckBlockTest : public ::testing::Test {
 protected:
     virtual void SetUp() {
-        SelectParams(CBaseChainParams::MAIN);
+        SelectParams(CBaseChainParams::Network::MAIN);
     }
 
     virtual void TearDown() {
@@ -203,7 +203,7 @@ TEST_F(ContextualCheckBlockTest, BlockSproutRulesAcceptSproutTx) {
 
 // Test block evaluated under Overwinter rules will accept Overwinter transactions.
 TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesAcceptOverwinterTx) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
 
     CMutableTransaction mtx = GetFirstBlockCoinbaseTx();
@@ -220,7 +220,7 @@ TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesAcceptOverwinterTx) {
 
 // Test that a block evaluated under Sapling rules can contain Sapling transactions.
 TEST_F(ContextualCheckBlockTest, BlockSaplingRulesAcceptSaplingTx) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, 1);
 
@@ -271,7 +271,7 @@ TEST_F(ContextualCheckBlockTest, BlockSproutRulesRejectOtherTx) {
 // Test block evaluated under Overwinter rules cannot contain non-Overwinter
 // transactions.
 TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesRejectOtherTx) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
 
     CMutableTransaction mtx = GetFirstBlockCoinbaseTx();
@@ -298,7 +298,7 @@ TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesRejectOtherTx) {
 
 // Test block evaluated under Sapling rules cannot contain non-Sapling transactions.
 TEST_F(ContextualCheckBlockTest, BlockSaplingRulesRejectOtherTx) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, 1);
 

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -136,7 +136,7 @@ TEST(checktransaction_tests, bad_txns_vout_empty) {
 }
 
 TEST(checktransaction_tests, BadTxnsOversize) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     CMutableTransaction mtx = GetValidTransaction();
 
     mtx.vin[0].scriptSig = CScript();
@@ -197,7 +197,7 @@ TEST(checktransaction_tests, BadTxnsOversize) {
 }
 
 TEST(checktransaction_tests, OversizeSaplingTxns) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
@@ -499,7 +499,7 @@ TEST(checktransaction_tests, bad_txns_prevout_null) {
 }
 
 TEST(checktransaction_tests, bad_txns_invalid_joinsplit_signature) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
 
     CMutableTransaction mtx = GetValidTransaction();
     mtx.joinSplitSig[0] += 1;
@@ -514,7 +514,7 @@ TEST(checktransaction_tests, bad_txns_invalid_joinsplit_signature) {
 }
 
 TEST(checktransaction_tests, non_canonical_ed25519_signature) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
 
     CMutableTransaction mtx = GetValidTransaction();
 
@@ -788,7 +788,7 @@ TEST(checktransaction_tests, OverwinterVersionNumberLow) {
 
 // Test bad Overwinter version number in ContextualCheckTransaction
 TEST(checktransaction_tests, OverwinterVersionNumberHigh) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CMutableTransaction mtx = GetValidTransaction();
@@ -825,7 +825,7 @@ TEST(checktransaction_tests, OverwinterBadVersionGroupId) {
 
 // This tests an Overwinter transaction checked against Sprout
 TEST(checktransaction_tests, OverwinterNotActive) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     CMutableTransaction mtx = GetValidTransaction();
     mtx.fOverwintered = true;
@@ -844,7 +844,7 @@ TEST(checktransaction_tests, OverwinterNotActive) {
 
 // This tests a transaction without the fOverwintered flag set, against the Overwinter consensus rule set.
 TEST(checktransaction_tests, OverwinterFlagNotSet) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CMutableTransaction mtx = GetValidTransaction();
@@ -887,7 +887,7 @@ TEST(checktransaction_tests, OverwinterInvalidSoftForkVersion) {
 
 // Test CreateNewContextualCMutableTransaction sets default values based on height
 TEST(checktransaction_tests, OverwinteredContextualCreateTx) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     const Consensus::Params& consensusParams = Params().GetConsensus();
     int activationHeight = 5;
     int saplingActivationHeight = 30;

--- a/src/gtest/test_deprecation.cpp
+++ b/src/gtest/test_deprecation.cpp
@@ -39,7 +39,7 @@ protected:
     virtual void SetUp() {
         uiInterface.ThreadSafeMessageBox.disconnect_all_slots();
         uiInterface.ThreadSafeMessageBox.connect(boost::bind(ThreadSafeMessageBox, &mock_, _1, _2, _3));
-        SelectParams(CBaseChainParams::MAIN);
+        SelectParams(CBaseChainParams::Network::MAIN);
         
     }
 
@@ -110,14 +110,14 @@ TEST_F(DeprecationTest, DeprecatedNodeErrorIsRepeatedOnStartup) {
 }
 
 TEST_F(DeprecationTest, DeprecatedNodeIgnoredOnRegtest) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     EXPECT_FALSE(ShutdownRequested());
     EnforceNodeDeprecation(DEPRECATION_HEIGHT+1);
     EXPECT_FALSE(ShutdownRequested());
 }
 
 TEST_F(DeprecationTest, DeprecatedNodeIgnoredOnTestnet) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
     EXPECT_FALSE(ShutdownRequested());
     EnforceNodeDeprecation(DEPRECATION_HEIGHT+1);
     EXPECT_FALSE(ShutdownRequested());

--- a/src/gtest/test_keys.cpp
+++ b/src/gtest/test_keys.cpp
@@ -7,7 +7,7 @@
 
 TEST(Keys, EncodeAndDecodeSapling)
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     std::vector<unsigned char, secure_allocator<unsigned char>> rawSeed(32);
     HDSeed seed(rawSeed);
@@ -19,7 +19,7 @@ TEST(Keys, EncodeAndDecodeSapling)
             std::string sk_string = EncodeSpendingKey(sk);
             EXPECT_EQ(
                 sk_string.substr(0, 26),
-                Params().Bech32HRP(CChainParams::SAPLING_EXTENDED_SPEND_KEY));
+                Params().Bech32HRP(CChainParams::Bech32Type::SAPLING_EXTENDED_SPEND_KEY));
 
             auto spendingkey2 = DecodeSpendingKey(sk_string);
             EXPECT_TRUE(IsValidSpendingKey(spendingkey2));
@@ -34,7 +34,7 @@ TEST(Keys, EncodeAndDecodeSapling)
             std::string addr_string = EncodePaymentAddress(addr);
             EXPECT_EQ(
                 addr_string.substr(0, 2),
-                Params().Bech32HRP(CChainParams::SAPLING_PAYMENT_ADDRESS));
+                Params().Bech32HRP(CChainParams::Bech32Type::SAPLING_PAYMENT_ADDRESS));
 
             auto paymentaddr2 = DecodePaymentAddress(addr_string);
             EXPECT_TRUE(IsValidPaymentAddress(paymentaddr2));

--- a/src/gtest/test_mempool.cpp
+++ b/src/gtest/test_mempool.cpp
@@ -104,7 +104,7 @@ TEST(Mempool, PriorityStatsDoNotCrash) {
 
 // Valid overwinter v3 format tx gets rejected because overwinter hasn't activated yet.
 TEST(Mempool, OverwinterNotActiveYet) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 
     CTxMemPool pool(::minRelayTxFee);
@@ -131,7 +131,7 @@ TEST(Mempool, OverwinterNotActiveYet) {
 // 2. pass ContextualCheckTransaction
 // 3. fail IsStandardTx
 TEST(Mempool, SproutV3TxFailsAsExpected) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     CTxMemPool pool(::minRelayTxFee);
     bool missingInputs;
@@ -151,7 +151,7 @@ TEST(Mempool, SproutV3TxFailsAsExpected) {
 // 1. pass CheckTransaction (and CheckTransactionWithoutProofVerification)
 // 2. fails ContextualCheckTransaction
 TEST(Mempool, SproutV3TxWhenOverwinterActive) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CTxMemPool pool(::minRelayTxFee);
@@ -175,7 +175,7 @@ TEST(Mempool, SproutV3TxWhenOverwinterActive) {
 // under Sprout consensus rules, should still be rejected under Overwinter consensus rules.
 // 1. fails CheckTransaction (specifically CheckTransactionWithoutProofVerification)
 TEST(Mempool, SproutNegativeVersionTxWhenOverwinterActive) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CTxMemPool pool(::minRelayTxFee);
@@ -224,7 +224,7 @@ TEST(Mempool, SproutNegativeVersionTxWhenOverwinterActive) {
 
 
 TEST(Mempool, ExpiringSoonTxRejection) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CTxMemPool pool(::minRelayTxFee);

--- a/src/gtest/test_miner.cpp
+++ b/src/gtest/test_miner.cpp
@@ -23,7 +23,7 @@ public:
 #endif
 
 TEST(Miner, GetMinerScriptPubKey) {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     boost::optional<CScript> scriptPubKey;
 #ifdef ENABLE_WALLET

--- a/src/gtest/test_mnode_governance.cpp
+++ b/src/gtest/test_mnode_governance.cpp
@@ -10,7 +10,7 @@
 #include "mnode-governance.h"
 
 TEST(mnode_governance, CalculateLastPaymentBlock) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     CMasternodeGovernance gov;
 
@@ -27,7 +27,7 @@ TEST(mnode_governance, CalculateLastPaymentBlock) {
 }
 
 TEST(mnode_governance, TicketProcessing) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     std::string address("tPVQMdSyVnSYgrww5TTXSJeF75aPQ3bAfdm");
     

--- a/src/gtest/test_mnode_rpc.cpp
+++ b/src/gtest/test_mnode_rpc.cpp
@@ -1,0 +1,86 @@
+#include "mnode-rpc.h"
+#include "base58.h"
+#include <gtest/gtest.h>
+#include <tuple>
+
+using namespace testing;
+using namespace std;
+
+string Base58Encode_TestKey(const string& s)
+{
+    vector<unsigned char> vch(s.cbegin(), s.cend());
+    return EncodeBase58Check(vch);
+}
+
+class PTest_ani2psl_secret : public TestWithParam<tuple<
+        string (*)(), // generate private key string
+        bool,  // CKey::IsValid()
+        bool   // CKey::IsCompressed()
+    >>        
+{
+public:
+    static void SetUpTestCase()
+    {
+        SelectParams(CBaseChainParams::Network::REGTEST);
+    }
+};
+
+TEST_P(PTest_ani2psl_secret, test)
+{
+    const string sKey = get<0>(GetParam())();
+    const bool bResult = get<1>(GetParam());
+    const bool bCompressed = get<2>(GetParam());
+    string sKeyError;
+
+    const CKey key = ani2psl_secret(sKey, sKeyError);
+    EXPECT_EQ(bResult, key.IsValid()) << "KeyError: " << sKeyError;
+    EXPECT_EQ(bResult, sKeyError.empty());
+
+    // check SECP256K1_EC_COMPRESSED flag
+    EXPECT_EQ(bCompressed, key.IsCompressed());
+}
+
+constexpr auto TestValidKey = "private key is base58 encoded___";
+
+INSTANTIATE_TEST_CASE_P(mnode_rpc_ani2psl, PTest_ani2psl_secret,
+	Values(
+		// key not base58 encoded
+		make_tuple([]() -> string { return "test";}, 
+            false, false),
+        // base58 encoding, but key is too short
+        make_tuple([]()
+        {
+            return Base58Encode_TestKey("test private key");
+        }, false, false),
+        // correct size, but no prefix
+        make_tuple([]()
+        {
+            return Base58Encode_TestKey(TestValidKey);
+        }, false, false),
+        // invalid prefix (SECRET_KEY) for the current network (regtest)
+        make_tuple([]()
+        {
+            const auto& v = Params().Base58Prefix(CChainParams::Base58Type::SECRET_KEY);
+            string s(v.size(), 'a');
+            s += TestValidKey;
+            return Base58Encode_TestKey(s);
+        }, false, false),
+        // valid private key - compressed flag is off
+        make_tuple([]()
+        {
+            const auto& v = Params().Base58Prefix(CChainParams::Base58Type::SECRET_KEY);
+            string s(v.cbegin(), v.cend());
+            s += TestValidKey;
+            return Base58Encode_TestKey(s);
+        }, true, false),
+        // valid private key - compressed flag is on
+        make_tuple([]()
+        {
+            const auto& v = Params().Base58Prefix(CChainParams::Base58Type::SECRET_KEY);
+            string s(v.cbegin(), v.cend());
+            s += TestValidKey;
+            s += '\1';
+            return Base58Encode_TestKey(s);
+        }, true, true)
+	));
+

--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -195,7 +195,7 @@ TEST(noteencryption, SaplingApi)
     {
         uint256 test_epk;
         uint256 test_esk = enc.get_esk();
-        ASSERT_TRUE(librustzcash_sapling_ka_derivepublic(pk_1.d.begin(), test_esk.begin(), test_epk.begin()));
+        ASSERT_TRUE(librustzcash_sapling_ka_derivepublic(pk_1.d.data(), test_esk.begin(), test_epk.begin()));
         ASSERT_TRUE(test_epk == epk_1);
     }
     auto cv_1 = random_uint256();

--- a/src/gtest/test_paymentdisclosure.cpp
+++ b/src/gtest/test_paymentdisclosure.cpp
@@ -93,7 +93,7 @@ public:
 // Note that the zpd: prefix is not part of the payment disclosure blob itself.  It is only
 // used as convention to improve the user experience when sharing payment disclosure blobs.
 TEST(paymentdisclosure, mainnet) {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
     boost::filesystem::create_directories(pathTemp);

--- a/src/gtest/test_pow.cpp
+++ b/src/gtest/test_pow.cpp
@@ -6,7 +6,7 @@
 #include "random.h"
 
 TEST(PoW, DifficultyAveraging) {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
     const Consensus::Params& params = Params().GetConsensus();
     size_t lastBlk = 2*params.nPowAveragingWindow+1002;
     size_t firstBlk = lastBlk - params.nPowAveragingWindow;
@@ -70,7 +70,7 @@ TEST(PoW, DifficultyAveraging) {
 }
 
 TEST(PoW, MinDifficultyRules) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
     const Consensus::Params& params = Params().GetConsensus();
     size_t lastBlk = 2*params.nPowAveragingWindow;
     size_t firstBlk = lastBlk - params.nPowAveragingWindow;

--- a/src/gtest/test_rpc.cpp
+++ b/src/gtest/test_rpc.cpp
@@ -12,7 +12,7 @@
 extern UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
 
 TEST(rpc, check_blockToJSON_returns_minified_solution) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     // Testnet block 0030b0d110441f5bdad733adcd68ad308aa96cf43aeb8bdcd57b04fed11cd56e
     // Height 4

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -15,13 +15,16 @@ static const std::string tSecretRegtest = "cND2ZvtabDbJ1gucx9GWH6XT9kgTAqfb6cotP
 
 TEST(TransactionBuilder, Invoke)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
+    std::string sKeyError;
     CBasicKeyStore keystore;
-    CKey tsk = DecodeSecret(tSecretRegtest);
+    const CKey tsk = DecodeSecret(tSecretRegtest, sKeyError);
+    EXPECT_TRUE(tsk.IsValid());
+    EXPECT_TRUE(sKeyError.empty());
     keystore.AddKey(tsk);
     auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
 
@@ -93,7 +96,7 @@ TEST(TransactionBuilder, Invoke)
 
 TEST(TransactionBuilder, ThrowsOnTransparentInputWithoutKeyStore)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     auto consensusParams = Params().GetConsensus();
 
     auto builder = TransactionBuilder(consensusParams, 1);
@@ -102,7 +105,7 @@ TEST(TransactionBuilder, ThrowsOnTransparentInputWithoutKeyStore)
 
 TEST(TransactionBuilder, RejectsInvalidTransparentOutput)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     auto consensusParams = Params().GetConsensus();
 
     // Default CTxDestination type is an invalid address
@@ -113,7 +116,7 @@ TEST(TransactionBuilder, RejectsInvalidTransparentOutput)
 
 TEST(TransactionBuilder, RejectsInvalidTransparentChangeAddress)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     auto consensusParams = Params().GetConsensus();
 
     // Default CTxDestination type is an invalid address
@@ -124,7 +127,7 @@ TEST(TransactionBuilder, RejectsInvalidTransparentChangeAddress)
 
 TEST(TransactionBuilder, FailsWithNegativeChange)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -136,8 +139,11 @@ TEST(TransactionBuilder, FailsWithNegativeChange)
     auto pk = sk.default_address();
 
     // Set up dummy transparent address
+    std::string sKeyError;
     CBasicKeyStore keystore;
-    CKey tsk = DecodeSecret(tSecretRegtest);
+    const CKey tsk = DecodeSecret(tSecretRegtest, sKeyError);
+    EXPECT_TRUE(tsk.IsValid());
+    EXPECT_TRUE(sKeyError.empty());
     keystore.AddKey(tsk);
     auto tkeyid = tsk.GetPubKey().GetID();
     auto scriptPubKey = GetScriptForDestination(tkeyid);
@@ -179,7 +185,7 @@ TEST(TransactionBuilder, FailsWithNegativeChange)
 
 TEST(TransactionBuilder, ChangeOutput)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -203,8 +209,11 @@ TEST(TransactionBuilder, ChangeOutput)
     auto zChangeAddr = sk2.default_address();
 
     // Set up dummy transparent address
+    std::string sKeyError;
     CBasicKeyStore keystore;
-    CKey tsk = DecodeSecret(tSecretRegtest);
+    const CKey tsk = DecodeSecret(tSecretRegtest, sKeyError);
+    EXPECT_TRUE(tsk.IsValid());
+    EXPECT_TRUE(sKeyError.empty());
     keystore.AddKey(tsk);
     auto tkeyid = tsk.GetPubKey().GetID();
     auto scriptPubKey = GetScriptForDestination(tkeyid);
@@ -270,7 +279,7 @@ TEST(TransactionBuilder, ChangeOutput)
 
 TEST(TransactionBuilder, SetFee)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -327,7 +336,7 @@ TEST(TransactionBuilder, SetFee)
 
 TEST(TransactionBuilder, CheckSaplingTxVersion)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 

--- a/src/gtest/test_upgrades.cpp
+++ b/src/gtest/test_upgrades.cpp
@@ -17,7 +17,7 @@ protected:
 };
 
 TEST_F(UpgradesTest, NetworkUpgradeState) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     const Consensus::Params& params = Params().GetConsensus();
 
     // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
@@ -55,7 +55,7 @@ TEST_F(UpgradesTest, NetworkUpgradeState) {
 }
 
 TEST_F(UpgradesTest, CurrentEpoch) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     const Consensus::Params& params = Params().GetConsensus();
     auto nBranchId = NetworkUpgradeInfo[Consensus::UPGRADE_TESTDUMMY].nBranchId;
 
@@ -86,7 +86,7 @@ TEST_F(UpgradesTest, CurrentEpoch) {
 }
 
 TEST_F(UpgradesTest, IsActivationHeight) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     const Consensus::Params& params = Params().GetConsensus();
 
     // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
@@ -115,7 +115,7 @@ TEST_F(UpgradesTest, IsActivationHeight) {
 }
 
 TEST_F(UpgradesTest, IsActivationHeightForAnyUpgrade) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     const Consensus::Params& params = Params().GetConsensus();
 
     // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
@@ -144,7 +144,7 @@ TEST_F(UpgradesTest, IsActivationHeightForAnyUpgrade) {
 }
 
 TEST_F(UpgradesTest, NextEpoch) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     const Consensus::Params& params = Params().GetConsensus();
 
     // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
@@ -173,7 +173,7 @@ TEST_F(UpgradesTest, NextEpoch) {
 }
 
 TEST_F(UpgradesTest, NextActivationHeight) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     const Consensus::Params& params = Params().GetConsensus();
 
     // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -82,7 +82,7 @@ TEST(Validation, ContextualCheckInputsPassesWithCoinbase) {
         auto consensusBranchId = NetworkUpgradeInfo[idx].nBranchId;
         CValidationState state;
         PrecomputedTransactionData txdata(tx);
-        EXPECT_TRUE(ContextualCheckInputs(tx, state, view, false, 0, false, txdata, Params(CBaseChainParams::MAIN).GetConsensus(), consensusBranchId));
+        EXPECT_TRUE(ContextualCheckInputs(tx, state, view, false, 0, false, txdata, Params(CBaseChainParams::Network::MAIN).GetConsensus(), consensusBranchId));
     }
 }
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -20,6 +20,8 @@
 #include <sys/stat.h>
 #include <signal.h>
 
+#include <deque>
+
 #include <event2/event.h>
 #include <event2/http.h>
 #include <event2/thread.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -43,6 +43,7 @@
 #endif
 #include <stdint.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #ifndef WIN32
 #include <signal.h>

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -16,7 +16,7 @@
 
 #include <string>
 
-CKey DecodeSecret(const std::string& str);
+CKey DecodeSecret(const std::string& str, std::string &error);
 std::string EncodeSecret(const CKey& key);
 
 CExtKey DecodeExtKey(const std::string& str);

--- a/src/leveldb/db/db_iter.cc
+++ b/src/leveldb/db/db_iter.cc
@@ -13,6 +13,7 @@
 #include "util/logging.h"
 #include "util/mutexlock.h"
 #include "util/random.h"
+#include <unistd.h>
 
 namespace leveldb {
 

--- a/src/leveldb/port/port_win.h
+++ b/src/leveldb/port/port_win.h
@@ -32,7 +32,9 @@
 #define STORAGE_LEVELDB_PORT_PORT_WIN_H_
 
 #ifdef _MSC_VER
+#if _MSC_VER < 1700
 #define snprintf _snprintf
+#endif
 #define close _close
 #define fread_unlocked _fread_nolock
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1023,8 +1023,8 @@ bool ContextualCheckTransaction(
                 spend.anchor.begin(),
                 spend.nullifier.begin(),
                 spend.rk.begin(),
-                spend.zkproof.begin(),
-                spend.spendAuthSig.begin(),
+                spend.zkproof.data(),
+                spend.spendAuthSig.data(),
                 dataToBeSigned.begin()
             ))
             {
@@ -1040,7 +1040,7 @@ bool ContextualCheckTransaction(
                 output.cv.begin(),
                 output.cm.begin(),
                 output.ephemeralKey.begin(),
-                output.zkproof.begin()
+                output.zkproof.data()
             ))
             {
                 librustzcash_sapling_verification_ctx_free(ctx);
@@ -1052,7 +1052,7 @@ bool ContextualCheckTransaction(
         if (!librustzcash_sapling_final_check(
             ctx,
             tx.valueBalance,
-            tx.bindingSig.begin(),
+            tx.bindingSig.data(),
             dataToBeSigned.begin()
         ))
         {

--- a/src/mnode-active.cpp
+++ b/src/mnode-active.cpp
@@ -155,7 +155,7 @@ void CActiveMasternode::ManageStateInitial()
         return;
     }
 
-    int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
+    int mainnetDefaultPort = Params(CBaseChainParams::Network::MAIN).GetDefaultPort();
     if(Params().IsMainNet()) {
         if(service.GetPort() != mainnetDefaultPort) {
             nState = ActiveMasternodeState::NotCapable;

--- a/src/mnode-config.cpp
+++ b/src/mnode-config.cpp
@@ -37,7 +37,7 @@ bool checkIPAddressPort(std::string& address, std::string alias, bool checkPort,
         return false;
     }
     if (checkPort) {
-        int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
+        int mainnetDefaultPort = Params(CBaseChainParams::Network::MAIN).GetDefaultPort();
         if(Params().IsMainNet()) {
             if(port != mainnetDefaultPort) {
                 strErr = _("Invalid port detected in masternode.conf") + "\n" +

--- a/src/mnode-controller.cpp
+++ b/src/mnode-controller.cpp
@@ -115,9 +115,11 @@ bool CMasterNodeController::EnableMasterNode(std::ostringstream& strErrors, boos
     if(fMasterNode) {
         LogPrintf("MASTERNODE:\n");
 
-        std::string strMasterNodePrivKey = GetArg("-masternodeprivkey", "");
-        if(!strMasterNodePrivKey.empty()) {
-            if(!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, activeMasternode.keyMasternode, activeMasternode.pubKeyMasternode)) {
+        const std::string strMasterNodePrivKey = GetArg("-masternodeprivkey", "");
+        if(!strMasterNodePrivKey.empty())
+        {
+            if(!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, activeMasternode.keyMasternode, activeMasternode.pubKeyMasternode))
+            {
                 strErrors << _("Invalid masternodeprivkey. Please see documentation.");
                 return false;
             }

--- a/src/mnode-manager.cpp
+++ b/src/mnode-manager.cpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <vector>
 #include <algorithm>
+#include <random>
 
 #include "mnode-active.h"
 
@@ -555,9 +556,10 @@ masternode_info_t CMasternodeMan::FindRandomNotInVec(const std::vector<COutPoint
         vpMasternodesShuffled.push_back(&mnpair.second);
     }
 
-    InsecureRand insecureRand;
+    std::random_device rd;
+    std::mt19937 g(rd());
     // shuffle pointers
-    std::random_shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), insecureRand);
+    std::shuffle(vpMasternodesShuffled.begin(), vpMasternodesShuffled.end(), g);
     bool fExclude;
 
     // loop through

--- a/src/mnode-masternode.cpp
+++ b/src/mnode-masternode.cpp
@@ -458,7 +458,7 @@ bool CMasternodeBroadcast::Create(std::string strService, std::string strKeyMast
     CService service;
     if (!Lookup(strService.c_str(), service, 0, false))
         return Log(strprintf("Invalid address %s for masternode.", strService));
-    int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
+    int mainnetDefaultPort = Params(CBaseChainParams::Network::MAIN).GetDefaultPort();
     if (Params().IsMainNet()) {
         if (service.GetPort() != mainnetDefaultPort)
             return Log(strprintf("Invalid port %u for masternode %s, only %d is supported on mainnet.", service.GetPort(), strService, mainnetDefaultPort));
@@ -570,7 +570,7 @@ bool CMasternodeBroadcast::SimpleCheck(int& nDos)
         return false;
     }
 
-    int mainnetDefaultPort = Params(CBaseChainParams::MAIN).GetDefaultPort();
+    int mainnetDefaultPort = Params(CBaseChainParams::Network::MAIN).GetDefaultPort();
     if(Params().IsMainNet()) {
         if(addr.GetPort() != mainnetDefaultPort) return false;
     } else if(addr.GetPort() == mainnetDefaultPort) return false;

--- a/src/mnode-msgsigner.cpp
+++ b/src/mnode-msgsigner.cpp
@@ -8,15 +8,13 @@
 
 #include "mnode-msgsigner.h"
 
-bool CMessageSigner::GetKeysFromSecret(const std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet)
+bool CMessageSigner::GetKeysFromSecret(const std::string &strSecret, CKey& keyRet, CPubKey& pubkeyRet)
 {
-    keyRet = DecodeSecret(strSecret);
-    if (!keyRet.IsValid()) {
+    std::string sKeyError;
+    keyRet = DecodeSecret(strSecret, sKeyError);
+    if (!keyRet.IsValid())
         return false;
-    }
-
     pubkeyRet = keyRet.GetPubKey();
-
     return true;
 }
 

--- a/src/mnode-msgsigner.h
+++ b/src/mnode-msgsigner.h
@@ -16,7 +16,7 @@ class CMessageSigner
 {
 public:
     /// Set the private/public key values, returns true if successful
-    static bool GetKeysFromSecret(const std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet);
+    static bool GetKeysFromSecret(const std::string &strSecret, CKey& keyRet, CPubKey& pubkeyRet);
     /// Sign the message, returns true if successful
     static bool SignMessage(const std::string strMessage, std::vector<unsigned char>& vchSigRet, const CKey key);
     /// Verify the message signature, returns true if succcessful

--- a/src/mnode-payments.cpp
+++ b/src/mnode-payments.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <unistd.h>
+
 #include "main.h"
 #include "core_io.h"
 #include "key_io.h"

--- a/src/mnode-rpc.h
+++ b/src/mnode-rpc.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "key_io.h"
+
+CKey ani2psl_secret(const std::string& str, std::string& sKeyError);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -26,6 +26,7 @@
 #endif
 #include <fcntl.h>
 #endif
+#include <unistd.h>
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -22,16 +22,28 @@ class CBlockHeader
 {
 public:
     // header
-    static const size_t HEADER_SIZE=4+32+32+32+4+4+32+(32+4)*3; // excluding Equihash solution
-    static const int32_t CURRENT_VERSION=4;
     int32_t nVersion;
-    uint256 hashPrevBlock;
-    uint256 hashMerkleRoot;
+    uint256 hashPrevBlock;                // hash of the previous block
+    uint256 hashMerkleRoot;               // merkle root
     uint256 hashFinalSaplingRoot;
     uint32_t nTime;
     uint32_t nBits;
     uint256 nNonce;
-    std::vector<unsigned char> nSolution;
+    std::vector<unsigned char> nSolution; // Equihash solution
+
+    // excluding Equihash solution
+    static constexpr size_t EMPTY_HEADER_SIZE =
+        sizeof(nVersion) +
+        32 + /* hashPrevBlock */
+        32 + /* hashMerkleRoot */
+        32 + /* hashFinalSaplingRoot */
+        sizeof(nTime) +
+        sizeof(nBits) +
+        32;  /* nNonce */
+    static constexpr size_t HEADER_SIZE = 
+        EMPTY_HEADER_SIZE +
+        (32 + 4) * 3; /* nSolution - can be empty vector */
+    static constexpr int32_t CURRENT_VERSION = 4;
 
     CBlockHeader()
     {

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -115,7 +115,7 @@ public:
         uint256 h_sig = params.h_sig(jsdesc.randomSeed, jsdesc.nullifiers, joinSplitPubKey);
 
         return librustzcash_sprout_verify(
-            proof.begin(),
+            proof.data(),
             jsdesc.anchor.begin(),
             h_sig.begin(),
             jsdesc.macs[0].begin(),

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -829,14 +829,17 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
 
     bool fGivenKeys = false;
     CBasicKeyStore tempKeystore;
-    if (params.size() > 2 && !params[2].isNull()) {
+    if (params.size() > 2 && !params[2].isNull())
+    {
         fGivenKeys = true;
         UniValue keys = params[2].get_array();
-        for (size_t idx = 0; idx < keys.size(); idx++) {
-            UniValue k = keys[idx];
-            CKey key = DecodeSecret(k.get_str());
+        std::string sKeyError;
+        for (size_t idx = 0; idx < keys.size(); idx++)
+        {
+            const UniValue k = keys[idx];
+            const CKey key = DecodeSecret(k.get_str(), sKeyError);
             if (!key.IsValid())
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, tinyformat::format("Invalid private key, %s", sKeyError.c_str()));
             tempKeystore.AddKey(key);
         }
     }

--- a/src/rpc/rpc_consts.h
+++ b/src/rpc/rpc_consts.h
@@ -13,4 +13,4 @@ constexpr auto RPC_KEY_ALIAS					= "alias";
 constexpr auto RPC_RESULT_FAILED				= "failed";
 constexpr auto RPC_RESULT_SUCCESS				= "successful";
 
-inline const bool get_rpc_result(const bool bSucceeded) noexcept { return bSucceeded ? RPC_RESULT_SUCCESS : RPC_RESULT_FAILED; }
+inline const char *get_rpc_result(const bool bSucceeded) noexcept { return bSucceeded ? RPC_RESULT_SUCCESS : RPC_RESULT_FAILED; }

--- a/src/rpc/rpc_consts.h
+++ b/src/rpc/rpc_consts.h
@@ -1,0 +1,16 @@
+#pragma once
+// Copyright (c) 2021 Pastel Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// rpc response object keys
+constexpr auto RPC_KEY_RESULT					= "result";
+constexpr auto RPC_KEY_ERROR_MESSAGE			= "errorMessage";
+constexpr auto RPC_KEY_STATUS					= "status";
+constexpr auto RPC_KEY_ALIAS					= "alias";
+
+// rpc response object key values
+constexpr auto RPC_RESULT_FAILED				= "failed";
+constexpr auto RPC_RESULT_SUCCESS				= "successful";
+
+inline const bool get_rpc_result(const bool bSucceeded) noexcept { return bSucceeded ? RPC_RESULT_SUCCESS : RPC_RESULT_FAILED; }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -284,13 +284,13 @@ public:
         return *this;
     }
 
-    int getint() const
+    int getint() const noexcept
     {
         if (m_value > std::numeric_limits<int>::max())
             return std::numeric_limits<int>::max();
         else if (m_value < std::numeric_limits<int>::min())
             return std::numeric_limits<int>::min();
-        return m_value;
+        return static_cast<int>(m_value);
     }
 
     std::vector<unsigned char> getvch() const
@@ -362,7 +362,7 @@ protected:
     {
         if (n == -1 || (n >= 1 && n <= 16))
         {
-            push_back(n + (OP_1 - 1));
+            push_back(static_cast<int8_t>(n) + (OP_1 - 1));
         }
         else if (n == 0)
         {
@@ -432,14 +432,17 @@ public:
         {
             insert(end(), OP_PUSHDATA2);
             uint8_t data[2];
-            WriteLE16(data, b.size());
+            WriteLE16(data, static_cast<uint16_t>(b.size()));
             insert(end(), data, data + sizeof(data));
         }
-        else
+        else 
         {
+            // !!! need to check for overflow - only max 32-bit size is supported
+            // vector with size > MAX_UINT32 will be truncated
+            // moreover it truncates size, but writes full data
             insert(end(), OP_PUSHDATA4);
             uint8_t data[4];
-            WriteLE32(data, b.size());
+            WriteLE32(data, static_cast<uint32_t>(b.size()));
             insert(end(), data, data + sizeof(data));
         }
         insert(end(), b.begin(), b.end());

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -326,14 +326,14 @@ CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys)
 //         // base58-encoded Bitcoin addresses.
 //         // Public-key-hash-addresses have first bite = 0x05 (or 0x14 testnet).
 //         // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
-//         const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
+//         const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::Base58Type::PUBKEY_ADDRESS);
 //         if (data.size() == hash.size() + pubkey_prefix.size() && std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin())) {
 //             std::copy(data.begin() + pubkey_prefix.size(), data.end(), hash.begin());
 //             return CKeyID(hash);
 //         }
 //         // Script-hash-addresses have first bite = 0x12 (or 0x15 testnet).
 //         // The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
-//         const std::vector<unsigned char>& script_prefix = params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
+//         const std::vector<unsigned char>& script_prefix = params.Base58Prefix(CChainParams::Base58Type::SCRIPT_ADDRESS);
 //         if (data.size() == hash.size() + script_prefix.size() && std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) {
 //             std::copy(data.begin() + script_prefix.size(), data.end(), hash.begin());
 //             return CScriptID(hash);

--- a/src/secp256k1/src/bench.h
+++ b/src/secp256k1/src/bench.h
@@ -9,7 +9,13 @@
 
 #include <stdio.h>
 #include <math.h>
-#include "sys/time.h"
+#include <unistd.h>
+#ifdef WIN32
+#include <winsock2.h>
+#else
+#include <sys/time.h>
+#endif
+
 
 static double gettimedouble(void) {
     struct timeval tv;

--- a/src/secp256k1/src/bench_ecdh.c
+++ b/src/secp256k1/src/bench_ecdh.c
@@ -36,7 +36,7 @@ static void bench_ecdh_setup(void* arg) {
     CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)) == 1);
 }
 
-static void bench_ecdh(void* arg) {
+static void bench_ecdh_benchmark(void* arg) {
     int i;
     unsigned char res[32];
     bench_ecdh *data = (bench_ecdh*)arg;
@@ -49,6 +49,6 @@ static void bench_ecdh(void* arg) {
 int main(void) {
     bench_ecdh data;
 
-    run_benchmark("ecdh", bench_ecdh, bench_ecdh_setup, NULL, &data, 10, 20000);
+    run_benchmark("ecdh", bench_ecdh_benchmark, bench_ecdh_setup, NULL, &data, 10, 20000);
     return 0;
 }

--- a/src/secp256k1/src/bench_recover.c
+++ b/src/secp256k1/src/bench_recover.c
@@ -15,7 +15,7 @@ typedef struct {
     unsigned char sig[64];
 } bench_recover;
 
-void bench_recover(void* arg) {
+void bench_recover_benchmark(void* arg) {
     int i;
     bench_recover *data = (bench_recover*)arg;
     secp256k1_pubkey pubkey;
@@ -53,7 +53,7 @@ int main(void) {
 
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
 
-    run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
+    run_benchmark("ecdsa_recover", bench_recover_benchmark, bench_recover_setup, NULL, &data, 10, 20000);
 
     secp256k1_context_destroy(data.ctx);
     return 0;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_SERIALIZE_H
 #define BITCOIN_SERIALIZE_H
 
+#include "compat.h"
 #include "compat/endian.h"
 
 #include <algorithm>
@@ -469,7 +470,7 @@ public:
     template<typename Stream>
     void Unserialize(Stream& s)
     {
-        size_t size = ReadCompactSize(s);
+        const uint64_t size = ReadCompactSize(s);
         if (size > Limit) {
             throw std::ios_base::failure("String length limit exceeded");
         }
@@ -605,7 +606,7 @@ void Serialize(Stream& os, const std::basic_string<C>& str)
 template<typename Stream, typename C>
 void Unserialize(Stream& is, std::basic_string<C>& str)
 {
-    unsigned int nSize = ReadCompactSize(is);
+    const uint64_t nSize = ReadCompactSize(is);
     str.resize(nSize);
     if (nSize != 0)
         is.read((char*)&str[0], nSize * sizeof(str[0]));
@@ -644,11 +645,11 @@ void Unserialize_impl(Stream& is, prevector<N, T>& v, const unsigned char&)
 {
     // Limit size per read so bogus size value won't cause out of memory
     v.clear();
-    unsigned int nSize = ReadCompactSize(is);
-    unsigned int i = 0;
+    const uint64_t nSize = ReadCompactSize(is);
+    uint64_t i = 0;
     while (i < nSize)
     {
-        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+        uint64_t blk = std::min<uint64_t>(nSize - i, 1 + 4999999 / sizeof(T));
         v.resize(i + blk);
         is.read((char*)&v[i], blk * sizeof(T));
         i += blk;
@@ -659,9 +660,9 @@ template<typename Stream, unsigned int N, typename T, typename V>
 void Unserialize_impl(Stream& is, prevector<N, T>& v, const V&)
 {
     v.clear();
-    unsigned int nSize = ReadCompactSize(is);
-    unsigned int i = 0;
-    unsigned int nMid = 0;
+    const uint64_t nSize = ReadCompactSize(is);
+    uint64_t i = 0;
+    uint64_t nMid = 0;
     while (nMid < nSize)
     {
         nMid += 5000000 / sizeof(T);
@@ -712,11 +713,11 @@ void Unserialize_impl(Stream& is, std::vector<T, A>& v, const unsigned char&)
 {
     // Limit size per read so bogus size value won't cause out of memory
     v.clear();
-    unsigned int nSize = ReadCompactSize(is);
-    unsigned int i = 0;
+    const uint64_t nSize = ReadCompactSize(is);
+    uint64_t i = 0;
     while (i < nSize)
     {
-        unsigned int blk = std::min(nSize - i, (unsigned int)(1 + 4999999 / sizeof(T)));
+        uint64_t blk = std::min<uint64_t>(nSize - i, 1 + 4999999 / sizeof(T));
         v.resize(i + blk);
         is.read((char*)&v[i], blk * sizeof(T));
         i += blk;
@@ -727,9 +728,9 @@ template<typename Stream, typename T, typename A, typename V>
 void Unserialize_impl(Stream& is, std::vector<T, A>& v, const V&)
 {
     v.clear();
-    unsigned int nSize = ReadCompactSize(is);
-    unsigned int i = 0;
-    unsigned int nMid = 0;
+    const uint64_t nSize = ReadCompactSize(is);
+    uint64_t i = 0;
+    uint64_t nMid = 0;
     while (nMid < nSize)
     {
         nMid += 5000000 / sizeof(T);
@@ -840,9 +841,9 @@ template<typename Stream, typename K, typename T, typename Pred, typename A>
 void Unserialize(Stream& is, std::map<K, T, Pred, A>& m)
 {
     m.clear();
-    unsigned int nSize = ReadCompactSize(is);
+    const uint64_t nSize = ReadCompactSize(is);
     typename std::map<K, T, Pred, A>::iterator mi = m.begin();
-    for (unsigned int i = 0; i < nSize; i++)
+    for (uint64_t i = 0; i < nSize; i++)
     {
         std::pair<K, T> item;
         Unserialize(is, item);
@@ -867,9 +868,9 @@ template<typename Stream, typename K, typename Pred, typename A>
 void Unserialize(Stream& is, std::set<K, Pred, A>& m)
 {
     m.clear();
-    unsigned int nSize = ReadCompactSize(is);
+    const uint64_t nSize = ReadCompactSize(is);
     typename std::set<K, Pred, A>::iterator it = m.begin();
-    for (unsigned int i = 0; i < nSize; i++)
+    for (uint64_t i = 0; i < nSize; i++)
     {
         K key;
         Unserialize(is, key);
@@ -894,9 +895,9 @@ template<typename Stream, typename T, typename A>
 void Unserialize(Stream& is, std::list<T, A>& l)
 {
     l.clear();
-    unsigned int nSize = ReadCompactSize(is);
+    const uint64_t nSize = ReadCompactSize(is);
     typename std::list<T, A>::iterator it = l.begin();
-    for (unsigned int i = 0; i < nSize; i++)
+    for (uint64_t i = 0; i < nSize; i++)
     {
         T item;
         Unserialize(is, item);

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2013 The Bitcoin Core developers
+// Copyright (c) 2009-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -13,22 +13,22 @@
 
 template <typename T>
 struct zero_after_free_allocator : public std::allocator<T> {
-    // MSVC8 default copy constructor is broken
-    typedef std::allocator<T> base;
-    typedef typename base::size_type size_type;
-    typedef typename base::difference_type difference_type;
-    typedef typename base::pointer pointer;
-    typedef typename base::const_pointer const_pointer;
-    typedef typename base::reference reference;
-    typedef typename base::const_reference const_reference;
-    typedef typename base::value_type value_type;
-    zero_after_free_allocator() throw() {}
-    zero_after_free_allocator(const zero_after_free_allocator& a) throw() : base(a) {}
+    using allocator_type = std::allocator<T>;
+    using value_type = T;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using difference_type = std::ptrdiff_t;
+    using size_type = std::size_t;
+    using pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+
+    zero_after_free_allocator() noexcept {}
+    zero_after_free_allocator(const zero_after_free_allocator& a) noexcept : allocator_type(a) {}
     template <typename U>
-    zero_after_free_allocator(const zero_after_free_allocator<U>& a) throw() : base(a)
+    zero_after_free_allocator(const zero_after_free_allocator<U>& a) noexcept : allocator_type(a)
     {
     }
-    ~zero_after_free_allocator() throw() {}
+    ~zero_after_free_allocator() noexcept {}
     template <typename _Other>
     struct rebind {
         typedef zero_after_free_allocator<_Other> other;
@@ -36,7 +36,7 @@ struct zero_after_free_allocator : public std::allocator<T> {
 
     void deallocate(T* p, std::size_t n)
     {
-        if (p != NULL)
+        if (p)
             memory_cleanse(p, sizeof(T) * n);
         std::allocator<T>::deallocate(p, n);
     }

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -22,7 +22,7 @@ BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup)
 /*
 BOOST_AUTO_TEST_CASE(sanity)
 {
-    const CCheckpointData& checkpoints = Params(CBaseChainParams::MAIN).Checkpoints();
+    const CCheckpointData& checkpoints = Params(CBaseChainParams::Network::MAIN).Checkpoints();
     BOOST_CHECK(Checkpoints::GetTotalBlocksEstimate(checkpoints) >= 134444);
 }
 */

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -283,7 +283,7 @@ BOOST_FIXTURE_TEST_SUITE(Alert_tests, ReadAlerts)
 BOOST_AUTO_TEST_CASE(AlertApplies)
 {
     SetMockTime(11);
-    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
+    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::Network::MAIN).AlertKey();
 
     BOOST_FOREACH(const CAlert& alert, alerts)
     {
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(AlertApplies)
 BOOST_AUTO_TEST_CASE(AlertNotify)
 {
     SetMockTime(11);
-    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
+    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::Network::MAIN).AlertKey();
 
     boost::filesystem::path temp = GetTempPath() /
         boost::filesystem::unique_path("alertnotify-%%%%.txt");
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE(AlertNotify)
 BOOST_AUTO_TEST_CASE(AlertDisablesRPC)
 {
     SetMockTime(11);
-    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::MAIN).AlertKey();
+    const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::Network::MAIN).AlertKey();
 
     // Command should work before alerts
     BOOST_CHECK_EQUAL(GetWarnings("rpc"), "");
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(PartitionAlert)
     // Test PartitionCheck
     CCriticalSection csDummy;
     CBlockIndex indexDummy[400];
-    CChainParams& params = Params(CBaseChainParams::MAIN);
+    CChainParams& params = Params(CBaseChainParams::Network::MAIN);
     int64_t nPowTargetSpacing = params.GetConsensus().nPowTargetSpacing;
 
     // Generate fake blockchain timestamps relative to

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -87,7 +87,8 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 BOOST_AUTO_TEST_CASE(bloom_create_insert_key)
 {
     std::string strSecret = std::string("5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C");
-    CKey key = DecodeSecret(strSecret);
+    std::string sKeyError;
+    const CKey key = DecodeSecret(strSecret, sKeyError);
     CPubKey pubkey = key.GetPubKey();
     vector<unsigned char> vchPubKey(pubkey.begin(), pubkey.end());
 

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -68,15 +68,16 @@ BOOST_AUTO_TEST_CASE(key_test1)
 #ifdef KEY_TESTS_DUMPINFO
     dumpKeyInfo(); return;
 #endif
-    CKey key1  = DecodeSecret(strSecret1);
+    std::string sKeyError;
+    const CKey key1  = DecodeSecret(strSecret1, sKeyError);
     BOOST_CHECK(key1.IsValid() && !key1.IsCompressed());
-    CKey key2  = DecodeSecret(strSecret2);
+    const CKey key2  = DecodeSecret(strSecret2, sKeyError);
     BOOST_CHECK(key2.IsValid() && !key2.IsCompressed());
-    CKey key1C = DecodeSecret(strSecret1C);
+    const CKey key1C = DecodeSecret(strSecret1C, sKeyError);
     BOOST_CHECK(key1C.IsValid() && key1C.IsCompressed());
-    CKey key2C = DecodeSecret(strSecret2C);
+    const CKey key2C = DecodeSecret(strSecret2C, sKeyError);
     BOOST_CHECK(key2C.IsValid() && key2C.IsCompressed());
-    CKey bad_key = DecodeSecret(strAddressBad);
+    const CKey bad_key = DecodeSecret(strAddressBad, sKeyError);
     BOOST_CHECK(!bad_key.IsValid());
 
     CPubKey pubkey1  = key1. GetPubKey();
@@ -225,7 +226,7 @@ BOOST_AUTO_TEST_CASE(zc_address_test)
 
 BOOST_AUTO_TEST_CASE(zs_address_test)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
 
     std::vector<unsigned char, secure_allocator<unsigned char>> rawSeed(32);
     HDSeed seed(rawSeed);
@@ -235,7 +236,7 @@ BOOST_AUTO_TEST_CASE(zs_address_test)
         auto sk = m.Derive(i);
         {
             std::string sk_string = EncodeSpendingKey(sk);
-            BOOST_CHECK(sk_string.compare(0, 29, Params().Bech32HRP(CChainParams::SAPLING_EXTENDED_SPEND_KEY)) == 0);
+            BOOST_CHECK(sk_string.compare(0, 29, Params().Bech32HRP(CChainParams::Bech32Type::SAPLING_EXTENDED_SPEND_KEY)) == 0);
 
             auto spendingkey2 = DecodeSpendingKey(sk_string);
             BOOST_CHECK(IsValidSpendingKey(spendingkey2));
@@ -248,7 +249,7 @@ BOOST_AUTO_TEST_CASE(zs_address_test)
             auto addr = sk.DefaultAddress();
 
             std::string addr_string = EncodePaymentAddress(addr);
-            BOOST_CHECK(addr_string.compare(0, 16, Params().Bech32HRP(CChainParams::SAPLING_PAYMENT_ADDRESS)) == 0);
+            BOOST_CHECK(addr_string.compare(0, 16, Params().Bech32HRP(CChainParams::Bech32Type::SAPLING_PAYMENT_ADDRESS)) == 0);
 
             auto paymentaddr2 = DecodePaymentAddress(addr_string);
             BOOST_CHECK(IsValidPaymentAddress(paymentaddr2));

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -40,14 +40,14 @@ static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 
 BOOST_AUTO_TEST_CASE(block_subsidy_test)
 {
-    TestBlockSubsidyHalvings(Params(CBaseChainParams::MAIN).GetConsensus()); // As in main
+    TestBlockSubsidyHalvings(Params(CBaseChainParams::Network::MAIN).GetConsensus()); // As in main
     TestBlockSubsidyHalvings(500000);
     TestBlockSubsidyHalvings(100000);
 }
 
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
-    const Consensus::Params& consensusParams = Params(CBaseChainParams::MAIN).GetConsensus();
+    const Consensus::Params& consensusParams = Params(CBaseChainParams::Network::MAIN).GetConsensus();
     CAmount nSum = 0;
     //1002 is the first block with real subsidy
     for (int nHeight = 1002, i=1; nHeight < 56000000; nHeight += consensusParams.nSubsidyHalvingInterval, i++) {

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -16,7 +16,7 @@ BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 /* Test calculation of next difficulty target with no constraints applying */
 BOOST_AUTO_TEST_CASE(get_next_work)
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
     const Consensus::Params& params = Params().GetConsensus();
 
     int64_t nLastRetargetTime = 1262149169; // NOTE: Not an actual block time
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
 /* Test the constraint on the upper bound for next work */
 BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
     const Consensus::Params& params = Params().GetConsensus();
 
     int64_t nLastRetargetTime = 1231006505; // Block #0 of Bitcoin
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 /* Test the constraint on the lower bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
     const Consensus::Params& params = Params().GetConsensus();
 
     int64_t nLastRetargetTime = 1279296753; // NOTE: Not an actual block time
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 /* Test the constraint on the upper bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
     const Consensus::Params& params = Params().GetConsensus();
 
     int64_t nLastRetargetTime = 1269205629; // NOTE: Not an actual block time
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 
 BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
     const Consensus::Params& params = Params().GetConsensus();
 
     std::vector<CBlockIndex> blocks(10000);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
 
 BOOST_AUTO_TEST_CASE(rpc_raw_create_overwinter_v3)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     // Sample regtest address:

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_getbalance)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_getbalance)
  */
 BOOST_AUTO_TEST_CASE(rpc_wallet_z_validateaddress)
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
@@ -898,7 +898,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_getoperations)
 
 BOOST_AUTO_TEST_CASE(rpc_z_sendmany_parameters)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -1011,7 +1011,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_parameters)
 // TODO: test private methods
 BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -1247,7 +1247,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
 
 BOOST_AUTO_TEST_CASE(rpc_z_sendmany_taddr_to_sapling)
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
@@ -1470,7 +1470,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_encrypted_wallet_sapzkeys)
 
 BOOST_AUTO_TEST_CASE(rpc_z_listunspent_parameters)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -1519,7 +1519,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_listunspent_parameters)
 
 BOOST_AUTO_TEST_CASE(rpc_z_shieldcoinbase_parameters)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -1598,7 +1598,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_shieldcoinbase_parameters)
 
 BOOST_AUTO_TEST_CASE(rpc_z_shieldcoinbase_internals)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -1668,7 +1668,7 @@ void CheckRPCThrows(std::string rpcString, std::string expectedErrorMessage) {
 
 BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 
@@ -1826,7 +1826,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
 // TODO: test private methods
 BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
 {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     LOCK(pwalletMain->cs_wallet);
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -83,7 +83,7 @@ BasicTestingSetup::BasicTestingSetup()
     SetupNetworking();
     fPrintToDebugLog = false; // don't want to write to debug.log file
     fCheckBlockIndex = true;
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 }
 BasicTestingSetup::~BasicTestingSetup()
 {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE(test_simple_joinsplit_invalidity_driver) {
     }
     {
         // Switch to regtest parameters so we can activate Overwinter
-        SelectParams(CBaseChainParams::REGTEST);
+        SelectParams(CBaseChainParams::Network::REGTEST);
 
         CMutableTransaction mtx;
         mtx.fOverwintered = true;
@@ -621,7 +621,7 @@ BOOST_AUTO_TEST_CASE(test_simple_joinsplit_invalidity_driver) {
         UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 
         // Switch back to mainnet parameters as originally selected in test fixture
-        SelectParams(CBaseChainParams::MAIN);
+        SelectParams(CBaseChainParams::Network::MAIN);
     }
 }
 

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -146,6 +146,9 @@ namespace tfm = tinyformat;
 #   ifdef __GXX_EXPERIMENTAL_CXX0X__
 #       define TINYFORMAT_USE_VARIADIC_TEMPLATES
 #   endif
+#   if defined(_MSC_VER) && _MSC_VER >= 1700
+#       define TINYFORMAT_USE_VARIADIC_TEMPLATES
+#   endif
 #endif
 
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -243,7 +243,7 @@ TransactionBuilderResult TransactionBuilder::Build()
                 output.note.r.begin(),
                 output.note.value(),
                 odesc.cv.begin(),
-                odesc.zkproof.begin())) {
+                odesc.zkproof.data())) {
             librustzcash_sapling_proving_ctx_free(ctx);
             return TransactionBuilderResult("Output proof failed");
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -15,6 +15,7 @@
 #include "sync.h"
 #include "utilstrencodings.h"
 #include "utiltime.h"
+#include "clientversion.h"
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -167,7 +167,7 @@ TEST(WalletTests, SproutNoteDataSerialisation) {
 
 
 TEST(WalletTests, FindUnspentSproutNotes) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
     CWallet wallet;
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSproutSpendingKey(sk);
@@ -356,7 +356,7 @@ TEST(WalletTests, SetSproutNoteAddrsInCWalletTx) {
 }
 
 TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -476,7 +476,7 @@ TEST(WalletTests, GetSproutNoteNullifier) {
 }
 
 TEST(WalletTests, FindMySaplingNotes) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -610,7 +610,7 @@ TEST(WalletTests, GetConflictedSproutNotes) {
 
 // Generate note A and spend to create note B, from which we spend to create two conflicting transactions
 TEST(WalletTests, GetConflictedSaplingNotes) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -773,7 +773,7 @@ TEST(WalletTests, SproutNullifierIsSpent) {
 }
 
 TEST(WalletTests, SaplingNullifierIsSpent) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -868,7 +868,7 @@ TEST(WalletTests, NavigateFromSproutNullifierToNote) {
 }
 
 TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -1001,7 +1001,7 @@ TEST(WalletTests, SpentSproutNoteIsFromMe) {
 
 // Create note A, spend A to create note B, spend and verify note B is from me.
 TEST(WalletTests, SpentSaplingNoteIsFromMe) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -1618,14 +1618,15 @@ TEST(WalletTests, WriteWitnessCache) {
 }
 
 TEST(WalletTests, SetBestChainIgnoresTxsWithoutShieldedData) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
 
+    std::string sKeyError;
     TestWallet wallet;
     MockWalletDB walletdb;
     CBlockLocator loc;
 
     // Set up transparent address
-    CKey tsk = DecodeSecret(tSecretRegtest);
+    const CKey tsk = DecodeSecret(tSecretRegtest, sKeyError);
     wallet.AddKey(tsk);
     auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
 
@@ -1782,7 +1783,7 @@ TEST(WalletTests, UpdatedSproutNoteData) {
 }
 
 TEST(WalletTests, UpdatedSaplingNoteData) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
@@ -1935,12 +1936,13 @@ TEST(WalletTests, MarkAffectedSproutTransactionsDirty) {
 }
 
 TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::Network::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
+    std::string sKeyError;
 
     // Generate Sapling address
     std::vector<unsigned char, secure_allocator<unsigned char>> rawSeed(32);
@@ -1956,7 +1958,7 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
 
     // Set up transparent address
     CBasicKeyStore keystore;
-    CKey tsk = DecodeSecret(tSecretRegtest);
+    const CKey tsk = DecodeSecret(tSecretRegtest, sKeyError);
     keystore.AddKey(tsk);
     auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
 

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -17,7 +17,7 @@
  * LoadSaplingZKeyMetadata()
  */
 TEST(wallet_zkeys_tests, StoreAndLoadSaplingZkeys) {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     CWallet wallet;
 
@@ -111,7 +111,7 @@ TEST(wallet_zkeys_tests, StoreAndLoadSaplingZkeys) {
  * LoadZKeyMetadata()
  */
 TEST(wallet_zkeys_tests, store_and_load_zkeys) {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     CWallet wallet;
 
@@ -168,7 +168,7 @@ TEST(wallet_zkeys_tests, store_and_load_zkeys) {
  * LoadSproutViewingKey()
  */
 TEST(wallet_zkeys_tests, StoreAndLoadViewingKeys) {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
 
     CWallet wallet;
 
@@ -213,7 +213,7 @@ TEST(wallet_zkeys_tests, StoreAndLoadViewingKeys) {
  * WriteZKey()
  */
 TEST(wallet_zkeys_tests, write_zkey_direct_to_db) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths
@@ -285,7 +285,7 @@ TEST(wallet_zkeys_tests, write_zkey_direct_to_db) {
  * WriteSproutViewingKey()
  */
 TEST(wallet_zkeys_tests, WriteViewingKeyDirectToDB) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths
@@ -330,7 +330,7 @@ TEST(wallet_zkeys_tests, WriteViewingKeyDirectToDB) {
  * This test covers methods on CWalletDB to load/save crypted z keys.
  */
 TEST(wallet_zkeys_tests, write_cryptedzkey_direct_to_db) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths
@@ -404,7 +404,7 @@ TEST(wallet_zkeys_tests, write_cryptedzkey_direct_to_db) {
  * This test covers methods on CWalletDB to load/save crypted sapling z keys.
  */
 TEST(wallet_zkeys_tests, WriteCryptedSaplingZkeyDirectToDb) {
-    SelectParams(CBaseChainParams::TESTNET);
+    SelectParams(CBaseChainParams::Network::TESTNET);
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -24,6 +24,7 @@
 #include "zcash/zip32.h"
 
 #include <assert.h>
+#include <random>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>
@@ -2962,7 +2963,9 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int
     vector<pair<CAmount, pair<const CWalletTx*,unsigned int> > > vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(vCoins.begin(), vCoins.end(), g);
 
     BOOST_FOREACH(const COutput &output, vCoins)
     {

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -297,7 +297,7 @@ public:
             std::vector<unsigned char> auth2(ss2.begin(), ss2.end());
 
             librustzcash_sprout_prove(
-                proof.begin(),
+                proof.data(),
 
                 phi.begin(),
                 rt.begin(),

--- a/src/zcash/NoteEncryption.cpp
+++ b/src/zcash/NoteEncryption.cpp
@@ -109,7 +109,7 @@ boost::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(di
     librustzcash_sapling_generate_r(esk.begin());
 
     // Compute epk given the diversifier
-    if (!librustzcash_sapling_ka_derivepublic(d.begin(), esk.begin(), epk.begin())) {
+    if (!librustzcash_sapling_ka_derivepublic(d.data(), esk.begin(), epk.begin())) {
         return boost::none;
     }
 
@@ -141,10 +141,10 @@ boost::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipien
     SaplingEncCiphertext ciphertext;
 
     crypto_aead_chacha20poly1305_ietf_encrypt(
-        ciphertext.begin(), NULL,
-        message.begin(), ZC_SAPLING_ENCPLAINTEXT_SIZE,
-        NULL, 0, // no "additional data"
-        NULL, cipher_nonce, K
+        ciphertext.data(), nullptr,
+        message.data(), ZC_SAPLING_ENCPLAINTEXT_SIZE,
+        nullptr, 0, // no "additional data"
+        nullptr, cipher_nonce, K
     );
 
     already_encrypted_enc = true;
@@ -174,10 +174,10 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     SaplingEncPlaintext plaintext;
 
     if (crypto_aead_chacha20poly1305_ietf_decrypt(
-        plaintext.begin(), NULL,
-        NULL,
-        ciphertext.begin(), ZC_SAPLING_ENCCIPHERTEXT_SIZE,
-        NULL,
+        plaintext.data(), nullptr,
+        nullptr,
+        ciphertext.data(), ZC_SAPLING_ENCCIPHERTEXT_SIZE,
+        nullptr,
         0,
         cipher_nonce, K) != 0)
     {
@@ -210,10 +210,10 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     SaplingEncPlaintext plaintext;
 
     if (crypto_aead_chacha20poly1305_ietf_decrypt(
-        plaintext.begin(), NULL,
-        NULL,
-        ciphertext.begin(), ZC_SAPLING_ENCCIPHERTEXT_SIZE,
-        NULL,
+        plaintext.data(), nullptr,
+        nullptr,
+        ciphertext.data(), ZC_SAPLING_ENCCIPHERTEXT_SIZE,
+        nullptr,
         0,
         cipher_nonce, K) != 0)
     {
@@ -245,10 +245,10 @@ SaplingOutCiphertext SaplingNoteEncryption::encrypt_to_ourselves(
     SaplingOutCiphertext ciphertext;
 
     crypto_aead_chacha20poly1305_ietf_encrypt(
-        ciphertext.begin(), NULL,
-        message.begin(), ZC_SAPLING_OUTPLAINTEXT_SIZE,
-        NULL, 0, // no "additional data"
-        NULL, cipher_nonce, K
+        ciphertext.data(), nullptr,
+        message.data(), ZC_SAPLING_OUTPLAINTEXT_SIZE,
+        nullptr, 0, // no "additional data"
+        nullptr, cipher_nonce, K
     );
 
     already_encrypted_out = true;
@@ -274,9 +274,9 @@ boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
     SaplingOutPlaintext plaintext;
 
     if (crypto_aead_chacha20poly1305_ietf_decrypt(
-        plaintext.begin(), NULL,
-        NULL,
-        ciphertext.begin(), ZC_SAPLING_OUTCIPHERTEXT_SIZE,
+        plaintext.data(), nullptr,
+        nullptr,
+        ciphertext.data(), ZC_SAPLING_OUTCIPHERTEXT_SIZE,
         NULL,
         0,
         cipher_nonce, K) != 0)
@@ -330,10 +330,10 @@ typename NoteEncryption<MLEN>::Ciphertext NoteEncryption<MLEN>::encrypt
 
     NoteEncryption<MLEN>::Ciphertext ciphertext;
 
-    crypto_aead_chacha20poly1305_ietf_encrypt(ciphertext.begin(), NULL,
-                                         message.begin(), MLEN,
-                                         NULL, 0, // no "additional data"
-                                         NULL, cipher_nonce, K);
+    crypto_aead_chacha20poly1305_ietf_encrypt(ciphertext.data(), nullptr,
+                                         message.data(), MLEN,
+                                         nullptr, 0, // no "additional data"
+                                         nullptr, cipher_nonce, K);
 
     return ciphertext;
 }
@@ -362,10 +362,10 @@ typename NoteDecryption<MLEN>::Plaintext NoteDecryption<MLEN>::decrypt
 
     // Message length is always NOTEENCRYPTION_AUTH_BYTES less than
     // the ciphertext length.
-    if (crypto_aead_chacha20poly1305_ietf_decrypt(plaintext.begin(), NULL,
-                                             NULL,
-                                             ciphertext.begin(), NoteDecryption<MLEN>::CLEN,
-                                             NULL,
+    if (crypto_aead_chacha20poly1305_ietf_decrypt(plaintext.data(), nullptr,
+                                             nullptr,
+                                             ciphertext.data(), NoteDecryption<MLEN>::CLEN,
+                                             nullptr,
                                              0,
                                              cipher_nonce, K) != 0) {
         throw note_decryption_failed();
@@ -405,10 +405,10 @@ typename PaymentDisclosureNoteDecryption<MLEN>::Plaintext PaymentDisclosureNoteD
 
     // Message length is always NOTEENCRYPTION_AUTH_BYTES less than
     // the ciphertext length.
-    if (crypto_aead_chacha20poly1305_ietf_decrypt(plaintext.begin(), NULL,
-                                             NULL,
-                                             ciphertext.begin(), PaymentDisclosureNoteDecryption<MLEN>::CLEN,
-                                             NULL,
+    if (crypto_aead_chacha20poly1305_ietf_decrypt(plaintext.data(), nullptr,
+                                             nullptr,
+                                             ciphertext.data(), PaymentDisclosureNoteDecryption<MLEN>::CLEN,
+                                             nullptr,
                                              0,
                                              cipher_nonce, K) != 0) {
         throw note_decryption_failed();

--- a/src/zcash/Proof.cpp
+++ b/src/zcash/Proof.cpp
@@ -1,7 +1,7 @@
 #include "Proof.hpp"
 
 #include "crypto/common.h"
-
+#include <unistd.h>
 #include <boost/static_assert.hpp>
 #include <libsnark/common/default_types/r1cs_ppzksnark_pp.hpp>
 #include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -172,8 +172,8 @@ double benchmark_solve_equihash()
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss << I;
 
-    unsigned int n = Params(CBaseChainParams::MAIN).EquihashN();
-    unsigned int k = Params(CBaseChainParams::MAIN).EquihashK();
+    unsigned int n = Params(CBaseChainParams::Network::MAIN).EquihashN();
+    unsigned int k = Params(CBaseChainParams::Network::MAIN).EquihashK();
     crypto_generichash_blake2b_state eh_state;
     EhInitialiseState(n, k, eh_state);
     crypto_generichash_blake2b_update(&eh_state, (unsigned char*)&ss[0], ss.size());
@@ -216,8 +216,8 @@ std::vector<double> benchmark_solve_equihash_threaded(int nThreads)
 
 double benchmark_verify_equihash()
 {
-    CChainParams params = Params(CBaseChainParams::MAIN);
-    CBlock genesis = Params(CBaseChainParams::MAIN).GenesisBlock();
+    CChainParams params = Params(CBaseChainParams::Network::MAIN);
+    CBlock genesis = Params(CBaseChainParams::Network::MAIN).GenesisBlock();
     CBlockHeader genesis_header = genesis.GetBlockHeader();
     struct timeval tv_start;
     timer_start(tv_start);
@@ -399,7 +399,7 @@ public:
 double benchmark_connectblock_slow()
 {
     // Test for issue 2017-05-01.a
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(CBaseChainParams::Network::MAIN);
     CBlock block;
     FILE* fp = fopen((GetDataDir() / "benchmark/block-107134.dat").string().c_str(), "rb");
     if (!fp) throw new std::runtime_error("Failed to open block data file");
@@ -557,7 +557,7 @@ double benchmark_create_sapling_output()
         note.r.begin(),
         note.value(),
         odesc.cv.begin(),
-        odesc.zkproof.begin());
+        odesc.zkproof.data());
 
     double t = timer_stop(tv_start);
     librustzcash_sapling_proving_ctx_free(ctx);
@@ -588,8 +588,8 @@ double benchmark_verify_sapling_spend()
                 spend.anchor.begin(),
                 spend.nullifier.begin(),
                 spend.rk.begin(),
-                spend.zkproof.begin(),
-                spend.spendAuthSig.begin(),
+                spend.zkproof.data(),
+                spend.spendAuthSig.data(),
                 dataToBeSigned.begin()
             );
 
@@ -620,7 +620,7 @@ double benchmark_verify_sapling_output()
                 output.cv.begin(),
                 output.cm.begin(),
                 output.ephemeralKey.begin(),
-                output.zkproof.begin()
+                output.zkproof.data()
             );
 
     double t = timer_stop(tv_start);

--- a/src/zcbenchmarks.h
+++ b/src/zcbenchmarks.h
@@ -1,7 +1,9 @@
 #ifndef BENCHMARKS_H
 #define BENCHMARKS_H
 
+#ifndef _MSC_VER
 #include <sys/time.h>
+#endif
 #include <stdlib.h>
 
 extern double benchmark_sleep();


### PR DESCRIPTION
	-added extended error diagnostic for private key decoding (DecodeSecret: used in ani2psl_secret)
	-validate CKey objects after decoding private key string (base58 encoded)
	-show extended error messages for ./pastel-cli ingest ani2psl_secret key
	-replaced all calls to DecodeSecret function to support extended error diagnostic
	-corrected some C++ code to compile on Visual Studio 2019

Pastel Core build improvements:
   -changed required gcc C++ standard from c++11 to c++17 (configure.ac)
   -updated autoconf m4 macros for boost libs,gcc compiler features

pastel-gtest (Google Tests for Pastel Core):
	-added new test_mnode_rpc.cpp - tests for mnode-rpc.cpp, ani2psl_secret parameterized test
	-fixed existing test_block.cpp, added to Makefile.gtest.include
	-implemented command-line options parsing using boost program-options library: (--help,--filter)
	-added support for --filter=xxx option to use Google Test filtering feature (include/exclude tests to run by filter);
    this can be used to debug specific tests much faster