### PR TITLE
libsodium 1.0.15 moved to unsupported

### DIFF
--- a/depends/packages/libsodium.mk
+++ b/depends/packages/libsodium.mk
@@ -1,6 +1,6 @@
 package=libsodium
 $(package)_version=1.0.15
-$(package)_download_path=https://download.libsodium.org/libsodium/releases/old/
+$(package)_download_path=https://download.libsodium.org/libsodium/releases/old/unsupported/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
 $(package)_dependencies=


### PR DESCRIPTION
Libsodium changed download path for 1.0.15. Moved to unsupported.
New download path for libsodium: https://download.libsodium.org/libsodium/releases/old/unsupported/