### PR TITLE
38417841: add new parameter "mine" to "tickets list id", to return registered PastelIDs that are available on the local cNode

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -218,6 +218,8 @@ BITCOIN_CORE_H = \
   rpc/protocol.h \
   rpc/server.h \
   rpc/register.h \
+  rpc/rpc_consts.h \
+  rpc/rpc_parser.h \
   scheduler.h \
   script/interpreter.h \
   script/script.h \

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Copyright (c) 2016-2017 The Zcash developers
+// Copyright (c) 2018-2021 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -16,7 +17,7 @@
 
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 1
-#define CLIENT_VERSION_MINOR 0
+#define CLIENT_VERSION_MINOR 1
 #define CLIENT_VERSION_REVISION 1
 #define CLIENT_VERSION_BUILD 1
 
@@ -27,7 +28,7 @@
  * Copyright year (2009-this)
  * Todo: update this when changing our copyright comments in the source
  */
-#define COPYRIGHT_YEAR 2018
+#define COPYRIGHT_YEAR 2021
 
 #endif //HAVE_CONFIG_H
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -1,9 +1,8 @@
+#pragma once
 // Copyright (c) 2012-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2021 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_DBWRAPPER_H
-#define BITCOIN_DBWRAPPER_H
 
 #include "clientversion.h"
 #include "serialize.h"
@@ -250,7 +249,7 @@ public:
         return WriteBatch(batch, true);
     }
 
-    CDBIterator *NewIterator()
+    CDBIterator *NewIterator() const
     {
         return new CDBIterator(*this, pdb->NewIterator(iteroptions));
     }
@@ -261,5 +260,4 @@ public:
     bool IsEmpty();
 };
 
-#endif // BITCOIN_DBWRAPPER_H
 

--- a/src/ed448/pastel_key.h
+++ b/src/ed448/pastel_key.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The PASTEL-Coin developers
+// Copyright (c) 2018-2021 The PASTEL-Coin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -81,9 +81,8 @@ public:
         pathPastelKeys = GetDataDir() / pathPastelKeys;
 
         std::vector<std::string> vec;
-        for(auto & p : boost::filesystem::directory_iterator( pathPastelKeys )){
+        for (const auto & p : boost::filesystem::directory_iterator( pathPastelKeys ))
             vec.push_back(p.path().filename().string());
-        }
         return vec;
     }
 

--- a/src/mnode-pastel.h
+++ b/src/mnode-pastel.h
@@ -1,12 +1,10 @@
-// Copyright (c) 2019 The PASTEL-Coin developers
+#pragma once
+// Copyright (c) 2019-2021 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef MASTERNODEPASTEL_H
-#define MASTERNODEPASTEL_H
-
 #include "main.h"
 #include "dbwrapper.h"
+#include <unordered_map>
 
 #define TICKETS_VERSION 0x01
 
@@ -534,13 +532,13 @@ public:
 #define FAKE_TICKET
 // Ticket  Processor ////////////////////////////////////////////////////////////////////////////////////////////////////
 class CPastelTicketProcessor {
-	map<TicketID, std::unique_ptr<CDBWrapper> > dbs;
+	std::unordered_map<TicketID, std::unique_ptr<CDBWrapper> > dbs;
     
     template<class T, TicketID ticketId, typename F>
-    void listTickets(F f);
+    void listTickets(F f) const;
     
     template<class T, TicketID ticketId, typename F>
-    std::string filterTickets(F f);
+    std::string filterTickets(F f) const;
 
 public:
 	CPastelTicketProcessor() = default;
@@ -560,7 +558,7 @@ public:
 	template<class T>
 	bool CheckTicketExist(const T& ticket);
 	template<class T>
-	bool FindTicket(T& ticket);
+	bool FindTicket(T& ticket) const;
 
 	template<class T>
 	bool CheckTicketExistBySecondaryKey(const T& ticket);
@@ -569,17 +567,18 @@ public:
     template<class T>
     std::vector<T> FindTicketsByMVKey(TicketID ticketId, const std::string& mvKey);
     
-    std::vector<std::string> GetAllKeys(TicketID id);
+    std::vector<std::string> GetAllKeys(const TicketID id) const;
 
     template<class T, TicketID ticketId>
-    std::string ListTickets();
+    std::string ListTickets() const;
     
-    std::string ListFilterPastelIDTickets(short filter = 0);    // 1 - mn;        2 - personal
-    std::string ListFilterArtTickets(short filter = 0);         // 1 - active;    2 - inactive;     3 - sold
-    std::string ListFilterActTickets(short filter = 0);         // 1 - available; 2 - sold
-    std::string ListFilterSellTickets(short filter = 0);        // 1 - available; 2 - unavailable;  3 - expired; 4 - sold
-    std::string ListFilterBuyTickets(short filter = 0);         // 1 - traded;    2 - expired
-    std::string ListFilterTradeTickets(short filter = 0);       // 1 - available; 2 - sold
+    std::string ListFilterPastelIDTickets(const short filter = 0,    // 1 - mn;        2 - personal;     3 - mine
+        const std::vector<std::string> *pvPastelIDs = nullptr) const; 
+    std::string ListFilterArtTickets(const short filter = 0) const;  // 1 - active;    2 - inactive;     3 - sold
+    std::string ListFilterActTickets(const short filter = 0) const;  // 1 - available; 2 - sold
+    std::string ListFilterSellTickets(const short filter = 0) const; // 1 - available; 2 - unavailable;  3 - expired; 4 - sold
+    std::string ListFilterBuyTickets(const short filter = 0) const;  // 1 - traded;    2 - expired
+    std::string ListFilterTradeTickets(const short filter = 0) const;// 1 - available; 2 - sold
 
 #ifdef ENABLE_WALLET
 	static bool CreateP2FMSTransaction(const std::string& input_string, CMutableTransaction& tx_out, CAmount price, std::string& error_ret);
@@ -616,5 +615,3 @@ public:
     static std::string CreateFakeTransaction(T& ticket, CAmount ticketPrice, const std::vector<std::pair<std::string, CAmount>>& extraPayments, const std::string& strVerb, bool bSend);
 #endif
 };
-
-#endif //MASTERNODEPASTEL_H

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -233,7 +233,7 @@ public:
 
     template<typename InputIterator>
     prevector(InputIterator first, InputIterator last) : _size(0) {
-        size_type n = last - first;
+        size_type n = static_cast<size_type>(std::distance(first, last));
         change_capacity(n);
         while (first != last) {
             _size++;

--- a/src/rpc/rpc_parser.h
+++ b/src/rpc/rpc_parser.h
@@ -1,0 +1,148 @@
+#pragma once
+#include "enum_util.h"
+#include "tinyformat.h"
+#include "rpc/protocol.h"
+#include "core_io.h"
+#include <string>
+#include <unordered_map>
+#include <sstream>
+
+/**
+ * trim string in-place from start (left trim).
+ *
+ * \param s - string to ltrim
+ */
+static inline void ltrim(std::string &s)
+{
+    s.erase(s.begin(), std::find_if(s.cbegin(), s.cend(), [](const auto ch) { return !std::isspace(ch); }));
+}
+
+/**
+ * trim string in-place from end (right trim).
+ *
+ * \param s - string to rtrim
+ */
+static inline void rtrim(std::string& s)
+{
+    s.erase(std::find_if(s.crbegin(), s.crend(), [](const auto ch) { return !std::isspace(ch); }).base(), s.end());
+}
+
+/**
+ * trim string in-place (both left & right trim).
+ */
+static inline void trim(std::string& s)
+{
+    ltrim(s);
+    rtrim(s);
+}
+
+/**
+ * lowercase string in-place.
+ *
+ * \param s
+ */
+static inline void lowercase(std::string &s)
+{
+    std::transform(s.cbegin(), s.cend(), s.begin(), [](const auto ch) { return std::tolower(ch); });
+}
+
+/**
+ * uppercase string in-place.
+ *
+ * \param s
+ */
+static inline void uppercase(std::string& s)
+{
+    std::transform(s.cbegin(), s.cend(), s.begin(), [](const auto ch) { return std::toupper(ch); });
+}
+
+template <typename RPC_CMD_ENUM>
+class RPCCommandParser
+{
+public:
+    RPCCommandParser(const UniValue& params, const size_t nCmdIndex, const char* szCmdList) :
+        m_Params(params),
+        m_Cmd(RPC_CMD_ENUM::unknown),
+        m_nCmdIndex(nCmdIndex)
+    {
+        string error;
+        if (!ParseCmdList(error, szCmdList))
+            throw JSONRPCError(RPC_MISC_ERROR, "Failed to parse rpc command list. " + error);
+        ParseParams();
+    }
+
+    RPC_CMD_ENUM cmd() const noexcept { return m_Cmd; }
+    bool IsCmdSupported() const noexcept { return m_Cmd != RPC_CMD_ENUM::unknown; }
+    bool IsCmd(const RPC_CMD_ENUM& cmd) const noexcept { return m_Cmd == cmd; }
+
+protected:
+    using map_cmdenum_t = std::unordered_map<std::string, RPC_CMD_ENUM>;
+
+    bool ParseCmdList(std::string &error, const char* szCmdList)
+    {
+        error.clear();
+        if (!szCmdList)
+        {
+            error = "rpc command list is empty";
+            return false;
+        }
+        m_CmdMap.clear();
+        std::string sCmdList(szCmdList), sToken;
+        std::istringstream tokenStream(sCmdList);
+        auto nCmdNo = to_integral_type<RPC_CMD_ENUM>(RPC_CMD_ENUM::unknown);
+        const auto nMaxCmdNo = to_integral_type<RPC_CMD_ENUM>(RPC_CMD_ENUM::max_command_count);
+        bool bRet = true;
+        while (std::getline(tokenStream, sToken, ','))
+        {
+            if (++nCmdNo >= nMaxCmdNo)
+            {
+                bRet = false;
+                break;
+            }
+            trim(sToken);
+            lowercase(sToken);
+            m_CmdMap.emplace(sToken, static_cast<RPC_CMD_ENUM>(nCmdNo));
+        }
+        if (nCmdNo + 1 != nMaxCmdNo)
+            bRet = false;
+        if (!bRet)
+            error = tfm::format("Failed to parser the list of rpc commands [%s] - mismatch", szCmdList);
+        return bRet;
+    }
+
+    void ParseParams() noexcept
+    {
+        if (m_Params.size() <= m_nCmdIndex)
+            return;
+        m_sCmd = m_Params[m_nCmdIndex].get_str();
+        trim(m_sCmd);
+        lowercase(m_sCmd);
+        if (m_sCmd.empty())
+            return;
+        const auto it = m_CmdMap.find(m_sCmd);
+        if (it != m_CmdMap.cend())
+            m_Cmd = it->second;
+    }
+
+    map_cmdenum_t m_CmdMap;     // map <command -> cmd_enum>
+    std::string m_sCmd;         // command
+    const UniValue &m_Params;   // rpc parameters
+    RPC_CMD_ENUM m_Cmd;         // cmd enumeration
+    size_t m_nCmdIndex;
+};
+
+// parse first command in params
+// examples:
+//     RPC_CMD_PARSER(TICKETS,params, register, find, list, get)
+#define RPC_CMD_PARSER(command,params,...) \
+    enum class RPC_CMD_##command : uint32_t{unknown = 0, __VA_ARGS__, max_command_count}; \
+    RPCCommandParser<RPC_CMD_##command> command(params, 0, #__VA_ARGS__);
+
+// parse second command in params
+// examples:
+//     RPC_CMD_PARSER2(LIST,params, id, art, act, sell, buy, trade, down)
+#define RPC_CMD_PARSER2(command,params,...) \
+    enum class RPC_CMD_##command : uint32_t \
+    { unknown = 0, __VA_ARGS__, max_command_count }; \
+    RPCCommandParser<RPC_CMD_##command> command(params, 1, #__VA_ARGS__);
+

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -1,10 +1,8 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_SCRIPT_SCRIPT_H
-#define BITCOIN_SCRIPT_SCRIPT_H
 
 #include "crypto/common.h"
 #include "prevector.h"
@@ -421,12 +419,12 @@ public:
     {
         if (b.size() < OP_PUSHDATA1)
         {
-            insert(end(), (unsigned char)b.size());
+            insert(end(), static_cast<unsigned char>(b.size()));
         }
         else if (b.size() <= 0xff)
         {
             insert(end(), OP_PUSHDATA1);
-            insert(end(), (unsigned char)b.size());
+            insert(end(), static_cast<unsigned char>(b.size()));
         }
         else if (b.size() <= 0xffff)
         {
@@ -592,4 +590,3 @@ public:
     }
 };
 
-#endif // BITCOIN_SCRIPT_SCRIPT_H


### PR DESCRIPTION
38417841: add new parameter "mine" to "tickets list id", to return registered PastelIDs that are available on the local cNode
  -implemented new filter parameter "mine" for "tickets list id" rpc command:
  id     - List PastelID registration tickets. Without filter parameter lists ALL (both masternode and personal) PastelIDs.
            Filter:
              all      - lists all masternode PastelIDs. Default.
              mn       - lists only masternode PastelIDs.
              personal - lists only personal PastelIDs.
              mine     - lists only registered PastelIDs available on the local node.
  -improved rpc commands parsing, new class RPCCommandParser
  -corrected help info for some rpc commands (changed to R-strings to simplify syntax)
