### PR TITLE
38417834: add new parameter "mine" to "listaddressamounts", to return only spendable addresses

### DIFF
--- a/build-aux/vs2019/libbitcoin_common/libbitcoin_common.props
+++ b/build-aux/vs2019/libbitcoin_common/libbitcoin_common.props
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="../settings/common.props" />
+    <Import Project="../settings/pastel_common.props" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/build-aux/vs2019/libbitcoin_server/libbitcoin_server.props
+++ b/build-aux/vs2019/libbitcoin_server/libbitcoin_server.props
@@ -2,11 +2,12 @@
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="../settings/common.props" />
+    <Import Project="../settings/pastel_common.props" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SRC)secp256k1\include;$(SRC)univalue\include;$(SRC)leveldb\include;$(SRC)leveldb\helpers\memenv;$(SRC)snark;$(SRC)snark\libsnark;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CONSOLE;ENABLE_WALLET;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <SDLCheck>false</SDLCheck>
       <ConformanceMode>true</ConformanceMode>

--- a/build-aux/vs2019/libbitcoin_util/libbitcoin_util.props
+++ b/build-aux/vs2019/libbitcoin_util/libbitcoin_util.props
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="../settings/common.props" />
+    <Import Project="../settings/pastel_common.props" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/build-aux/vs2019/libbitcoin_wallet/libbitcoin_wallet.props
+++ b/build-aux/vs2019/libbitcoin_wallet/libbitcoin_wallet.props
@@ -2,11 +2,12 @@
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="../settings/common.props" />
+    <Import Project="../settings/pastel_common.props" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SRC)secp256k1\include;$(SRC)univalue\include;$(SRC)leveldb\include;$(SRC)leveldb\helpers\memenv;$(SRC)snark;$(SRC)snark\libsnark;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CONSOLE;ENABLE_WALLET;SODIUM_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;SODIUM_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <SDLCheck>false</SDLCheck>
       <ConformanceMode>true</ConformanceMode>

--- a/build-aux/vs2019/pastel-cli/pastel-cli.props
+++ b/build-aux/vs2019/pastel-cli/pastel-cli.props
@@ -2,6 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="../settings/common.props" />
+    <Import Project="../settings/pastel_common.props" />
     <Import Project="../settings/boost.props" />
   </ImportGroup>
   <ItemDefinitionGroup>

--- a/build-aux/vs2019/pasteld/pasteld.props
+++ b/build-aux/vs2019/pasteld/pasteld.props
@@ -2,12 +2,13 @@
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="../settings/common.props" />
+    <Import Project="../settings/pastel_common.props" />
     <Import Project="../settings/boost.props" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SRC)univalue\include;$(SRC)leveldb\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__GMP_LIBGMP_DLL;ENABLE_WALLET;ENABLE_ZMQ;ZMQ_STATIC;BINARY_OUTPUT;BOOST_SPIRIT_THREADSAFE;MONTGOMERY_OUTPUT;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__GMP_LIBGMP_DLL;ENABLE_ZMQ;ZMQ_STATIC;BINARY_OUTPUT;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/build-aux/vs2019/settings/common.props
+++ b/build-aux/vs2019/settings/common.props
@@ -31,6 +31,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <StringPooling>true</StringPooling>
+      <LanguageStandard>stdcpp17</LanguageStandard>
   </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>

--- a/build-aux/vs2019/settings/pastel_common.props
+++ b/build-aux/vs2019/settings/pastel_common.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>ENABLE_WALLET;BOOST_SPIRIT_THREADSAFE;MONTGOMERY_OUTPUT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -10,7 +10,7 @@
 #include "policy/fees.h"
 
 #include <assert.h>
-
+#include <unordered_map>
 /**
  * calculate number of bytes for the bitmask, and its number of non-zero bytes
  * each bit in the bitmask represents the availability of one output, but the
@@ -564,7 +564,7 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
 
 bool CCoinsViewCache::HaveShieldedRequirements(const CTransaction& tx) const
 {
-    boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
+    std::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
 
     BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit)
     {

--- a/src/coins.h
+++ b/src/coins.h
@@ -1,22 +1,17 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_COINS_H
-#define BITCOIN_COINS_H
-
 #include "compressor.h"
 #include "core_memusage.h"
 #include "memusage.h"
 #include "serialize.h"
 #include "uint256.h"
-
 #include <assert.h>
 #include <stdint.h>
-
+#include <unordered_map>
 #include <boost/foreach.hpp>
-#include <boost/unordered_map.hpp>
 #include "zcash/IncrementalMerkleTree.hpp"
 
 /** 
@@ -317,10 +312,10 @@ enum ShieldedType
     SAPLING,
 };
 
-typedef boost::unordered_map<uint256, CCoinsCacheEntry, CCoinsKeyHasher> CCoinsMap;
-typedef boost::unordered_map<uint256, CAnchorsSproutCacheEntry, CCoinsKeyHasher> CAnchorsSproutMap;
-typedef boost::unordered_map<uint256, CAnchorsSaplingCacheEntry, CCoinsKeyHasher> CAnchorsSaplingMap;
-typedef boost::unordered_map<uint256, CNullifiersCacheEntry, CCoinsKeyHasher> CNullifiersMap;
+typedef std::unordered_map<uint256, CCoinsCacheEntry, CCoinsKeyHasher> CCoinsMap;
+typedef std::unordered_map<uint256, CAnchorsSproutCacheEntry, CCoinsKeyHasher> CAnchorsSproutMap;
+typedef std::unordered_map<uint256, CAnchorsSaplingCacheEntry, CCoinsKeyHasher> CAnchorsSaplingMap;
+typedef std::unordered_map<uint256, CNullifiersCacheEntry, CCoinsKeyHasher> CNullifiersMap;
 
 struct CCoinsStats
 {
@@ -584,4 +579,3 @@ private:
     );
 };
 
-#endif // BITCOIN_COINS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -680,8 +680,10 @@ bool InitSanityCheck(void)
         InitError("Elliptic curve cryptography sanity check failure. Aborting.");
         return false;
     }
+#ifdef __GLIBC__
     if (!glibc_sanity_test() || !glibcxx_sanity_test())
         return false;
+#endif
 
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <atomic>
 #include <sstream>
+#include <unistd.h>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>

--- a/src/main.h
+++ b/src/main.h
@@ -1,10 +1,8 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_MAIN_H
-#define BITCOIN_MAIN_H
 
 #if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
@@ -30,13 +28,12 @@
 #include <algorithm>
 #include <exception>
 #include <map>
+#include <unordered_map>
 #include <set>
 #include <stdint.h>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <boost/unordered_map.hpp>
 
 class CBlockIndex;
 class CBlockTreeDB;
@@ -119,7 +116,7 @@ extern unsigned int expiryDelta;
 extern CScript COINBASE_FLAGS;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;
-typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;
@@ -598,5 +595,3 @@ CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Para
  */
 //<-INGEST!!!
 
-
-#endif // BITCOIN_MAIN_H

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -1,19 +1,15 @@
+#pragma once
 // Copyright (c) 2015 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_MEMUSAGE_H
-#define BITCOIN_MEMUSAGE_H
-
 #include <stdlib.h>
-
 #include <map>
 #include <set>
 #include <vector>
-
+#include <unordered_set>
+#include <unordered_map>
 #include <boost/foreach.hpp>
-#include <boost/unordered_set.hpp>
-#include <boost/unordered_map.hpp>
 
 namespace memusage
 {
@@ -104,17 +100,16 @@ private:
 };
 
 template<typename X, typename Y>
-static inline size_t DynamicUsage(const boost::unordered_set<X, Y>& s)
+static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
 {
     return MallocUsage(sizeof(boost_unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
 }
 
 template<typename X, typename Y, typename Z>
-static inline size_t DynamicUsage(const boost::unordered_map<X, Y, Z>& m)
+static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(boost_unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }
 
 }
 
-#endif

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -439,6 +439,20 @@ bool enableVTMode()
 }
 #endif
 
+void SendVTSequence(const char *szVTcmd)
+{
+    if (!szVTcmd)
+        return;
+    std::string s;
+#ifdef WIN32
+    s = "\x1b[";
+#else
+    s = "\e[";
+#endif
+    s += szVTcmd;
+    std::cout << s;
+}
+
 void ThreadShowMetricsScreen()
 {
     // Make this thread recognisable as the metrics screen thread
@@ -455,7 +469,7 @@ void ThreadShowMetricsScreen()
 #endif
 
         // Clear screen
-        std::cout << "\e[2J";
+        SendVTSequence("2J");
 
         // Print art
         // std::cout << METRICS_ART << std::endl;
@@ -491,10 +505,9 @@ void ThreadShowMetricsScreen()
 #endif
         }
 
-        if (isScreen) {
-            // Erase below current position
-            std::cout << "\e[J";
-        }
+        // Erase below current position
+        if (isScreen)
+            SendVTSequence("J");
 
         // Miner status
 #ifdef ENABLE_MINING
@@ -531,9 +544,8 @@ void ThreadShowMetricsScreen()
             MilliSleep(200);
         }
 
-        if (isScreen) {
-            // Return to the top of the updating section
-            std::cout << "\e[" << lines << "A";
-        }
+        // Return to the top of the updating section
+        if (isScreen)
+            SendVTSequence(tfm::format("%dA", lines).c_str());
     }
 }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -44,6 +44,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listreceivedbyaccount", 0 },
     { "listreceivedbyaccount", 1 },
     { "listreceivedbyaccount", 2 },
+    { "listaddressamounts", 0 },
     { "getbalance", 1 },
     { "getbalance", 2 },
     { "getblockhash", 0 },

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -10,9 +10,8 @@
 #include "random.h"
 #include "uint256.h"
 #include "util.h"
-
+#include <unordered_set>
 #include <boost/thread.hpp>
-#include <boost/unordered_set.hpp>
 
 namespace {
 
@@ -38,7 +37,7 @@ class CSignatureCache
 private:
      //! Entries are SHA256(nonce || signature hash || public key || signature):
     uint256 nonce;
-    typedef boost::unordered_set<uint256, CSignatureCacheHasher> map_type;
+    typedef std::unordered_set<uint256, CSignatureCacheHasher> map_type;
     map_type setValid;
     boost::shared_mutex cs_sigcache;
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1,10 +1,8 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_SERIALIZE_H
-#define BITCOIN_SERIALIZE_H
 
 #include "compat.h"
 #include "compat/endian.h"
@@ -255,17 +253,17 @@ void WriteCompactSize(Stream& os, uint64_t nSize)
 {
     if (nSize < 253)
     {
-        ser_writedata8(os, nSize);
+        ser_writedata8(os, static_cast<uint8_t>(nSize));
     }
     else if (nSize <= 0xFFFFu)
     {
         ser_writedata8(os, 253);
-        ser_writedata16(os, nSize);
+        ser_writedata16(os, static_cast<uint16_t>(nSize));
     }
     else if (nSize <= 0xFFFFFFFFu)
     {
         ser_writedata8(os, 254);
-        ser_writedata32(os, nSize);
+        ser_writedata32(os, static_cast<uint32_t>(nSize));
     }
     else
     {
@@ -649,9 +647,9 @@ void Unserialize_impl(Stream& is, prevector<N, T>& v, const unsigned char&)
     uint64_t i = 0;
     while (i < nSize)
     {
-        uint64_t blk = std::min<uint64_t>(nSize - i, 1 + 4999999 / sizeof(T));
+        const uint64_t blk = std::min<uint64_t>(nSize - i, 1 + 4999999 / sizeof(T));
         v.resize(i + blk);
-        is.read((char*)&v[i], blk * sizeof(T));
+        is.read((char*)&v[static_cast<typename prevector<N, T>::size_type>(i)], blk * sizeof(T));
         i += blk;
     }
 }
@@ -1091,4 +1089,3 @@ size_t GetSerializeSize(const S& s, const T& t)
     return (CSizeComputer(s.GetType(), s.GetVersion()) << t).size();
 }
 
-#endif // BITCOIN_SERIALIZE_H

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -1,37 +1,39 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2013 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_SUPPORT_ALLOCATORS_SECURE_H
-#define BITCOIN_SUPPORT_ALLOCATORS_SECURE_H
-
 #include "support/pagelocker.h"
-
 #include <string>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif // _MSC_VER
 //
 // Allocator that locks its contents from being paged
 // out of memory and clears its contents before deletion.
 //
 template <typename T>
 struct secure_allocator : public std::allocator<T> {
-    // MSVC8 default copy constructor is broken
-    typedef std::allocator<T> base;
-    typedef typename base::size_type size_type;
-    typedef typename base::difference_type difference_type;
-    typedef typename base::pointer pointer;
-    typedef typename base::const_pointer const_pointer;
-    typedef typename base::reference reference;
-    typedef typename base::const_reference const_reference;
-    typedef typename base::value_type value_type;
-    secure_allocator() throw() {}
-    secure_allocator(const secure_allocator& a) throw() : base(a) {}
+    using allocator_type = std::allocator<T>;
+    using value_type = T;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using difference_type = std::ptrdiff_t;
+    using size_type = std::size_t;
+    using pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+    secure_allocator() noexcept {}
+    secure_allocator(const secure_allocator& a) noexcept : 
+        allocator_type(a)
+    {}
     template <typename U>
-    secure_allocator(const secure_allocator<U>& a) throw() : base(a)
-    {
-    }
-    ~secure_allocator() throw() {}
+    secure_allocator(const secure_allocator<U>& a) noexcept : 
+        allocator_type(a)
+    {}
+    ~secure_allocator() noexcept {}
     template <typename _Other>
     struct rebind {
         typedef secure_allocator<_Other> other;
@@ -39,16 +41,16 @@ struct secure_allocator : public std::allocator<T> {
 
     T* allocate(std::size_t n, const void* hint = 0)
     {
-        T* p;
-        p = std::allocator<T>::allocate(n, hint);
-        if (p != NULL)
+        T* p = std::allocator<T>::allocate(n, hint);
+        if (p)
             LockedPageManager::Instance().LockRange(p, sizeof(T) * n);
         return p;
     }
 
     void deallocate(T* p, std::size_t n)
     {
-        if (p != NULL) {
+        if (p)
+        {
             memory_cleanse(p, sizeof(T) * n);
             LockedPageManager::Instance().UnlockRange(p, sizeof(T) * n);
         }
@@ -56,7 +58,9 @@ struct secure_allocator : public std::allocator<T> {
     }
 };
 
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+
 // This is exactly like std::string, but with a custom allocator.
 typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char> > SecureString;
-
-#endif // BITCOIN_SUPPORT_ALLOCATORS_SECURE_H

--- a/src/support/allocators/zeroafterfree.h
+++ b/src/support/allocators/zeroafterfree.h
@@ -1,13 +1,9 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_SUPPORT_ALLOCATORS_ZEROAFTERFREE_H
-#define BITCOIN_SUPPORT_ALLOCATORS_ZEROAFTERFREE_H
-
 #include "support/cleanse.h"
-
 #include <memory>
 #include <vector>
 
@@ -23,11 +19,13 @@ struct zero_after_free_allocator : public std::allocator<T> {
     using const_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
 
     zero_after_free_allocator() noexcept {}
-    zero_after_free_allocator(const zero_after_free_allocator& a) noexcept : allocator_type(a) {}
+    zero_after_free_allocator(const zero_after_free_allocator& a) noexcept : 
+        allocator_type(a)
+    {}
     template <typename U>
-    zero_after_free_allocator(const zero_after_free_allocator<U>& a) noexcept : allocator_type(a)
-    {
-    }
+    zero_after_free_allocator(const zero_after_free_allocator<U>& a) noexcept : 
+        allocator_type(a)
+    {}
     ~zero_after_free_allocator() noexcept {}
     template <typename _Other>
     struct rebind {
@@ -44,5 +42,3 @@ struct zero_after_free_allocator : public std::allocator<T> {
 
 // Byte-vector that clears its contents before deletion.
 typedef std::vector<char, zero_after_free_allocator<char> > CSerializeData;
-
-#endif // BITCOIN_SUPPORT_ALLOCATORS_ZEROAFTERFREE_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -15,7 +15,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "version.h"
-
+#include <unordered_map>
 using namespace std;
 
 CTxMemPoolEntry::CTxMemPoolEntry():
@@ -405,7 +405,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             i++;
         }
 
-        boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
+        unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
 
         BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit) {
             BOOST_FOREACH(const uint256 &nf, joinsplit.nullifiers) {

--- a/src/wallet/asyncrpcoperation_mergetoaddress.cpp
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.cpp
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 #include "paymentdisclosuredb.h"
 
@@ -506,7 +507,7 @@ bool AsyncRPCOperation_mergetoaddress::main_impl()
     }
 
     // Keep track of treestate within this transaction
-    boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
+    unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
     std::vector<uint256> previousCommitments;
 
     while (!vpubNewProcessed) {

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -645,7 +645,7 @@ bool AsyncRPCOperation_sendmany::main_impl() {
     }
 
     // Keep track of treestate within this transaction
-    boost::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
+    unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
     std::vector<uint256> previousCommitments;
 
     while (!vpubNewProcessed) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1,11 +1,8 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_WALLET_WALLET_H
-#define BITCOIN_WALLET_WALLET_H
-
 #include "amount.h"
 #include "coins.h"
 #include "key.h"
@@ -969,7 +966,7 @@ public:
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false, bool fIncludeCoinBase=true, int exactCoins = 0, bool fIncludeLocked=false) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
-    bool IsSpent(const uint256& hash, unsigned int n) const;
+    bool IsSpent(const uint256& hash, const unsigned int n) const;
     bool IsSproutSpent(const uint256& nullifier) const;
     bool IsSaplingSpent(const uint256& nullifier) const;
 
@@ -1144,7 +1141,7 @@ public:
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
 
     std::set< std::set<CTxDestination> > GetAddressGroupings();
-    std::map<CTxDestination, CAmount> GetAddressBalances();
+    std::map<CTxDestination, CAmount> GetAddressBalances(const isminefilter &isMineFilter);
 
     std::set<CTxDestination> GetAccountAddresses(const std::string& strAccount) const;
 
@@ -1427,6 +1424,3 @@ public:
     SpendingKeyAddResult operator()(const libzcash::SaplingExtendedSpendingKey &sk) const;
     SpendingKeyAddResult operator()(const libzcash::InvalidEncoding& no) const;    
 };
-
-
-#endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/wallet_ismine.cpp
+++ b/src/wallet/wallet_ismine.cpp
@@ -4,14 +4,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "wallet_ismine.h"
-
 #include "key.h"
 #include "keystore.h"
 #include "script/script.h"
 #include "script/standard.h"
-
-#include <boost/foreach.hpp>
-
 using namespace std;
 
 typedef vector<unsigned char> valtype;
@@ -19,9 +15,9 @@ typedef vector<unsigned char> valtype;
 unsigned int HaveKeys(const vector<valtype>& pubkeys, const CKeyStore& keystore)
 {
     unsigned int nResult = 0;
-    BOOST_FOREACH(const valtype& pubkey, pubkeys)
+    for(const auto& pubkey : pubkeys)
     {
-        CKeyID keyID = CPubKey(pubkey).GetID();
+        const auto keyID = CPubKey(pubkey).GetID();
         if (keystore.HaveKey(keyID))
             ++nResult;
     }
@@ -30,7 +26,7 @@ unsigned int HaveKeys(const vector<valtype>& pubkeys, const CKeyStore& keystore)
 
 isminetype IsMine(const CKeyStore &keystore, const CTxDestination& dest)
 {
-    CScript script = GetScriptForDestination(dest);
+    const CScript script = GetScriptForDestination(dest);
     return IsMine(keystore, script);
 }
 
@@ -89,4 +85,25 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
     if (keystore.HaveWatchOnly(scriptPubKey))
         return ISMINE_WATCH_ONLY;
     return ISMINE_NO;
+}
+
+/**
+ * Converts string to isminetype.
+ * 
+ * \param szStr - case-insensitive isminetype filter (no, all, watchOnly, spendableOnly)
+ * \param DefaultIsMineType - default isminetype (if s is empty or not valid)
+ * \return 
+ */
+isminetype StrToIsMineType(const string &s, const isminetype DefaultIsMineType) noexcept
+{
+    isminetype isMine = DefaultIsMineType;
+    if (s.compare(ISMINE_FILTERSTR_SPENDABLE_ONLY) == 0)
+        isMine = ISMINE_SPENDABLE;
+    else if (s.compare(ISMINE_FILTERSTR_WATCH_ONLY) == 0)
+        isMine = ISMINE_WATCH_ONLY;
+    else if (s.compare(ISMINE_FILTERSTR_ALL) == 0)
+        isMine = ISMINE_ALL;
+    else if (s.compare(ISMINE_FILTERSTR_NO) == 0)
+        isMine = ISMINE_NO;
+    return isMine;
 }

--- a/src/wallet/wallet_ismine.h
+++ b/src/wallet/wallet_ismine.h
@@ -1,19 +1,18 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLET_WALLET_ISMINE_H
-#define BITCOIN_WALLET_WALLET_ISMINE_H
-
 #include "key.h"
 #include "script/standard.h"
+#include <string>
 
 class CKeyStore;
 class CScript;
 
 /** IsMine() return codes */
-enum isminetype
+enum isminetype : uint8_t
 {
     ISMINE_NO = 0,
     ISMINE_WATCH_ONLY = 1,
@@ -26,4 +25,10 @@ typedef uint8_t isminefilter;
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey);
 isminetype IsMine(const CKeyStore& keystore, const CTxDestination& dest);
 
-#endif // BITCOIN_WALLET_WALLET_ISMINE_H
+constexpr auto ISMINE_FILTERSTR_NO             = "no";
+constexpr auto ISMINE_FILTERSTR_WATCH_ONLY     = "watchOnly";
+constexpr auto ISMINE_FILTERSTR_SPENDABLE_ONLY = "spendableOnly";
+constexpr auto ISMINE_FILTERSTR_ALL            = "all"; // watch only & spendable
+
+// convert string to isminefilter type
+isminetype StrToIsMineType(const std::string &s, const isminetype DefaultIsMineType = ISMINE_NO) noexcept;


### PR DESCRIPTION
- implemented new parameter for "listaddressamounts" rpc command:
        ismineFilter (string, optional, default=all) Whether to include "all", "watchOnly" or "spendableOnly" addresses
- fixed "listaddressamounts" includeEmpty boolean parameter conversion to json in pastel-cli
- fixed VT console sequences for win32 - showmetrics correctly on win32

Visual Studio 2019 support:
  -changed cpp standard in common.props to stdcpp17
  -fixed c++17 compilation issues
  -replaced boost::unordered_map|unordered_set with std::unordered_map|unordered_set,
  these boost containers merged into c++17 standard
  -added pastel_common.props property sheet
