### PR TITLE
[39503490] boost classes migration to std

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     pkg-config make automake libtool patch \
+     bsdmainutils curl wget unzip xz-utils zlib1g-dev git openssh-client \
+     g++-10-multilib mingw-w64 python3-dev python3-pip \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave \
+     /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
+  && update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix \
+  && update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix \
+  && ln -fs /usr/bin/x86_64-linux-gnu-gcc-10 /usr/bin/x86_64-linux-gnu-gcc \
+  && ln -fs /usr/bin/gcc /usr/bin/cc && pip3 install pyblake2
+
+WORKDIR /pastel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ jobs:
       - run:
           name: Building Pastel Core
           command: |
-            ./pcutil/build.sh -j20
+            ./pcutil/build.sh -j16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: akobrin/pastel:0.0.1
+    steps:
+      - checkout
+      - run:
+          name: Building Pastel Core
+          command: |
+            ./pcutil/build.sh -j`nproc`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ jobs:
   build:
     docker:
       - image: akobrin/pastel:0.0.1
+    working_directory: /pastel
     steps:
       - checkout
       - run:
           name: Building Pastel Core
           command: |
-            ./pcutil/build.sh -j16
+            ./pcutil/build.sh -j8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ jobs:
       - run:
           name: Building Pastel Core
           command: |
-            ./pcutil/build.sh -j`nproc`
+            ./pcutil/build.sh -j20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,10 @@ jobs:
     docker:
       - image: akobrin/pastel:0.0.1
     working_directory: /pastel
+    resource_class: xlarge
     steps:
       - checkout
       - run:
           name: Building Pastel Core
           command: |
-            ./pcutil/build.sh -j8
+            ./pcutil/build.sh -j4

--- a/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj
+++ b/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj
@@ -115,6 +115,7 @@
     <ClInclude Include="..\..\..\src\compat\byteswap.h" />
     <ClInclude Include="..\..\..\src\compat\endian.h" />
     <ClInclude Include="..\..\..\src\compat\sanity.h" />
+    <ClInclude Include="..\..\..\src\fs.h" />
     <ClInclude Include="..\..\..\src\random.h" />
     <ClInclude Include="..\..\..\src\rpc\client.h" />
     <ClInclude Include="..\..\..\src\rpc\protocol.h" />

--- a/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj.filters
+++ b/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj.filters
@@ -126,5 +126,8 @@
     <ClInclude Include="..\..\..\src\rpc\register.h">
       <Filter>Source Files\rpc</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\fs.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/build-aux/vs2019/libunivalue/libunivalue.vcxproj
+++ b/build-aux/vs2019/libunivalue/libunivalue.vcxproj
@@ -46,7 +46,7 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/build-aux/vs2019/pastel-cli/pastel-cli.props
+++ b/build-aux/vs2019/pastel-cli/pastel-cli.props
@@ -14,8 +14,9 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>libsodium.lib;libcrypto.lib;libevent.lib;libunivalue.lib;libbitcoin_util.lib;libzcash.lib;libsnark.lib;libbitcoin_crypto.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libsodium$(LIBDBGSFX).lib;libcrypto.lib;libevent.lib;libunivalue.lib;libbitcoin_util.lib;libzcash.lib;libsnark.lib;libbitcoin_crypto.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcmt$(LIBDBGSFX).lib</IgnoreSpecificDefaultLibraries>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/build-aux/vs2019/pastel-tx/pastel-tx.props
+++ b/build-aux/vs2019/pastel-tx/pastel-tx.props
@@ -10,7 +10,7 @@
       <PreprocessorDefinitions>SODIUM_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libsodium.lib;libcrypto.lib;libevent.lib;libsecp256k1.lib;libunivalue.lib;libbitcoin_util.lib;libzcash.lib;libsnark.lib;libbitcoin_common.lib;libbitcoin_crypto.lib;libbitcoin_util.lib;libzcash.lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;ws2_32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libsodium$(LIBDBGSFX).lib;libcrypto.lib;libevent.lib;libsecp256k1.lib;libunivalue.lib;libbitcoin_util.lib;libzcash.lib;libsnark.lib;libbitcoin_common.lib;libbitcoin_crypto.lib;libbitcoin_util.lib;libzcash.lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;ws2_32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ResourceCompile>

--- a/build-aux/vs2019/pastel_gtest/pastel_gtest.props
+++ b/build-aux/vs2019/pastel_gtest/pastel_gtest.props
@@ -11,8 +11,9 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libevent.lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libzmq-v142-mt-sgd-4_3_1.lib;libcrypto.lib;libsodium.lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libevent.lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libzmq-v142-mt-sgd-4_3_1.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcmt$(LIBDBGSFX).lib</IgnoreSpecificDefaultLibraries>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/build-aux/vs2019/pasteld/pasteld.props
+++ b/build-aux/vs2019/pasteld/pasteld.props
@@ -12,8 +12,9 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libevent.lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libzmq-v142-mt-sgd-4_3_1.lib;libcrypto.lib;libsodium.lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libevent.lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libzmq-v142-mt-sgd-4_3_1.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcmt$(LIBDBGSFX).lib</IgnoreSpecificDefaultLibraries>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/build-aux/vs2019/pasteld/pasteld.vcxproj
+++ b/build-aux/vs2019/pasteld/pasteld.vcxproj
@@ -85,6 +85,9 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Link>
+      <ShowProgress>LinkVerboseLib</ShowProgress>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\bitcoind.cpp" />

--- a/build-aux/vs2019/settings/release.props
+++ b/build-aux/vs2019/settings/release.props
@@ -11,7 +11,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/configure.ac
+++ b/configure.ac
@@ -92,9 +92,9 @@ AC_ARG_ENABLE([wallet],
 
 AC_ARG_ENABLE([mining],
   [AS_HELP_STRING([--enable-mining],
-  [enable mining (default is yes)])],
+  [enable mining (default is no)])],
   [enable_mining=$enableval],
-  [enable_mining=yes])
+  [enable_mining=no])
 
 AC_ARG_ENABLE([proton],
   [AS_HELP_STRING([--disable-proton],

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -101,7 +101,7 @@ $(1)_download_path_fixed=$(subst :,\:,$$($(1)_download_path))
 
 #default commands
 $(1)_fetch_cmds ?= $(call fetch_file,$(1),$(subst \:,:,$$($(1)_download_path_fixed)),$$($(1)_download_file),$($(1)_file_name),$($(1)_sha256_hash))
-$(1)_extract_cmds ?= mkdir -p "$$($(1)_extract_dir)" && echo "$$($(1)_sha256_hash)  $$($(1)_source)" > "$$($(1)_extract_dir)/.$$($(1)_file_name).hash" && $(build_SHA256SUM) -c "$$($(1)_extract_dir)/.$$($(1)_file_name).hash" && tar --strip-components=1 -xf "$$($(1)_source)"
+$(1)_extract_cmds ?= mkdir -p "$$($(1)_extract_dir)" && echo "$$($(1)_sha256_hash)  $$($(1)_source)" > "$$($(1)_extract_dir)/.$$($(1)_file_name).hash" && $(build_SHA256SUM) -c "$$($(1)_extract_dir)/.$$($(1)_file_name).hash" && tar --no-same-owner --strip-components=1 -xf "$$($(1)_source)"
 $(1)_preprocess_cmds ?=
 $(1)_build_cmds ?=
 $(1)_config_cmds ?=
@@ -203,7 +203,7 @@ $($(1)_preprocessed): | $($(1)_dependencies) $($(1)_extracted)
 $($(1)_configured): | $($(1)_preprocessed)
 	$(AT)@echo "Configuring $(1)..."
 	$(AT)echo "Extracting dependent packages [$($(1)_all_dependencies)]..."
-	$(AT)rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar -xf $($(package)_cached); )
+	$(AT)rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar --no-same-owner -xf $($(package)_cached); )
 	$(AT)mkdir -p $$(@D)
 	$(AT)+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
 	$(AT)touch $$@
@@ -224,7 +224,7 @@ $($(1)_postprocessed): | $($(1)_staged)
 	$(AT)touch $$@
 $($(1)_cached): | $($(1)_dependencies) $($(1)_postprocessed)
 	$(AT)@echo "Caching $(1)..."
-	$(AT)cd $$($(1)_staging_dir)/$(host_prefix); find . | sort | tar --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
+	$(AT)cd $$($(1)_staging_dir)/$(host_prefix); find . | sort | tar --no-same-owner --no-recursion -czf $$($(1)_staging_dir)/$$(@F) -T -
 	$(AT)mkdir -p $$(@D)
 	$(AT)rm -rf $$(@D) && mkdir -p $$(@D)
 	$(AT)mv $$($(1)_staging_dir)/$$(@F) $$(@)

--- a/depends/packages/native_rust.mk
+++ b/depends/packages/native_rust.mk
@@ -41,9 +41,9 @@ define $(package)_extract_cmds
   echo "$($(package)_sha256_hash_$(build_os))  $($(package)_source_dir)/$($(package)_file_name_$(build_os))" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   mkdir $(canonical_host) && \
-  tar --strip-components=1 -xf $($(package)_source) -C $(canonical_host) && \
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source) -C $(canonical_host) && \
   mkdir buildos && \
-  tar --strip-components=1 -xf $($(package)_source_dir)/$($(package)_file_name_$(build_os)) -C buildos
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_file_name_$(build_os)) -C buildos
 endef
 
 define $(package)_stage_cmds

--- a/qa/test-suite/create_benchmark_archive.py
+++ b/qa/test-suite/create_benchmark_archive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import binascii
 import calendar
 import json
@@ -30,7 +32,7 @@ LD_LIBRARY_PATH=src/leveldb python qa/test-suite/create_benchmark_archive.py
 
 def check_deps():
     if subprocess.call(['which', 'find', 'xz', PASTEL_CLI], stdout=subprocess.PIPE):
-        print USAGE
+        print(USAGE)
         sys.exit()
 
 def encode_varint(n):
@@ -155,8 +157,8 @@ def deterministic_filter(tarinfo):
 
 def create_benchmark_archive(blk_hash):
     blk = json.loads(subprocess.check_output([PASTEL_CLI, 'getblock', blk_hash]))
-    print 'Height: %d' % blk['height']
-    print 'Transactions: %d' % len(blk['tx'])
+    print('Height: %d' % blk['height'])
+    print('Transactions: %d' % len(blk['tx']))
 
     os.mkdir('benchmark')
     with open('benchmark/block-%d.dat' % blk['height'], 'wb') as f:
@@ -167,11 +169,11 @@ def create_benchmark_archive(blk_hash):
 
     js_txs = len([tx for tx in txs if len(tx['vjoinsplit']) > 0])
     if js_txs:
-        print 'Block contains %d JoinSplit-containing transactions' % js_txs
+        print('Block contains %d JoinSplit-containing transactions' % js_txs)
         return
 
     inputs = [(x['txid'], x['vout']) for tx in txs for x in tx['vin'] if x.has_key('txid')]
-    print 'Total inputs: %d' % len(inputs)
+    print('Total inputs: %d' % len(inputs))
 
     unique_inputs = {}
     for i in sorted(inputs):
@@ -179,13 +181,13 @@ def create_benchmark_archive(blk_hash):
             unique_inputs[i[0]].append(i[1])
         else:
             unique_inputs[i[0]] = [i[1]]
-    print 'Unique input transactions: %d' % len(unique_inputs)
+    print('Unique input transactions: %d' % len(unique_inputs))
 
     db_path = 'benchmark/block-%d-inputs' % blk['height']
     db = plyvel.DB(db_path, create_if_missing=True)
     wb = db.write_batch()
     bar = progressbar.ProgressBar(redirect_stdout=True)
-    print 'Collecting input coins for block'
+    print('Collecting input coins for block')
     for tx in bar(unique_inputs.keys()):
         rawtx = json.loads(subprocess.check_output([PASTEL_CLI, 'getrawtransaction', tx, '1']))
 
@@ -254,7 +256,7 @@ def create_benchmark_archive(blk_hash):
         tar.add(name, recursive=False, filter=deterministic_filter)
     tar.close()
     subprocess.check_call(['xz', '-6', archive_name])
-    print 'Created archive %s.xz' % archive_name
+    print('Created archive %s.xz' % archive_name)
     subprocess.call(['rm', '-r', 'benchmark'])
 
 if __name__ == '__main__':

--- a/qa/test-suite/create_wallet_200k_utxos.py
+++ b/qa/test-suite/create_wallet_200k_utxos.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # Copyright (c) 2017 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/qa/test-suite/full_test_suite.py
+++ b/qa/test-suite/full_test_suite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Execute all of the automated tests related to Zcash.
 #
@@ -34,7 +34,7 @@ def test_rpath_runpath(filename):
     output = subprocess.check_output(
         [repofile('qa/test-suite/checksec.sh'), '--file', repofile(filename)]
     )
-    if RE_RPATH_RUNPATH.search(output):
+    if RE_RPATH_RUNPATH.search(output.decode('utf-8')):
         print('PASS: %s has no RPATH or RUNPATH.' % filename)
         return True
     else:
@@ -50,7 +50,7 @@ def test_fortify_source(filename):
     line1 = proc.stdout.readline()
     line2 = proc.stdout.readline()
     proc.terminate()
-    if RE_FORTIFY_AVAILABLE.search(line1) and RE_FORTIFY_USED.search(line2):
+    if RE_FORTIFY_AVAILABLE.search(line1.decode('utf-8')) and RE_FORTIFY_USED.search(line2.decode('utf-8')):
         print('PASS: %s has FORTIFY_SOURCE.' % filename)
         return True
     else:
@@ -104,18 +104,18 @@ def ensure_no_dot_so_in_depends():
 
         for lib in libraries:
             if lib.find(".so") != -1:
-                print lib
+                print(lib)
                 exit_code = 1
     else:
         exit_code = 2
-        print "arch-specific build dir not present"
-        print "Did you build the ./depends tree?"
-        print "Are you on a currently unsupported architecture?"
+        print("arch-specific build dir not present")
+        print("Did you build the ./depends tree?")
+        print("Are you on a currently unsupported architecture?")
 
     if exit_code == 0:
-        print "PASS."
+        print("PASS.")
     else:
-        print "FAIL."
+        print("FAIL.")
 
     return exit_code == 0
 

--- a/qa/test-suite/test-depends-sources-mirror.py
+++ b/qa/test-suite/test-depends-sources-mirror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 # This script tests that the package mirror at https://z.cash/depends-sources/
 # contains all of the packages required to build this version of Zcash.
@@ -27,17 +27,17 @@ def get_depends_sources_list():
 for filename in get_depends_sources_list():
     resp = requests.head(MIRROR_URL_DIR + filename)
 
-    print "Checking [" + filename + "] ..."
+    print("Checking [" + filename + "] ...")
 
     if resp.status_code != 200:
-	print "FAIL. File not found on server: " + filename
+	print("FAIL. File not found on server: " + filename)
 	sys.exit(1)
 
     expected_size = os.path.getsize(os.path.join(DEPENDS_SOURCES_DIR, filename))
     server_size = int(resp.headers['Content-Length'])
     if expected_size != server_size:
-	print "FAIL. On the server, %s is %d bytes, but locally it is %d bytes." % (filename, server_size, expected_size)
+	print("FAIL. On the server, %s is %d bytes, but locally it is %d bytes." % (filename, server_size, expected_size))
 	sys.exit(1)
 
-print "PASS."
+print("PASS.")
 sys.exit(0)

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -18,7 +18,6 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/foreach.hpp>
 #include <boost/thread.hpp>
 
 using namespace std;
@@ -47,10 +46,11 @@ void CUnsignedAlert::SetNull()
 std::string CUnsignedAlert::ToString() const
 {
     std::string strSetCancel;
-    BOOST_FOREACH(int n, setCancel)
+    strSetCancel.reserve(setCancel.size() * 3);
+    for (const auto & n : setCancel)
         strSetCancel += strprintf("%d ", n);
     std::string strSetSubVer;
-    BOOST_FOREACH(const std::string& str, setSubVer)
+    for(const auto& str : setSubVer)
         strSetSubVer += "\"" + str + "\" ";
     return strprintf(
         "CAlert(\n"
@@ -222,9 +222,8 @@ bool CAlert::ProcessAlert(const std::vector<unsigned char>& alertKey, bool fThre
         }
 
         // Check if this alert has been cancelled
-        BOOST_FOREACH(PAIRTYPE(const uint256, CAlert)& item, mapAlerts)
+        for (const auto &[hash, alert] : mapAlerts)
         {
-            const CAlert& alert = item.second;
             if (alert.Cancels(*this))
             {
                 LogPrint("alert", "alert already cancelled by %d\n", alert.nID);

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -11,7 +11,6 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-#include <boost/filesystem/operations.hpp>
 #include <stdio.h>
 
 #include <event2/buffer.h>
@@ -97,7 +96,7 @@ static int AppInitRPC(int argc, char* argv[])
         }
         return EXIT_SUCCESS;
     }
-    if (!boost::filesystem::is_directory(GetDataDir(false))) {
+    if (!fs::is_directory(GetDataDir(false))) {
         fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());
         return EXIT_FAILURE;
     }

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -484,7 +484,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& strInput)
             ProduceSignature(MutableTransactionSignatureCreator(&keystore, &mergedTx, i, amount, nHashType), prevPubKey, sigdata, consensusBranchId);
 
         // ... and merge in other signatures:
-        BOOST_FOREACH(const CTransaction& txv, txVariants)
+        for (const auto& txv : txVariants)
             sigdata = CombineSignatures(prevPubKey, MutableTransactionSignatureChecker(&mergedTx, i, amount), sigdata, DataFromTransaction(txv, i), consensusBranchId);
         UpdateTransaction(mergedTx, i, sigdata);
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -14,7 +14,6 @@
 #include "httprpc.h"
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
 #include <stdio.h>
@@ -92,7 +91,7 @@ bool AppInit(int argc, char* argv[])
 
     try
     {
-        if (!boost::filesystem::is_directory(GetDataDir(false)))
+        if (!fs::is_directory(GetDataDir(false)))
         {
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", mapArgs["-datadir"].c_str());
             return false;

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -14,8 +14,6 @@
 #include <math.h>
 #include <stdlib.h>
 
-#include <boost/foreach.hpp>
-
 #define LN2SQUARED 0.4804530139182014246671025263266649717305529515945455
 #define LN2 0.6931471805599453094172321214581765680755001343602552
 
@@ -181,7 +179,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (fFound)
         return true;
 
-    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    for (const auto& txin : tx.vin)
     {
         // Match if the filter contains an outpoint tx spends
         if (contains(txin.prevout))

--- a/src/chain.h
+++ b/src/chain.h
@@ -1,20 +1,15 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_CHAIN_H
-#define BITCOIN_CHAIN_H
 
 #include "arith_uint256.h"
 #include "primitives/block.h"
 #include "pow.h"
 #include "tinyformat.h"
 #include "uint256.h"
-
 #include <vector>
-
-#include <boost/foreach.hpp>
 
 static const int SPROUT_VALUE_VERSION = 1001400;
 static const int SAPLING_VALUE_VERSION = 1010100;
@@ -150,7 +145,7 @@ public:
     //! Branch ID corresponding to the consensus rules used to validate this block.
     //! Only cached if block validity is BLOCK_VALID_CONSENSUS.
     //! Persisted at each activation height, memory-only for intervening blocks.
-    boost::optional<uint32_t> nCachedBranchId;
+    std::optional<uint32_t> nCachedBranchId;
 
     //! The anchor for the tree state up to the start of this block
     uint256 hashSproutAnchor;
@@ -159,22 +154,22 @@ public:
     uint256 hashFinalSproutRoot;
 
     //! Change in value held by the Sprout circuit over this block.
-    //! Will be boost::none for older blocks on old nodes until a reindex has taken place.
-    boost::optional<CAmount> nSproutValue;
+    //! Will be std::nullopt for older blocks on old nodes until a reindex has taken place.
+    std::optional<CAmount> nSproutValue;
 
     //! (memory only) Total value held by the Sprout circuit up to and including this block.
-    //! Will be boost::none for on old nodes until a reindex has taken place.
-    //! Will be boost::none if nChainTx is zero.
-    boost::optional<CAmount> nChainSproutValue;
+    //! Will be std::nullopt for on old nodes until a reindex has taken place.
+    //! Will be std::nullopt if nChainTx is zero.
+    std::optional<CAmount> nChainSproutValue;
 
     //! Change in value held by the Sapling circuit over this block.
-    //! Not a boost::optional because this was added before Sapling activated, so we can
+    //! Not a std::optional because this was added before Sapling activated, so we can
     //! rely on the invariant that every block before this was added had nSaplingValue = 0.
     CAmount nSaplingValue;
 
     //! (memory only) Total value held by the Sapling circuit up to and including this block.
-    //! Will be boost::none if nChainTx is zero.
-    boost::optional<CAmount> nChainSaplingValue;
+    //! Will be std::nullopt if nChainTx is zero.
+    std::optional<CAmount> nChainSaplingValue;
 
     //! block header
     int nVersion;
@@ -201,14 +196,14 @@ public:
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
-        nCachedBranchId = boost::none;
+        nCachedBranchId = std::nullopt;
         hashSproutAnchor = uint256();
         hashFinalSproutRoot = uint256();
         nSequenceId = 0;
-        nSproutValue = boost::none;
-        nChainSproutValue = boost::none;
+        nSproutValue = std::nullopt;
+        nChainSproutValue = std::nullopt;
         nSaplingValue = 0;
-        nChainSaplingValue = boost::none;
+        nChainSaplingValue = std::nullopt;
 
         nVersion       = 0;
         hashMerkleRoot = uint256();
@@ -488,5 +483,3 @@ public:
     /** Find the last common block between this chain and a block index entry. */
     const CBlockIndex *FindFork(const CBlockIndex *pindex) const;
 };
-
-#endif // BITCOIN_CHAIN_H

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -322,7 +322,7 @@ public:
         consensus.nPowMaxAdjustDown = 32; // 32% adjustment down
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
         consensus.nPowTargetSpacing = 2.5 * 60;
-        consensus.nPowAllowMinDifficultyBlocksAfterHeight = boost::none;
+        consensus.nPowAllowMinDifficultyBlocksAfterHeight = std::nullopt;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
         consensus.vUpgrades[Consensus::BASE_SPROUT].nActivationHeight = Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
         consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nProtocolVersion = 170002;

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -3,14 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "checkpoints.h"
-
 #include "chainparams.h"
 #include "main.h"
 #include "uint256.h"
-
 #include <stdint.h>
-
-#include <boost/foreach.hpp>
 
 namespace Checkpoints {
 
@@ -67,15 +63,18 @@ namespace Checkpoints {
     CBlockIndex* GetLastCheckpoint(const CCheckpointData& data)
     {
         const MapCheckpoints& checkpoints = data.mapCheckpoints;
-
-        BOOST_REVERSE_FOREACH(const MapCheckpoints::value_type& i, checkpoints)
+        CBlockIndex* pBlock = nullptr;
+        for (auto i = checkpoints.crbegin(); i != checkpoints.crend(); ++i)
         {
-            const uint256& hash = i.second;
-            BlockMap::const_iterator t = mapBlockIndex.find(hash);
+            const auto& hash = i->second;
+            auto t = mapBlockIndex.find(hash);
             if (t != mapBlockIndex.end())
-                return t->second;
+            {
+                pBlock = t->second;
+                break;
+            }
         }
-        return NULL;
+        return pBlock;
     }
 
 } // namespace Checkpoints

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -1,14 +1,11 @@
+#pragma once
 // Copyright (c) 2012-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CHECKQUEUE_H
-#define BITCOIN_CHECKQUEUE_H
-
 #include <algorithm>
 #include <vector>
 
-#include <boost/foreach.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
@@ -119,7 +116,7 @@ private:
                 fOk = fAllOk;
             }
             // execute work
-            BOOST_FOREACH (T& check, vChecks)
+            for (T& check : vChecks)
                 if (fOk)
                     fOk = check();
             vChecks.clear();
@@ -146,7 +143,8 @@ public:
     void Add(std::vector<T>& vChecks)
     {
         boost::unique_lock<boost::mutex> lock(mutex);
-        BOOST_FOREACH (T& check, vChecks) {
+        for (T& check : vChecks)
+        {
             queue.push_back(T());
             check.swap(queue.back());
         }
@@ -211,5 +209,3 @@ public:
             Wait();
     }
 };
-
-#endif // BITCOIN_CHECKQUEUE_H

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -566,9 +566,9 @@ bool CCoinsViewCache::HaveShieldedRequirements(const CTransaction& tx) const
 {
     std::unordered_map<uint256, SproutMerkleTree, CCoinsKeyHasher> intermediates;
 
-    BOOST_FOREACH(const JSDescription &joinsplit, tx.vjoinsplit)
+    for (const auto &joinsplit : tx.vjoinsplit)
     {
-        BOOST_FOREACH(const uint256& nullifier, joinsplit.nullifiers)
+        for (const auto& nullifier : joinsplit.nullifiers)
         {
             if (GetNullifier(nullifier, SPROUT)) {
                 // If the nullifier is set, this transaction
@@ -585,10 +585,8 @@ bool CCoinsViewCache::HaveShieldedRequirements(const CTransaction& tx) const
             return false;
         }
 
-        BOOST_FOREACH(const uint256& commitment, joinsplit.commitments)
-        {
+        for (const auto& commitment : joinsplit.commitments)
             tree.append(commitment);
-        }
 
         intermediates.insert(std::make_pair(tree.root(), tree));
     }
@@ -636,7 +634,7 @@ double CCoinsViewCache::GetPriority(const CTransaction &tx, int nHeight) const
 
     // FIXME: this logic is partially duplicated between here and CreateNewBlock in miner.cpp.
     double dResult = 0.0;
-    BOOST_FOREACH(const CTxIn& txin, tx.vin)
+    for (const auto& txin : tx.vin)
     {
         const CCoins* coins = AccessCoins(txin.prevout.hash);
         assert(coins);

--- a/src/coins.h
+++ b/src/coins.h
@@ -11,7 +11,6 @@
 #include <assert.h>
 #include <stdint.h>
 #include <unordered_map>
-#include <boost/foreach.hpp>
 #include "zcash/IncrementalMerkleTree.hpp"
 
 /** 
@@ -114,7 +113,8 @@ public:
     }
 
     void ClearUnspendable() {
-        BOOST_FOREACH(CTxOut &txout, vout) {
+        for (auto &txout : vout)
+        {
             if (txout.scriptPubKey.IsUnspendable())
                 txout.SetNull();
         }
@@ -221,18 +221,21 @@ public:
 
     //! check whether the entire CCoins is spent
     //! note that only !IsPruned() CCoins can be serialized
-    bool IsPruned() const {
-        BOOST_FOREACH(const CTxOut &out, vout)
+    bool IsPruned() const
+    {
+        for(const auto &out : vout)
+        {
             if (!out.IsNull())
                 return false;
+        }
         return true;
     }
 
-    size_t DynamicMemoryUsage() const {
+    size_t DynamicMemoryUsage() const
+    {
         size_t ret = memusage::DynamicUsage(vout);
-        BOOST_FOREACH(const CTxOut &out, vout) {
+        for (const auto &out : vout)
             ret += RecursiveDynamicUsage(out.scriptPubKey);
-        }
         return ret;
     }
 };

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -12,6 +12,7 @@
 #include <sys/select.h>
 #endif
 
+#ifdef __GLIBC__
 // Prior to GLIBC_2.14, memcpy was aliased to memmove.
 extern "C" void* memmove(void* a, const void* b, size_t c);
 extern "C" void* memcpy(void* a, const void* b, size_t c)
@@ -19,7 +20,6 @@ extern "C" void* memcpy(void* a, const void* b, size_t c)
     return memmove(a, b, c);
 }
 
-#ifdef __GLIBC__
 extern "C" void __chk_fail(void) __attribute__((__noreturn__));
 extern "C" FDELT_TYPE __fdelt_warn(FDELT_TYPE a)
 {

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -7,8 +7,7 @@
 #define BITCOIN_CONSENSUS_PARAMS_H
 
 #include "uint256.h"
-
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Consensus {
 
@@ -74,7 +73,7 @@ struct Params {
     NetworkUpgrade vUpgrades[MAX_NETWORK_UPGRADES];
     /** Proof of work parameters */
     uint256 powLimit;
-    boost::optional<uint32_t> nPowAllowMinDifficultyBlocksAfterHeight;
+    std::optional<uint32_t> nPowAllowMinDifficultyBlocksAfterHeight;
     int64_t nPowAveragingWindow;
     int64_t nPowMaxAdjustDown;
     int64_t nPowMaxAdjustUp;

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -123,9 +123,10 @@ bool IsActivationHeightForAnyUpgrade(
     return false;
 }
 
-boost::optional<int> NextEpoch(int nHeight, const Consensus::Params& params) {
+std::optional<int> NextEpoch(int nHeight, const Consensus::Params& params)
+{
     if (nHeight < 0) {
-        return boost::none;
+        return std::nullopt;
     }
 
     // Sprout is never pending
@@ -135,16 +136,16 @@ boost::optional<int> NextEpoch(int nHeight, const Consensus::Params& params) {
         }
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<int> NextActivationHeight(
+std::optional<int> NextActivationHeight(
     int nHeight,
     const Consensus::Params& params)
 {
     auto idx = NextEpoch(nHeight, params);
     if (idx) {
-        return params.vUpgrades[idx.get()].nActivationHeight;
+        return params.vUpgrades[idx.value()].nActivationHeight;
     }
-    return boost::none;
+    return std::nullopt;
 }

--- a/src/consensus/upgrades.h
+++ b/src/consensus/upgrades.h
@@ -6,8 +6,7 @@
 #define ZCASH_CONSENSUS_UPGRADES_H
 
 #include "consensus/params.h"
-
-#include <boost/optional.hpp>
+#include <optional>
 
 enum UpgradeState {
     UPGRADE_DISABLED,
@@ -87,15 +86,15 @@ bool IsActivationHeightForAnyUpgrade(
 
 /**
  * Returns the index of the next upgrade after the given block height, or
- * boost::none if there are no more known upgrades.
+ * std::nullopt if there are no more known upgrades.
  */
-boost::optional<int> NextEpoch(int nHeight, const Consensus::Params& params);
+std::optional<int> NextEpoch(int nHeight, const Consensus::Params& params);
 
 /**
  * Returns the activation height for the next upgrade after the given block height,
- * or boost::none if there are no more known upgrades.
+ * or std::nullopt if there are no more known upgrades.
  */
-boost::optional<int> NextActivationHeight(
+std::optional<int> NextActivationHeight(
     int nHeight,
     const Consensus::Params& params);
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -17,7 +17,6 @@
 #include "script/interpreter.h"
 
 #include <boost/assign/list_of.hpp>
-#include <boost/foreach.hpp>
 
 using namespace std;
 
@@ -164,7 +163,8 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
 
     UniValue vin(UniValue::VARR);
-    BOOST_FOREACH(const CTxIn& txin, tx.vin) {
+    for (const auto& txin : tx.vin)
+    {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
             in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));

--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -23,8 +23,7 @@
 #include <algorithm>
 #include <iostream>
 #include <stdexcept>
-
-#include <boost/optional.hpp>
+#include <optional>
 
 static EhSolverCancelledException solver_cancelled;
 
@@ -636,7 +635,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
         size_t hashLen;
         size_t lenIndices;
         unsigned char tmpHash[HashOutput];
-        std::vector<boost::optional<std::vector<FullStepRow<FinalFullWidth>>>> X;
+        std::vector<std::optional<std::vector<FullStepRow<FinalFullWidth>>>> X;
         X.reserve(K+1);
 
         // 3) Repeat steps 1 and 2 for each partial index
@@ -654,7 +653,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
                                  N/8, HashLength, CollisionBitLength, newIndex);
                 if (cancelled(PartialGeneration)) throw solver_cancelled;
             }
-            boost::optional<std::vector<FullStepRow<FinalFullWidth>>> ic = icv;
+            std::optional<std::vector<FullStepRow<FinalFullWidth>>> ic = icv;
 
             // 2a) For each pair of lists:
             hashLen = HashLength;
@@ -679,7 +678,7 @@ bool Equihash<N,K>::OptimisedSolve(const eh_HashState& base_state,
                         if (ic->size() == 0)
                             goto invalidsolution;
 
-                        X[r] = boost::none;
+                        X[r] = std::nullopt;
                         hashLen -= CollisionByteLength;
                         lenIndices *= 2;
                         rti = lti;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -6,8 +6,6 @@
 
 #include "util.h"
 
-#include <boost/filesystem.hpp>
-
 #include <leveldb/cache.h>
 #include <leveldb/env.h>
 #include <leveldb/filter_policy.h>
@@ -30,7 +28,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     return options;
 }
 
-CDBWrapper::CDBWrapper(const boost::filesystem::path& path, size_t nCacheSize, bool fMemory, bool fWipe)
+CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe)
 {
     penv = NULL;
     readoptions.verify_checksums = true;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -10,8 +10,6 @@
 #include "util.h"
 #include "version.h"
 
-#include <boost/filesystem/path.hpp>
-
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
 
@@ -172,7 +170,7 @@ public:
      * @param[in] fMemory     If true, use leveldb's memory environment.
      * @param[in] fWipe       If true, remove all existing data.
      */
-    CDBWrapper(const boost::filesystem::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
     ~CDBWrapper();
 
     template <typename K, typename V>

--- a/src/fs.h
+++ b/src/fs.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <stdio.h>
+#include <string>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+/** Filesystem operations and types */
+namespace fs = boost::filesystem;

--- a/src/gtest/main.cpp
+++ b/src/gtest/main.cpp
@@ -30,16 +30,16 @@ int main(int argc, char **argv)
   libsnark::default_r1cs_ppzksnark_pp::init_public_params();
   libsnark::inhibit_profiling_info = true;
   libsnark::inhibit_profiling_counters = true;
-  boost::filesystem::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
-  boost::filesystem::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
+  fs::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
+  fs::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
   params = ZCJoinSplit::Prepared(vk_path.string(), pk_path.string());
 
-  boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
-  boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
-  boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
+  fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
+  fs::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
+  fs::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
 
     static_assert(
-        sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
+        sizeof(fs::path::value_type) == sizeof(codeunit),
         "librustzcash not configured correctly");
     auto sapling_spend_str = sapling_spend.native();
     auto sapling_output_str = sapling_output.native();

--- a/src/gtest/test_circuit.cpp
+++ b/src/gtest/test_circuit.cpp
@@ -1,11 +1,10 @@
 #include <gtest/gtest.h>
 #include "uint256.h"
-
 #include "zcash/util.h"
 
-#include <boost/foreach.hpp>
+#include <optional>
+
 #include <boost/format.hpp>
-#include <boost/optional.hpp>
 
 #include <libsnark/common/default_types/r1cs_ppzksnark_pp.hpp>
 #include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>

--- a/src/gtest/test_deprecation.cpp
+++ b/src/gtest/test_deprecation.cpp
@@ -9,7 +9,6 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-#include <boost/filesystem/operations.hpp>
 #include <boost/bind/bind.hpp>
 #include <fstream>
 
@@ -50,7 +49,7 @@ protected:
 
     StrictMock<MockUIInterface> mock_;
 
-    static std::vector<std::string> read_lines(boost::filesystem::path filepath) {
+    static std::vector<std::string> read_lines(fs::path filepath) {
         std::vector<std::string> result;
 
         std::ifstream f(filepath.string().c_str());
@@ -124,8 +123,8 @@ TEST_F(DeprecationTest, DeprecatedNodeIgnoredOnTestnet) {
 }
 
 TEST_F(DeprecationTest, AlertNotify) {
-    boost::filesystem::path temp = GetTempPath() /
-        boost::filesystem::unique_path("alertnotify-%%%%.txt");
+    fs::path temp = GetTempPath() /
+        fs::unique_path("alertnotify-%%%%.txt");
 
     mapArgs["-alertnotify"] = std::string("echo %s >> ") + temp.string();
 
@@ -147,5 +146,5 @@ TEST_F(DeprecationTest, AlertNotify) {
 #else
     EXPECT_EQ(r[0], strprintf("'%s' ", expectedMsg));
 #endif
-    boost::filesystem::remove(temp);
+    fs::remove(temp);
 }

--- a/src/gtest/test_joinsplit.cpp
+++ b/src/gtest/test_joinsplit.cpp
@@ -2,7 +2,6 @@
 
 #include "utilstrencodings.h"
 
-#include <boost/foreach.hpp>
 #include <boost/variant/get.hpp>
 
 #include "zcash/prf.h"
@@ -314,7 +313,8 @@ for test_input in TEST_VECTORS:
         }
     };
 
-    BOOST_FOREACH(std::vector<std::string>& v, tests) {
+    for (auto& v : tests)
+    {
         auto expected = ZCJoinSplit::h_sig(
             uint256S(v[0]),
             {uint256S(v[1]), uint256S(v[2])},

--- a/src/gtest/test_merkletree.cpp
+++ b/src/gtest/test_merkletree.cpp
@@ -31,8 +31,6 @@
 #include <libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp>
 #include <libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp>
 
-#include <boost/foreach.hpp>
-
 #include "json_test_vectors.h"
 
 using namespace std;
@@ -104,7 +102,7 @@ void test_tree(
         expect_ser_test_vector(ser_tests[i], tree, tree);
 
         bool first = true; // The first witness can never form a path
-        BOOST_FOREACH(Witness& wit, witnesses)
+        for (auto& wit : witnesses)
         {
             // Append the same commitment to all the witnesses
             wit.append(test_commitment);
@@ -179,7 +177,7 @@ void test_tree(
         // Tree should be full now
         ASSERT_THROW(tree.append(uint256()), std::runtime_error);
 
-        BOOST_FOREACH(Witness& wit, witnesses)
+        for(auto& wit : witnesses)
         {
             ASSERT_THROW(wit.append(uint256()), std::runtime_error);
         }

--- a/src/gtest/test_miner.cpp
+++ b/src/gtest/test_miner.cpp
@@ -9,7 +9,7 @@
 #include "wallet/wallet.h"
 #endif
 
-#include <boost/optional.hpp>
+#include <optional>
 
 using ::testing::Return;
 
@@ -25,7 +25,7 @@ public:
 TEST(Miner, GetMinerScriptPubKey) {
     SelectParams(CBaseChainParams::Network::MAIN);
 
-    boost::optional<CScript> scriptPubKey;
+    std::optional<CScript> scriptPubKey;
 #ifdef ENABLE_WALLET
     MockReserveKey reservekey;
     EXPECT_CALL(reservekey, GetReservedKey(::testing::_))

--- a/src/gtest/test_noteencryption.cpp
+++ b/src/gtest/test_noteencryption.cpp
@@ -39,7 +39,7 @@ TEST(noteencryption, NotePlaintext)
     if (!cmu_opt) {
         FAIL();
     }
-    uint256 cmu = cmu_opt.get();
+    uint256 cmu = cmu_opt.value();
     SaplingNotePlaintext pt(note, memo);
 
     auto res = pt.encrypt(addr.pk_d);
@@ -47,7 +47,7 @@ TEST(noteencryption, NotePlaintext)
         FAIL();
     }
 
-    auto enc = res.get();
+    auto enc = res.value();
 
     auto ct = enc.first;
     auto encryptor = enc.second;
@@ -73,7 +73,7 @@ TEST(noteencryption, NotePlaintext)
         FAIL();
     }
 
-    auto bar = foo.get();
+    auto bar = foo.value();
 
     ASSERT_TRUE(bar.value() == pt.value());
     ASSERT_TRUE(bar.memo() == pt.memo());
@@ -86,7 +86,7 @@ TEST(noteencryption, NotePlaintext)
         FAIL();
     }
 
-    auto new_note = foobar.get();
+    auto new_note = foobar.value();
 
     ASSERT_TRUE(note.value() == new_note.value());
     ASSERT_TRUE(note.d == new_note.d);
@@ -121,7 +121,7 @@ TEST(noteencryption, NotePlaintext)
         FAIL();
     }
 
-    auto decrypted_out_ct_unwrapped = decrypted_out_ct.get();
+    auto decrypted_out_ct_unwrapped = decrypted_out_ct.value();
 
     ASSERT_TRUE(decrypted_out_ct_unwrapped.pk_d == out_pt.pk_d);
     ASSERT_TRUE(decrypted_out_ct_unwrapped.esk == out_pt.esk);
@@ -150,7 +150,7 @@ TEST(noteencryption, NotePlaintext)
         FAIL();
     }
 
-    bar = foo.get();
+    bar = foo.value();
 
     ASSERT_TRUE(bar.value() == pt.value());
     ASSERT_TRUE(bar.memo() == pt.memo());
@@ -183,7 +183,7 @@ TEST(noteencryption, SaplingApi)
     }
 
     // Invalid diversifier
-    ASSERT_EQ(boost::none, SaplingNoteEncryption::FromDiversifier({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+    ASSERT_EQ(std::nullopt, SaplingNoteEncryption::FromDiversifier({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
     // Encrypt to pk_1
     auto enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d);

--- a/src/gtest/test_paymentdisclosure.cpp
+++ b/src/gtest/test_paymentdisclosure.cpp
@@ -13,7 +13,6 @@
 #include <string>
 #include <set>
 #include <vector>
-#include <boost/filesystem.hpp>
 #include <iostream>
 #include "util.h"
 
@@ -53,7 +52,7 @@ static uint256 random_uint256()
 // Subclass of PaymentDisclosureDB to add debugging methods
 class PaymentDisclosureDBTest : public PaymentDisclosureDB {
 public:
-    PaymentDisclosureDBTest(const boost::filesystem::path& dbPath) : PaymentDisclosureDB(dbPath) {}
+    PaymentDisclosureDBTest(const fs::path& dbPath) : PaymentDisclosureDB(dbPath) {}
 
     void DebugDumpAllStdout() {
         ASSERT_NE(db, nullptr);
@@ -95,8 +94,8 @@ public:
 TEST(paymentdisclosure, mainnet) {
     SelectParams(CBaseChainParams::Network::MAIN);
 
-    boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
-    boost::filesystem::create_directories(pathTemp);
+    fs::path pathTemp = fs::temp_directory_path() / fs::unique_path();
+    fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
     std::cout << "Test payment disclosure database created in folder: " << pathTemp.string() << std::endl;

--- a/src/gtest/test_pow.cpp
+++ b/src/gtest/test_pow.cpp
@@ -79,7 +79,7 @@ TEST(PoW, MinDifficultyRules) {
     std::vector<CBlockIndex> blocks(lastBlk+1);
     for (int i = 0; i <= lastBlk; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : nullptr;
-        blocks[i].nHeight = params.nPowAllowMinDifficultyBlocksAfterHeight.get() + i;
+        blocks[i].nHeight = params.nPowAllowMinDifficultyBlocksAfterHeight.value() + i;
         blocks[i].nTime = 1269211443 + i * params.nPowTargetSpacing;
         blocks[i].nBits = 0x1e7fffff; /* target 0x007fffff000... */
         blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);

--- a/src/gtest/test_sapling_note.cpp
+++ b/src/gtest/test_sapling_note.cpp
@@ -45,7 +45,7 @@ TEST(SaplingNote, TestVectors)
 
     // Test commitment
     SaplingNote note = SaplingNote(diversifier, pk_d, v, r);
-    ASSERT_EQ(note.cm().get(), cm);
+    ASSERT_EQ(note.cm().value(), cm);
 
     // Test nullifier
     SaplingSpendingKey spendingKey(sk);

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -60,9 +60,9 @@ TEST(TransactionBuilder, Invoke)
     auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
         tx1.vShieldedOutput[0].encCiphertext, ivk, tx1.vShieldedOutput[0].ephemeralKey, tx1.vShieldedOutput[0].cm);
     ASSERT_EQ(static_cast<bool>(maybe_pt), true);
-    auto maybe_note = maybe_pt.get().note(ivk);
+    auto maybe_note = maybe_pt.value().note(ivk);
     ASSERT_EQ(static_cast<bool>(maybe_note), true);
-    auto note = maybe_note.get();
+    auto note = maybe_note.value();
     SaplingMerkleTree tree;
     tree.append(tx1.vShieldedOutput[0].cm);
     auto anchor = tree.root();

--- a/src/gtest/test_upgrades.cpp
+++ b/src/gtest/test_upgrades.cpp
@@ -3,7 +3,7 @@
 #include "chainparams.h"
 #include "consensus/upgrades.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 class UpgradesTest : public ::testing::Test {
 protected:
@@ -148,28 +148,28 @@ TEST_F(UpgradesTest, NextEpoch) {
     const Consensus::Params& params = Params().GetConsensus();
 
     // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
-    EXPECT_EQ(NextEpoch(-1, params), boost::none);
-    EXPECT_EQ(NextEpoch(0, params), boost::none);
-    EXPECT_EQ(NextEpoch(1, params), boost::none);
-    EXPECT_EQ(NextEpoch(1000000, params), boost::none);
+    EXPECT_EQ(NextEpoch(-1, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(0, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(1, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(1000000, params), std::nullopt);
 
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
-    EXPECT_EQ(NextEpoch(-1, params), boost::none);
-    EXPECT_EQ(NextEpoch(0, params), boost::none);
-    EXPECT_EQ(NextEpoch(1, params), boost::none);
-    EXPECT_EQ(NextEpoch(1000000, params), boost::none);
+    EXPECT_EQ(NextEpoch(-1, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(0, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(1, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(1000000, params), std::nullopt);
 
     int nActivationHeight = 100;
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, nActivationHeight);
 
-    EXPECT_EQ(NextEpoch(-1, params), boost::none);
+    EXPECT_EQ(NextEpoch(-1, params), std::nullopt);
     EXPECT_EQ(NextEpoch(0, params), static_cast<int>(Consensus::UPGRADE_TESTDUMMY));
     EXPECT_EQ(NextEpoch(1, params), static_cast<int>(Consensus::UPGRADE_TESTDUMMY));
     EXPECT_EQ(NextEpoch(nActivationHeight - 1, params), static_cast<int>(Consensus::UPGRADE_TESTDUMMY));
-    EXPECT_EQ(NextEpoch(nActivationHeight, params), boost::none);
-    EXPECT_EQ(NextEpoch(nActivationHeight + 1, params), boost::none);
-    EXPECT_EQ(NextEpoch(1000000, params), boost::none);
+    EXPECT_EQ(NextEpoch(nActivationHeight, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(nActivationHeight + 1, params), std::nullopt);
+    EXPECT_EQ(NextEpoch(1000000, params), std::nullopt);
 }
 
 TEST_F(UpgradesTest, NextActivationHeight) {
@@ -177,26 +177,26 @@ TEST_F(UpgradesTest, NextActivationHeight) {
     const Consensus::Params& params = Params().GetConsensus();
 
     // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
-    EXPECT_EQ(NextActivationHeight(-1, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(0, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(1, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(1000000, params), boost::none);
+    EXPECT_EQ(NextActivationHeight(-1, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(0, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(1, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(1000000, params), std::nullopt);
 
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
-    EXPECT_EQ(NextActivationHeight(-1, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(0, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(1, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(1000000, params), boost::none);
+    EXPECT_EQ(NextActivationHeight(-1, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(0, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(1, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(1000000, params), std::nullopt);
 
     int nActivationHeight = 100;
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, nActivationHeight);
 
-    EXPECT_EQ(NextActivationHeight(-1, params), boost::none);
+    EXPECT_EQ(NextActivationHeight(-1, params), std::nullopt);
     EXPECT_EQ(NextActivationHeight(0, params), nActivationHeight);
     EXPECT_EQ(NextActivationHeight(1, params), nActivationHeight);
     EXPECT_EQ(NextActivationHeight(nActivationHeight - 1, params), nActivationHeight);
-    EXPECT_EQ(NextActivationHeight(nActivationHeight, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(nActivationHeight + 1, params), boost::none);
-    EXPECT_EQ(NextActivationHeight(1000000, params), boost::none);
+    EXPECT_EQ(NextActivationHeight(nActivationHeight, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(nActivationHeight + 1, params), std::nullopt);
+    EXPECT_EQ(NextActivationHeight(1000000, params), std::nullopt);
 }

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -9,7 +9,7 @@ extern ZCJoinSplit* params;
 
 extern bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBlockIndex *pindexNew, const CDiskBlockPos& pos);
 
-void ExpectOptionalAmount(CAmount expected, boost::optional<CAmount> actual) {
+void ExpectOptionalAmount(CAmount expected, std::optional<CAmount> actual) {
     EXPECT_TRUE((bool)actual);
     if (actual) {
         EXPECT_EQ(expected, *actual);

--- a/src/gtest/test_zip32.cpp
+++ b/src/gtest/test_zip32.cpp
@@ -109,7 +109,7 @@ TEST(ZIP32, TestVectors) {
     auto maybe_m_1_2hv_3 = m_1_2hv.Derive(3);
     EXPECT_TRUE(maybe_m_1_2hv_3);
 
-    auto m_1_2hv_3 = maybe_m_1_2hv_3.get();
+    auto m_1_2hv_3 = maybe_m_1_2hv_3.value();
     EXPECT_EQ(m_1_2hv_3.depth, 3);
     EXPECT_EQ(m_1_2hv_3.parentFVKTag, 0x7583c148);
     EXPECT_EQ(m_1_2hv_3.childIndex, 3);

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -37,7 +37,6 @@
 #endif
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
-#include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 
 /** HTTP request work item */
@@ -195,7 +194,7 @@ static bool ClientAllowed(const CNetAddr& netaddr)
 {
     if (!netaddr.IsValid())
         return false;
-    BOOST_FOREACH (const CSubNet& subnet, rpc_allow_subnets)
+    for (const auto& subnet : rpc_allow_subnets)
         if (subnet.Match(netaddr))
             return true;
     return false;
@@ -207,11 +206,14 @@ static bool InitHTTPAllowList()
     rpc_allow_subnets.clear();
     rpc_allow_subnets.push_back(CSubNet("127.0.0.0/8")); // always allow IPv4 local subnet
     rpc_allow_subnets.push_back(CSubNet("::1"));         // always allow IPv6 localhost
-    if (mapMultiArgs.count("-rpcallowip")) {
-        const std::vector<std::string>& vAllow = mapMultiArgs["-rpcallowip"];
-        BOOST_FOREACH (std::string strAllow, vAllow) {
+    if (mapMultiArgs.count("-rpcallowip"))
+    {
+        const auto& vAllow = mapMultiArgs["-rpcallowip"];
+        for (const auto &strAllow : vAllow)
+        {
             CSubNet subnet(strAllow);
-            if (!subnet.IsValid()) {
+            if (!subnet.IsValid())
+            {
                 uiInterface.ThreadSafeMessageBox(
                     strprintf("Invalid -rpcallowip subnet specification: %s. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24).", strAllow),
                     "", CClientUIInterface::MSG_ERROR);
@@ -221,7 +223,7 @@ static bool InitHTTPAllowList()
         }
     }
     std::string strAllowed;
-    BOOST_FOREACH (const CSubNet& subnet, rpc_allow_subnets)
+    for (const auto& subnet : rpc_allow_subnets)
         strAllowed += subnet.ToString() + " ";
     LogPrint("http", "Allowing HTTP connections from: %s\n", strAllowed);
     return true;
@@ -461,9 +463,8 @@ void InterruptHTTPServer()
     LogPrint("http", "Interrupting HTTP server\n");
     if (eventHTTP) {
         // Unlisten sockets
-        BOOST_FOREACH (evhttp_bound_socket *socket, boundSockets) {
+        for (auto socket : boundSockets)
             evhttp_del_accept_socket(eventHTTP, socket);
-        }
         // Reject requests on current connections
         evhttp_set_gencb(eventHTTP, http_reject_request_cb, NULL);
     }

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -4,11 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "keystore.h"
-
 #include "key.h"
 #include "util.h"
-
-#include <boost/foreach.hpp>
 
 bool CKeyStore::GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const
 {

--- a/src/main.h
+++ b/src/main.h
@@ -190,7 +190,7 @@ FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Open an undo file (rev?????.dat) */
 FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-boost::filesystem::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
+fs::path GetBlockPosFilename(const CDiskBlockPos& pos, const char* prefix);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos *dbp = NULL);
 /** Initialize a new block tree database + block data on disk */

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -9,7 +9,6 @@
 #include <vector>
 #include <unordered_set>
 #include <unordered_map>
-#include <boost/foreach.hpp>
 
 namespace memusage
 {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -35,7 +35,7 @@
 #include "sodium.h"
 
 #include <boost/thread.hpp>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 #ifdef ENABLE_MINING
 #include <functional>
 #endif
@@ -74,7 +74,7 @@ uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockSize = 0;
 
 // We want to sort transactions by priority and fee rate, so:
-typedef boost::tuple<double, CFeeRate, const CTransaction*> TxPriority;
+typedef std::tuple<double, CFeeRate, const CTransaction*> TxPriority;
 class TxPriorityCompare
 {
     bool byFee;
@@ -86,15 +86,15 @@ public:
     {
         if (byFee)
         {
-            if (a.get<1>() == b.get<1>())
-                return a.get<0>() < b.get<0>();
-            return a.get<1>() < b.get<1>();
+            if (std::get<1>(a) == std::get<1>(b))
+                return std::get<0>(a) < std::get<0>(b);
+            return std::get<1>(a) < std::get<1>(b);
         }
         else
         {
-            if (a.get<0>() == b.get<0>())
-                return a.get<1>() < b.get<1>();
-            return a.get<0>() < b.get<0>();
+            if (std::get<0>(a) == std::get<0>(b))
+                return std::get<1>(a) < std::get<1>(b);
+            return std::get<0>(a) < std::get<0>(b);
         }
     }
 };
@@ -104,7 +104,7 @@ void UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, 
     pblock->nTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
 
     // Updating time can change work required on testnet:
-    if (consensusParams.nPowAllowMinDifficultyBlocksAfterHeight != boost::none) {
+    if (consensusParams.nPowAllowMinDifficultyBlocksAfterHeight != std::nullopt) {
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
     }
 }
@@ -182,7 +182,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             double dPriority = 0;
             CAmount nTotalIn = 0;
             bool fMissingInputs = false;
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
+            for (const auto& txin : tx.vin)
             {
                 // Read prev transaction
                 if (!view.HaveCoins(txin.prevout.hash))
@@ -256,9 +256,9 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         while (!vecPriority.empty())
         {
             // Take highest priority transaction off the priority queue:
-            double dPriority = vecPriority.front().get<0>();
-            CFeeRate feeRate = vecPriority.front().get<1>();
-            const CTransaction& tx = *(vecPriority.front().get<2>());
+            double dPriority = std::get<0>(vecPriority.front());
+            CFeeRate feeRate = std::get<1>(vecPriority.front());
+            const CTransaction& tx = *(std::get<2>(vecPriority.front()));
 
             std::pop_heap(vecPriority.begin(), vecPriority.end(), comparer);
             vecPriority.pop_back();
@@ -310,9 +310,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 
             UpdateCoins(tx, view, nHeight);
 
-            BOOST_FOREACH(const OutputDescription &outDescription, tx.vShieldedOutput) {
+            for (const auto &outDescription : tx.vShieldedOutput)
                 sapling_tree.append(outDescription.cm);
-            }
 
             // Added
             pblock->vtx.push_back(tx);
@@ -332,7 +331,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
             // Add transactions that depend on this one to the priority queue
             if (mapDependers.count(hash))
             {
-                BOOST_FOREACH(COrphan* porphan, mapDependers[hash])
+                for (auto porphan : mapDependers[hash])
                 {
                     if (!porphan->setDependsOn.empty())
                     {
@@ -392,9 +391,9 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
 }
 
 #ifdef ENABLE_WALLET
-boost::optional<CScript> GetMinerScriptPubKey(CReserveKey& reservekey)
+std::optional<CScript> GetMinerScriptPubKey(CReserveKey& reservekey)
 #else
-boost::optional<CScript> GetMinerScriptPubKey()
+std::optional<CScript> GetMinerScriptPubKey()
 #endif
 {
     CKeyID keyID;
@@ -405,11 +404,11 @@ boost::optional<CScript> GetMinerScriptPubKey()
 #ifdef ENABLE_WALLET
         CPubKey pubkey;
         if (!reservekey.GetReservedKey(pubkey)) {
-            return boost::optional<CScript>();
+            return std::optional<CScript>();
         }
         keyID = pubkey.GetID();
 #else
-        return boost::optional<CScript>();
+        return std::optional<CScript>();
 #endif
     }
 
@@ -420,11 +419,11 @@ boost::optional<CScript> GetMinerScriptPubKey()
 #ifdef ENABLE_WALLET
 CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey)
 {
-    boost::optional<CScript> scriptPubKey = GetMinerScriptPubKey(reservekey);
+    std::optional<CScript> scriptPubKey = GetMinerScriptPubKey(reservekey);
 #else
 CBlockTemplate* CreateNewBlockWithKey()
 {
-    boost::optional<CScript> scriptPubKey = GetMinerScriptPubKey();
+    std::optional<CScript> scriptPubKey = GetMinerScriptPubKey();
 #endif
 
     if (!scriptPubKey) {
@@ -731,7 +730,7 @@ void static BitcoinMiner()
                 // Update nNonce and nTime
                 pblock->nNonce = ArithToUint256(UintToArith256(pblock->nNonce) + 1);
                 UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
-                if (chainparams.GetConsensus().nPowAllowMinDifficultyBlocksAfterHeight != boost::none)
+                if (chainparams.GetConsensus().nPowAllowMinDifficultyBlocksAfterHeight != std::nullopt)
                 {
                     // Changing pblock->nTime can change work required on testnet:
                     hashTarget.SetCompact(pblock->nBits);

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,7 +8,7 @@
 
 #include "primitives/block.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <stdint.h>
 
 class CBlockIndex;
@@ -29,10 +29,10 @@ struct CBlockTemplate
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
 #ifdef ENABLE_WALLET
-boost::optional<CScript> GetMinerScriptPubKey(CReserveKey& reservekey);
+std::optional<CScript> GetMinerScriptPubKey(CReserveKey& reservekey);
 CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey);
 #else
-boost::optional<CScript> GetMinerScriptPubKey();
+std::optional<CScript> GetMinerScriptPubKey();
 CBlockTemplate* CreateNewBlockWithKey();
 #endif
 

--- a/src/mnode-config.cpp
+++ b/src/mnode-config.cpp
@@ -1,6 +1,3 @@
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-
 #include "mnode-config.h"
 #include "mnode-controller.h"
 
@@ -70,8 +67,8 @@ std::string get_obj_as_string(json::iterator& it, std::string name)
 
 bool CMasternodeConfig::read(std::string& strErr)
 {
-    boost::filesystem::path pathMasternodeConfigFile = masterNodeCtrl.GetMasternodeConfigFile();
-    boost::filesystem::ifstream streamConfig(pathMasternodeConfigFile);
+    fs::path pathMasternodeConfigFile = masterNodeCtrl.GetMasternodeConfigFile();
+    fs::ifstream streamConfig(pathMasternodeConfigFile);
 
     nlohmann::json jsonObj;
 

--- a/src/mnode-controller.cpp
+++ b/src/mnode-controller.cpp
@@ -143,7 +143,8 @@ bool CMasterNodeController::EnableMasterNode(std::ostringstream& strErrors, boos
         LogPrintf("Locking Masternodes:\n");
         uint256 mnTxHash;
         int outputIndex;
-        BOOST_FOREACH(CMasternodeConfig::CMasternodeEntry mne, masternodeConfig.getEntries()) {
+        for (const auto & mne : masternodeConfig.getEntries())
+        {
             mnTxHash.SetHex(mne.getTxHash());
             outputIndex = boost::lexical_cast<unsigned int>(mne.getOutputIndex());
             COutPoint outpoint = COutPoint(mnTxHash, outputIndex);
@@ -160,7 +161,7 @@ bool CMasterNodeController::EnableMasterNode(std::ostringstream& strErrors, boos
 
     // LOAD SERIALIZED DAT FILES INTO DATA CACHES FOR INTERNAL USE
 
-    boost::filesystem::path pathDB = GetDataDir();
+    fs::path pathDB = GetDataDir();
     std::string strDBName;
 
     strDBName = "mncache.dat";
@@ -345,9 +346,11 @@ bool CMasterNodeController::ProcessGetData(CNode* pfrom, const CInv& inv)
         BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
         LOCK(cs_mapMasternodeBlockPayees);
         if (mi != mapBlockIndex.end() && masternodePayments.mapMasternodeBlockPayees.count(mi->second->nHeight)) {
-            BOOST_FOREACH(CMasternodePayee& payee, masternodePayments.mapMasternodeBlockPayees[mi->second->nHeight].vecPayees) {
-                std::vector<uint256> vecVoteHashes = payee.GetVoteHashes();
-                BOOST_FOREACH(uint256& hash, vecVoteHashes) {
+            for (auto & payee : masternodePayments.mapMasternodeBlockPayees[mi->second->nHeight].vecPayees)
+            {
+                auto vecVoteHashes = payee.GetVoteHashes();
+                for (auto& hash : vecVoteHashes)
+                {
                     if(masternodePayments.HasVerifiedPaymentVote(hash)) {
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
                         ss.reserve(1000);
@@ -403,10 +406,11 @@ void CMasterNodeController::ShutdownMasterNode()
     flatDB5.Dump(masternodeMessages);
 }
 
-boost::filesystem::path CMasterNodeController::GetMasternodeConfigFile()
+fs::path CMasterNodeController::GetMasternodeConfigFile()
 {
-    boost::filesystem::path pathConfigFile(GetArg("-mnconf", "masternode.conf"));
-    if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir() / pathConfigFile;
+    fs::path pathConfigFile(GetArg("-mnconf", "masternode.conf"));
+    if (!pathConfigFile.is_absolute()) 
+        pathConfigFile = GetDataDir() / pathConfigFile;
     return pathConfigFile;
 }
 

--- a/src/mnode-controller.h
+++ b/src/mnode-controller.h
@@ -95,7 +95,7 @@ public:
 
     void ShutdownMasterNode();
 
-    boost::filesystem::path GetMasternodeConfigFile();
+    fs::path GetMasternodeConfigFile();
 
     bool IsSynced() {return masternodeSync.IsSynced();}
 

--- a/src/mnode-db.h
+++ b/src/mnode-db.h
@@ -1,11 +1,7 @@
+#pragma once
 // Copyright (c) 2014-2017 The Dash Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef MASTERNODE_DB_H
-#define MASTERNODE_DB_H
-
-#include <boost/filesystem.hpp>
 
 #include "clientversion.h"
 
@@ -29,7 +25,7 @@ private:
         IncorrectFormat
     };
 
-    boost::filesystem::path pathDB;
+    fs::path pathDB;
     std::string strFilename;
     std::string strMagicMessage;
 
@@ -83,7 +79,7 @@ private:
         }
 
         // use file size to size memory buffer
-        int fileSize = boost::filesystem::file_size(pathDB);
+        int fileSize = fs::file_size(pathDB);
         int dataSize = fileSize - sizeof(uint256);
         // Don't try to resize to a negative number if file is small
         if (dataSize < 0)
@@ -222,4 +218,3 @@ public:
 };
 
 
-#endif

--- a/src/mnode-governance.cpp
+++ b/src/mnode-governance.cpp
@@ -228,7 +228,8 @@ bool CMasternodeGovernance::IsTransactionValid(const CTransaction& txNew, int nH
     CAmount tnxPayment;
     CAmount nGovernancePayment = GetGovernancePayment(txNew.GetValueOut());
     CScript scriptPubKey = ticket.scriptPubKey;
-    BOOST_FOREACH(CTxOut txout, txNew.vout) {
+    for (const auto & txout : txNew.vout)
+    {
         if (scriptPubKey == txout.scriptPubKey) {
             tnxPayment = txout.nValue;
             if (nGovernancePayment == txout.nValue) {

--- a/src/mnode-manager.cpp
+++ b/src/mnode-manager.cpp
@@ -522,15 +522,18 @@ bool CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool f
     int nTenthNetwork = nMnCount/10;
     int nCountTenth = 0;
     arith_uint256 nHighest = 0;
-    CMasternode *pBestMasternode = NULL;
-    BOOST_FOREACH (PAIRTYPE(int, CMasternode*)& s, vecMasternodeLastPaid){
-        arith_uint256 nScore = s.second->CalculateScore(blockHash);
-        if(nScore > nHighest){
+    CMasternode *pBestMasternode = nullptr;
+    for (auto &[nBlock, pMN] : vecMasternodeLastPaid)
+    {
+        auto nScore = pMN->CalculateScore(blockHash);
+        if(nScore > nHighest)
+        {
             nHighest = nScore;
-            pBestMasternode = s.second;
+            pBestMasternode = pMN;
         }
         nCountTenth++;
-        if(nCountTenth >= nTenthNetwork) break;
+        if (nCountTenth >= nTenthNetwork)
+            break;
     }
     if (pBestMasternode) {
         mnInfoRet = pBestMasternode->GetInfo();
@@ -563,10 +566,13 @@ masternode_info_t CMasternodeMan::FindRandomNotInVec(const std::vector<COutPoint
     bool fExclude;
 
     // loop through
-    BOOST_FOREACH(CMasternode* pmn, vpMasternodesShuffled) {
-        if(pmn->nProtocolVersion < nProtocolVersion || !pmn->IsEnabled()) continue;
+    for (auto pmn : vpMasternodesShuffled)
+    {
+        if(pmn->nProtocolVersion < nProtocolVersion || !pmn->IsEnabled())
+            continue;
         fExclude = false;
-        BOOST_FOREACH(const COutPoint &outpointToExclude, vecToExclude) {
+        for (const auto &outpointToExclude : vecToExclude)
+        {
             if(pmn->vin.prevout == outpointToExclude) {
                 fExclude = true;
                 break;
@@ -965,7 +971,8 @@ void CMasternodeMan::CheckSameAddr()
 
         sort(vSortedByAddr.begin(), vSortedByAddr.end(), CompareByAddr());
 
-        BOOST_FOREACH(CMasternode* pmn, vSortedByAddr) {
+        for (auto pmn : vSortedByAddr)
+        {
             // check only (pre)enabled masternodes
             if(!pmn->IsEnabled() && !pmn->IsPreEnabled()) continue;
             // initial step
@@ -993,7 +1000,8 @@ void CMasternodeMan::CheckSameAddr()
     }
 
     // ban duplicates
-    BOOST_FOREACH(CMasternode* pmn, vBan) {
+    for (auto pmn : vBan)
+    {
         LogPrintf("CMasternodeMan::CheckSameAddr -- increasing PoSe ban score for masternode %s\n", pmn->vin.prevout.ToStringShort());
         pmn->IncreasePoSeBanScore();
     }
@@ -1161,7 +1169,8 @@ void CMasternodeMan::ProcessVerifyReply(CNode* pnode, CMasternodeVerification& m
         LogPrintf("CMasternodeMan::ProcessVerifyReply -- verified real masternode %s for addr %s\n",
                     prealMasternode->vin.prevout.ToStringShort(), pnode->addr.ToString());
         // increase ban score for everyone else
-        BOOST_FOREACH(CMasternode* pmn, vpMasternodesToBan) {
+        for (auto pmn : vpMasternodesToBan)
+        {
             pmn->IncreasePoSeBanScore();
             LogPrint("masternode", "CMasternodeMan::ProcessVerifyReply -- increased PoSe ban score for %s addr %s, new score %d\n",
                         prealMasternode->vin.prevout.ToStringShort(), pnode->addr.ToString(), pmn->nPoSeBanScore);

--- a/src/mnode-masternode.cpp
+++ b/src/mnode-masternode.cpp
@@ -272,9 +272,13 @@ bool CMasternode::IsInputAssociatedWithPubkey()
 
     CTransaction tx;
     uint256 hash;
-    if(GetTransaction(vin.prevout.hash, tx, hash, true)) {
-        BOOST_FOREACH(CTxOut out, tx.vout)
-            if(out.nValue == masterNodeCtrl.MasternodeCollateral*COIN && out.scriptPubKey == payee) return true;
+    if (GetTransaction(vin.prevout.hash, tx, hash, true))
+    {
+        for (const auto & out : tx.vout)
+        {
+            if (out.nValue == masterNodeCtrl.MasternodeCollateral * COIN && out.scriptPubKey == payee)
+                return true;
+        }
     }
 
     return false;
@@ -348,13 +352,15 @@ void CMasternode::UpdateLastPaid(const CBlockIndex *pindex, int nMaxBlocksToScan
 
             CAmount nMasternodePayment = masterNodeCtrl.masternodePayments.GetMasternodePayment(BlockReading->nHeight, block.vtx[0].GetValueOut());
 
-            BOOST_FOREACH(CTxOut txout, block.vtx[0].vout)
+            for (const auto & txout : block.vtx[0].vout)
+            {
                 if(mnpayee == txout.scriptPubKey && nMasternodePayment == txout.nValue) {
                     nBlockLastPaid = BlockReading->nHeight;
                     nTimeLastPaid = BlockReading->nTime;
                     LogPrint("masternode", "CMasternode::UpdateLastPaidBlock -- searching for block with payment to %s -- found new %d\n", vin.prevout.ToStringShort(), nBlockLastPaid);
                     return;
                 }
+            }
         }
 
         if (BlockReading->pprev == NULL) { assert(BlockReading); break; }

--- a/src/mnode-pastel.cpp
+++ b/src/mnode-pastel.cpp
@@ -26,9 +26,9 @@ using json = nlohmann::json;
 
 void CPastelTicketProcessor::InitTicketDB()
 {
-	boost::filesystem::path ticketsDir = GetDataDir() / "tickets";
-	if (!boost::filesystem::exists(ticketsDir)) {
-		boost::filesystem::create_directories(ticketsDir);
+    fs::path ticketsDir = GetDataDir() / "tickets";
+    if (!fs::exists(ticketsDir)) {
+        fs::create_directories(ticketsDir);
 	}
 	
 	uint64_t nTotalCache = (GetArg("-dbcache", 450) << 20);

--- a/src/mnode-payments.h
+++ b/src/mnode-payments.h
@@ -1,10 +1,7 @@
+#pragma once
 // Copyright (c) 2018 airk42
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-
-#ifndef MASTERNODEPAYMENTS_H
-#define MASTERNODEPAYMENTS_H
 
 #include "vector"
 #include "map"
@@ -52,9 +49,9 @@ public:
 
     CScript GetPayee() { return scriptPubKey; }
 
-    void AddVoteHash(uint256 hashIn) { vecVoteHashes.push_back(hashIn); }
+    void AddVoteHash(const uint256 hashIn) { vecVoteHashes.push_back(hashIn); }
     std::vector<uint256> GetVoteHashes() { return vecVoteHashes; }
-    int GetVoteCount() { return vecVoteHashes.size(); }
+    int GetVoteCount() const noexcept { return vecVoteHashes.size(); }
 
 };
 
@@ -204,4 +201,3 @@ public:
     CAmount GetMasternodePayment(int nHeight, CAmount blockValue);
 };
 
-#endif

--- a/src/mnode-sync.cpp
+++ b/src/mnode-sync.cpp
@@ -205,7 +205,7 @@ void CMasternodeSync::ProcessTick()
 
     std::vector<CNode*> vNodesCopy = CNodeHelper::CopyNodeVector();
 
-    BOOST_FOREACH(CNode* pnode, vNodesCopy)
+    for (auto pnode : vNodesCopy)
     {
         // Don't try to sync any data from outbound "masternode" connections -
         // they are temporary and should be considered unreliable for a sync process.

--- a/src/mnode-validation.cpp
+++ b/src/mnode-validation.cpp
@@ -65,7 +65,7 @@ bool GetMasternodeOutpointAndKeys(CWallet* pWalletMain, COutPoint& outpointRet, 
     uint256 txHash = uint256S(strTxHash);
     int nOutputIndex = atoi(strOutputIndex.c_str());
 
-    BOOST_FOREACH(COutput& out, vPossibleCoins)
+    for (const auto& out : vPossibleCoins)
         if(out.tx->GetHash() == txHash && out.i == nOutputIndex) // found it!
             return GetOutpointAndKeysFromOutput(pWalletMain, out, outpointRet, pubKeyRet, keyRet);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,7 +24,6 @@
 #include <fcntl.h>
 #endif
 
-#include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
 // Dump addresses to peers.dat every 15 minutes (900s)
@@ -330,37 +329,45 @@ CCriticalSection CNode::cs_totalBytesSent;
 CNode* FindNode(const CNetAddr& ip)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    for (auto pnode : vNodes)
+    {
         if ((CNetAddr)pnode->addr == ip)
             return (pnode);
-    return NULL;
+    }
+    return nullptr;
 }
 
 CNode* FindNode(const CSubNet& subNet)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
-    if (subNet.Match((CNetAddr)pnode->addr))
-        return (pnode);
-    return NULL;
+    for (auto pnode : vNodes)
+    {
+        if (subNet.Match((CNetAddr)pnode->addr))
+            return (pnode);
+    }
+    return nullptr;
 }
 
 CNode* FindNode(const std::string& addrName)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    for (auto pnode : vNodes)
+    {
         if (pnode->addrName == addrName)
             return (pnode);
-    return NULL;
+    }
+    return nullptr;
 }
 
 CNode* FindNode(const CService& addr)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    for (auto pnode : vNodes)
+    {
         if ((CService)pnode->addr == addr)
             return (pnode);
-    return NULL;
+    }
+    return nullptr;
 }
 
 CNode* ConnectNode(CAddress addrConnect, const char *pszDest /*= NULL*/, bool fConnectToMasternode /*= false*/)
@@ -575,7 +582,8 @@ CCriticalSection CNode::cs_vWhitelistedRange;
 
 bool CNode::IsWhitelistedRange(const CNetAddr &addr) {
     LOCK(cs_vWhitelistedRange);
-    BOOST_FOREACH(const CSubNet& subnet, vWhitelistedRange) {
+    for (const auto& subnet : vWhitelistedRange)
+    {
         if (subnet.Match(addr))
             return true;
     }
@@ -847,7 +855,8 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
     {
         LOCK(cs_vNodes);
 
-        BOOST_FOREACH(CNode *node, vNodes) {
+        for (auto node : vNodes)
+        {
             if (node->fWhitelisted)
                 continue;
             if (!node->fInbound)
@@ -873,7 +882,7 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
     const Consensus::Params& params = Params().GetConsensus();
     auto nextEpoch = NextEpoch(height, params);
     if (nextEpoch) {
-        auto idx = nextEpoch.get();
+        auto idx = nextEpoch.value();
         int nActivationHeight = params.vUpgrades[idx].nActivationHeight;
 
         if (nActivationHeight > 0 &&
@@ -922,7 +931,8 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
     unsigned int nMostConnections = 0;
     int64_t nMostConnectionsTime = 0;
     std::map<std::vector<unsigned char>, std::vector<CNodeRef> > mapAddrCounts;
-    BOOST_FOREACH(const CNodeRef &node, vEvictionCandidates) {
+    for (const auto &node : vEvictionCandidates)
+    {
         mapAddrCounts[node->addr.GetGroup()].push_back(node);
         int64_t grouptime = mapAddrCounts[node->addr.GetGroup()][0]->nTimeConnected;
         size_t groupsize = mapAddrCounts[node->addr.GetGroup()].size();
@@ -964,9 +974,11 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
     bool whitelisted = hListenSocket.whitelisted || CNode::IsWhitelistedRange(addr);
     {
         LOCK(cs_vNodes);
-        BOOST_FOREACH(CNode* pnode, vNodes)
+        for (auto pnode : vNodes)
+        {
             if (pnode->fInbound)
                 nInbound++;
+        }
     }
 
     if (hSocket == INVALID_SOCKET)
@@ -1042,7 +1054,7 @@ void ThreadSocketHandler()
             LOCK(cs_vNodes);
             // Disconnect unused nodes
             vector<CNode*> vNodesCopy = vNodes;
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            for (auto pnode : vNodesCopy)
             {
                 if (pnode->fDisconnect ||
                     (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0 && pnode->ssSend.empty()))
@@ -1073,7 +1085,7 @@ void ThreadSocketHandler()
         {
             // Delete disconnected nodes
             list<CNode*> vNodesDisconnectedCopy = vNodesDisconnected;
-            BOOST_FOREACH(CNode* pnode, vNodesDisconnectedCopy)
+            for (auto pnode : vNodesDisconnectedCopy)
             {
                 // wait until threads are done using it
                 if (pnode->GetRefCount() <= 0)
@@ -1121,7 +1133,8 @@ void ThreadSocketHandler()
         SOCKET hSocketMax = 0;
         bool have_fds = false;
 
-        BOOST_FOREACH(const ListenSocket& hListenSocket, vhListenSocket) {
+        for (const auto& hListenSocket : vhListenSocket)
+        {
             FD_SET(hListenSocket.socket, &fdsetRecv);
             hSocketMax = max(hSocketMax, hListenSocket.socket);
             have_fds = true;
@@ -1129,7 +1142,7 @@ void ThreadSocketHandler()
 
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes)
+            for (auto pnode : vNodes)
             {
                 if (pnode->hSocket == INVALID_SOCKET)
                     continue;
@@ -1190,7 +1203,7 @@ void ThreadSocketHandler()
         //
         // Accept new connections
         //
-        BOOST_FOREACH(const ListenSocket& hListenSocket, vhListenSocket)
+        for (const auto& hListenSocket : vhListenSocket)
         {
             if (hListenSocket.socket != INVALID_SOCKET && FD_ISSET(hListenSocket.socket, &fdsetRecv))
             {
@@ -1205,10 +1218,10 @@ void ThreadSocketHandler()
         {
             LOCK(cs_vNodes);
             vNodesCopy = vNodes;
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            for (auto pnode : vNodesCopy)
                 pnode->AddRef();
         }
-        BOOST_FOREACH(CNode* pnode, vNodesCopy)
+        for (auto pnode : vNodesCopy)
         {
             boost::this_thread::interruption_point();
 
@@ -1298,7 +1311,7 @@ void ThreadSocketHandler()
         }
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            for (auto pnode : vNodesCopy)
                 pnode->Release();
         }
     }
@@ -1324,7 +1337,8 @@ void ThreadDNSAddressSeed()
 
     LogPrintf("Loading addresses from DNS seeds (could take a while)\n");
 
-    BOOST_FOREACH(const CDNSSeedData &seed, vSeeds) {
+    for (const auto &seed : vSeeds)
+    {
         if (HaveNameProxy()) {
             AddOneShot(seed.host);
         } else {
@@ -1332,7 +1346,7 @@ void ThreadDNSAddressSeed()
             vector<CAddress> vAdd;
             if (LookupHost(seed.host.c_str(), vIPs))
             {
-                BOOST_FOREACH(const CNetAddr& ip, vIPs)
+                for (const auto& ip : vIPs)
                 {
                     int nOneDay = 24*3600;
                     CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()));
@@ -1396,10 +1410,10 @@ void ThreadOpenConnections()
         for (int64_t nLoop = 0;; nLoop++)
         {
             ProcessOneShot();
-            BOOST_FOREACH(const std::string& strAddr, mapMultiArgs["-connect"])
+            for (const auto& strAddr : mapMultiArgs["-connect"])
             {
                 CAddress addr;
-                OpenNetworkConnection(addr, NULL, strAddr.c_str());
+                OpenNetworkConnection(addr, nullptr, strAddr.c_str());
                 for (int i = 0; i < 10 && i < nLoop; i++)
                 {
                     MilliSleep(500);
@@ -1441,7 +1455,8 @@ void ThreadOpenConnections()
         set<vector<unsigned char> > setConnected;
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes) {
+            for (auto pnode : vNodes)
+            {
                 if (!pnode->fInbound && !pnode->fMasternode) {
 
                     setConnected.insert(pnode->addr.GetGroup());
@@ -1500,10 +1515,11 @@ void ThreadOpenAddedConnections()
             list<string> lAddresses(0);
             {
                 LOCK(cs_vAddedNodes);
-                BOOST_FOREACH(const std::string& strAddNode, vAddedNodes)
+                for (const auto& strAddNode : vAddedNodes)
                     lAddresses.push_back(strAddNode);
             }
-            BOOST_FOREACH(const std::string& strAddNode, lAddresses) {
+            for (const auto& strAddNode : lAddresses)
+            {
                 CAddress addr;
                 CSemaphoreGrant grant(*semOutbound);
                 OpenNetworkConnection(addr, &grant, strAddNode.c_str());
@@ -1518,19 +1534,20 @@ void ThreadOpenAddedConnections()
         list<string> lAddresses(0);
         {
             LOCK(cs_vAddedNodes);
-            BOOST_FOREACH(const std::string& strAddNode, vAddedNodes)
+            for (const auto& strAddNode : vAddedNodes)
                 lAddresses.push_back(strAddNode);
         }
 
         list<vector<CService> > lservAddressesToAdd(0);
-        BOOST_FOREACH(const std::string& strAddNode, lAddresses) {
+        for (const auto& strAddNode : lAddresses)
+        {
             vector<CService> vservNode(0);
             if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
             {
                 lservAddressesToAdd.push_back(vservNode);
                 {
                     LOCK(cs_setservAddNodeAddresses);
-                    BOOST_FOREACH(const CService& serv, vservNode)
+                    for (const auto& serv : vservNode)
                         setservAddNodeAddresses.insert(serv);
                 }
             }
@@ -1539,17 +1556,22 @@ void ThreadOpenAddedConnections()
         // (keeping in mind that addnode entries can have many IPs if fNameLookup)
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodes)
-                for (list<vector<CService> >::iterator it = lservAddressesToAdd.begin(); it != lservAddressesToAdd.end(); it++)
-                    BOOST_FOREACH(const CService& addrNode, *(it))
-                        if (pnode->addr == addrNode)
-                        {
+            for (auto pnode : vNodes)
+            {
+                for (list<vector<CService>>::iterator it = lservAddressesToAdd.begin(); it != lservAddressesToAdd.end(); it++)
+                {
+                    for (const auto& addrNode : *(it))
+                    {
+                        if (pnode->addr == addrNode) {
                             it = lservAddressesToAdd.erase(it);
                             it--;
                             break;
                         }
+                    }
+                }
+            }
         }
-        BOOST_FOREACH(vector<CService>& vserv, lservAddressesToAdd)
+        for (const auto &vserv : lservAddressesToAdd)
         {
             CSemaphoreGrant grant(*semOutbound);
             OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), &grant);
@@ -1600,9 +1622,8 @@ void ThreadMessageHandler()
         {
             LOCK(cs_vNodes);
             vNodesCopy = vNodes;
-            BOOST_FOREACH(CNode* pnode, vNodesCopy) {
+            for (auto pnode : vNodesCopy)
                 pnode->AddRef();
-            }
         }
 
         // Poll the connected nodes for messages
@@ -1612,7 +1633,7 @@ void ThreadMessageHandler()
 
         bool fSleep = true;
 
-        BOOST_FOREACH(CNode* pnode, vNodesCopy)
+        for (auto pnode : vNodesCopy)
         {
             if (pnode->fDisconnect)
                 continue;
@@ -1647,7 +1668,7 @@ void ThreadMessageHandler()
 
         {
             LOCK(cs_vNodes);
-            BOOST_FOREACH(CNode* pnode, vNodesCopy)
+            for (auto pnode : vNodesCopy)
                 pnode->Release();
         }
 
@@ -1772,7 +1793,7 @@ void static Discover(boost::thread_group& threadGroup)
         vector<CNetAddr> vaddr;
         if (LookupHost(pszHostName, vaddr))
         {
-            BOOST_FOREACH (const CNetAddr &addr, vaddr)
+            for (const auto &addr : vaddr)
             {
                 if (AddLocal(addr, LOCAL_IF))
                     LogPrintf("%s: %s - %s\n", __func__, pszHostName, addr.ToString());
@@ -1891,18 +1912,24 @@ public:
     ~CNetCleanup()
     {
         // Close sockets
-        BOOST_FOREACH(CNode* pnode, vNodes)
+        for (auto pnode : vNodes)
+        {
             if (pnode->hSocket != INVALID_SOCKET)
                 CloseSocket(pnode->hSocket);
-        BOOST_FOREACH(ListenSocket& hListenSocket, vhListenSocket)
+        }
+        for (auto& hListenSocket : vhListenSocket)
+        {
             if (hListenSocket.socket != INVALID_SOCKET)
+            {
                 if (!CloseSocket(hListenSocket.socket))
                     LogPrintf("CloseSocket(hListenSocket) failed with error %s\n", NetworkErrorString(WSAGetLastError()));
+            }
+        }
 
         // clean up some globals (to help leak detection)
-        BOOST_FOREACH(CNode *pnode, vNodes)
+        for (auto pnode : vNodes)
             delete pnode;
-        BOOST_FOREACH(CNode *pnode, vNodesDisconnected)
+        for (auto pnode : vNodesDisconnected)
             delete pnode;
         vNodes.clear();
         vNodesDisconnected.clear();
@@ -1951,7 +1978,7 @@ void RelayTransaction(const CTransaction& tx, const CDataStream& ss)
         vRelayExpiration.push_back(std::make_pair(GetTime() + 15 * 60, inv));
     }
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
+    for (auto pnode : vNodes)
     {
         if(!pnode->fRelayTxes)
             continue;
@@ -2048,7 +2075,7 @@ bool CAddrDB::Write(const CAddrMan& addr)
     ssPeers << hash;
 
     // open temp output file, and associate with CAutoFile
-    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
+    fs::path pathTmp = GetDataDir() / tmpfn;
     FILE *file = fopen(pathTmp.string().c_str(), "wb");
     CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
     if (fileout.IsNull())
@@ -2080,7 +2107,7 @@ bool CAddrDB::Read(CAddrMan& addr)
         return error("%s: Failed to open file %s", __func__, pathAddr.string());
 
     // use file size to size memory buffer
-    int fileSize = boost::filesystem::file_size(pathAddr);
+    int fileSize = fs::file_size(pathAddr);
     int dataSize = fileSize - sizeof(uint256);
     // Don't try to resize to a negative number if file is small
     if (dataSize < 0)

--- a/src/net.h
+++ b/src/net.h
@@ -26,8 +26,6 @@
 #include <arpa/inet.h>
 #endif
 
-#include <boost/filesystem/path.hpp>
-#include <boost/foreach.hpp>
 #include <boost/signals2/signal.hpp>
 
 class CAddrMan;
@@ -365,7 +363,7 @@ public:
     unsigned int GetTotalRecvSize()
     {
         unsigned int total = 0;
-        BOOST_FOREACH(const CNetMessage &msg, vRecvMsg)
+        for (const auto &msg : vRecvMsg)
             total += msg.vRecv.size() + 24;
         return total;
     }
@@ -377,7 +375,7 @@ public:
     void SetRecvVersion(int nVersionIn)
     {
         nRecvVersion = nVersionIn;
-        BOOST_FOREACH(CNetMessage &msg, vRecvMsg)
+        for(auto &msg : vRecvMsg)
             msg.SetVersion(nVersionIn);
     }
 
@@ -651,7 +649,8 @@ void RelayTransaction(const CTransaction& tx, const CDataStream& ss);
 class CAddrDB
 {
 private:
-    boost::filesystem::path pathAddr;
+    fs::path pathAddr;
+
 public:
     CAddrDB();
     bool Write(const CAddrMan& addr);

--- a/src/nodehelper.h
+++ b/src/nodehelper.h
@@ -91,9 +91,11 @@ public:
 /***** Push message helpers *****/
     static void RelayInv(CInv &inv, const int minProtoVersion = MIN_PEER_PROTO_VERSION) {
         LOCK(cs_vNodes);
-        BOOST_FOREACH(CNode* pnode, vNodes)
-            if(pnode->nVersion >= minProtoVersion)
+        for (auto pnode : vNodes)
+        {
+            if (pnode->nVersion >= minProtoVersion)
                 pnode->PushInventory(inv);
+        }
     }
 
 /*****  *****/

--- a/src/paymentdisclosuredb.cpp
+++ b/src/paymentdisclosuredb.cpp
@@ -3,15 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "paymentdisclosuredb.h"
-
 #include "util.h"
 #include "dbwrapper.h"
-
-#include <boost/filesystem.hpp>
-
 using namespace std;
 
-static boost::filesystem::path emptyPath;
+static fs::path emptyPath;
 
 /**
  * Static method to return the shared/default payment disclosure database.
@@ -26,8 +22,9 @@ shared_ptr<PaymentDisclosureDB> PaymentDisclosureDB::sharedInstance() {
 PaymentDisclosureDB::PaymentDisclosureDB() : PaymentDisclosureDB(emptyPath) {
 }
 
-PaymentDisclosureDB::PaymentDisclosureDB(const boost::filesystem::path& dbPath) {
-    boost::filesystem::path path(dbPath);
+PaymentDisclosureDB::PaymentDisclosureDB(const fs::path& dbPath)
+{
+    fs::path path(dbPath);
     if (path.empty()) {
         path = GetDataDir() / "paymentdisclosure";
         LogPrintf("PaymentDisclosure: using default path for database: %s\n", path.string());

--- a/src/paymentdisclosuredb.h
+++ b/src/paymentdisclosuredb.h
@@ -12,8 +12,7 @@
 #include <mutex>
 #include <future>
 #include <memory>
-
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <leveldb/db.h>
 
@@ -31,7 +30,7 @@ public:
     static std::shared_ptr<PaymentDisclosureDB> sharedInstance();
 
     PaymentDisclosureDB();
-    PaymentDisclosureDB(const boost::filesystem::path& dbPath);
+    PaymentDisclosureDB(const fs::path& dbPath);
     ~PaymentDisclosureDB();
 
     bool Put(const PaymentDisclosureKey& key, const PaymentDisclosureInfo& info);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -45,8 +45,8 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     {
         // Comparing to pindexLast->nHeight with >= because this function
         // returns the work required for the block after pindexLast.
-        if (params.nPowAllowMinDifficultyBlocksAfterHeight != boost::none &&
-            pindexLast->nHeight >= params.nPowAllowMinDifficultyBlocksAfterHeight.get())
+        if (params.nPowAllowMinDifficultyBlocksAfterHeight != std::nullopt &&
+            pindexLast->nHeight >= params.nPowAllowMinDifficultyBlocksAfterHeight.value())
         {
             // Special difficulty rule for testnet:
             // If the new block's timestamp is more than 6 * 2.5 minutes

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -129,7 +129,7 @@ public:
         typedef const T* pointer;
         typedef const T& reference;
         typedef std::bidirectional_iterator_tag iterator_category;
-        const_reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        const_reverse_iterator(const T* ptr_) : ptr(ptr_) {}
         const_reverse_iterator(reverse_iterator x) : ptr(&(*x)) {}
         const T& operator*() const { return *ptr; }
         const T* operator->() const { return ptr; }
@@ -189,7 +189,7 @@ private:
     }
 
     T* item_ptr(difference_type pos) { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
-    const T* item_ptr(difference_type pos) const { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
+    const T* item_ptr(const difference_type pos) const { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
 
 public:
     void assign(size_type n, const T& val) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -152,9 +152,8 @@ static bool rest_headers(HTTPRequest* req,
     }
 
     CDataStream ssHeader(SER_NETWORK, PROTOCOL_VERSION);
-    BOOST_FOREACH(const CBlockIndex *pindex, headers) {
+    for (const auto pindex : headers)
         ssHeader << pindex->GetBlockHeader();
-    }
 
     switch (rf) {
     case RF_BINARY: {
@@ -172,9 +171,8 @@ static bool rest_headers(HTTPRequest* req,
     }
     case RF_JSON: {
         UniValue jsonHeaders(UniValue::VARR);
-        BOOST_FOREACH(const CBlockIndex *pindex, headers) {
+        for (const auto pindex : headers)
             jsonHeaders.push_back(blockheaderToJSON(pindex));
-        }
         string strJSON = jsonHeaders.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);
@@ -561,7 +559,8 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
         objGetUTXOResponse.push_back(Pair("bitmap", bitmapStringRepresentation));
 
         UniValue utxos(UniValue::VARR);
-        BOOST_FOREACH (const CCoin& coin, outs) {
+        for (const auto& coin : outs)
+        {
             UniValue utxo(UniValue::VOBJ);
             utxo.push_back(Pair("txvers", (int32_t)coin.nTxVer));
             utxo.push_back(Pair("height", (int32_t)coin.nHeight));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -80,8 +80,8 @@ double GetNetworkDifficulty(const CBlockIndex* blockindex)
 
 static UniValue ValuePoolDesc(
     const std::string &name,
-    const boost::optional<CAmount> chainValue,
-    const boost::optional<CAmount> valueDelta)
+    const std::optional<CAmount> chainValue,
+    const std::optional<CAmount> valueDelta)
 {
     UniValue rv(UniValue::VOBJ);
     rv.push_back(Pair("id", name));
@@ -140,7 +140,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
     result.push_back(Pair("finalsaplingroot", block.hashFinalSaplingRoot.GetHex()));
     UniValue txs(UniValue::VARR);
-    BOOST_FOREACH(const CTransaction&tx, block.vtx)
+    for (const auto &tx : block.vtx)
     {
         if(txDetails)
         {
@@ -230,7 +230,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
     {
         LOCK(mempool.cs);
         UniValue o(UniValue::VOBJ);
-        BOOST_FOREACH(const CTxMemPoolEntry& e, mempool.mapTx)
+        for (const auto& e : mempool.mapTx)
         {
             const uint256& hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);
@@ -242,17 +242,15 @@ UniValue mempoolToJSON(bool fVerbose = false)
             info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
             const CTransaction& tx = e.GetTx();
             set<string> setDepends;
-            BOOST_FOREACH(const CTxIn& txin, tx.vin)
+            for (const auto &txin : tx.vin)
             {
                 if (mempool.exists(txin.prevout.hash))
                     setDepends.insert(txin.prevout.hash.ToString());
             }
 
             UniValue depends(UniValue::VARR);
-            BOOST_FOREACH(const string& dep, setDepends)
-            {
+            for (const auto& dep : setDepends)
                 depends.push_back(dep);
-            }
 
             info.push_back(Pair("depends", depends));
             o.push_back(Pair(hash.ToString(), info));
@@ -265,7 +263,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
         mempool.queryHashes(vtxid);
 
         UniValue a(UniValue::VARR);
-        BOOST_FOREACH(const uint256& hash, vtxid)
+        for (const auto& hash : vtxid)
             a.push_back(hash.ToString());
 
         return a;
@@ -781,8 +779,8 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
 
     CBlockIndex* tip = chainActive.Tip();
     UniValue valuePools(UniValue::VARR);
-    valuePools.push_back(ValuePoolDesc("sprout", tip->nChainSproutValue, boost::none));
-    valuePools.push_back(ValuePoolDesc("sapling", tip->nChainSaplingValue, boost::none));
+    valuePools.push_back(ValuePoolDesc("sprout", tip->nChainSproutValue, std::nullopt));
+    valuePools.push_back(ValuePoolDesc("sapling", tip->nChainSaplingValue, std::nullopt));
     obj.push_back(Pair("valuePools",            valuePools));
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
@@ -868,11 +866,11 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
        known blocks, and successively remove blocks that appear as pprev
        of another block.  */
     std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
-        setTips.insert(item.second);
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
+    for (const auto &[hash, blockIndex] : mapBlockIndex)
+        setTips.insert(blockIndex);
+    for (const auto& [hash, blockIndex] : mapBlockIndex)
     {
-        const CBlockIndex* pprev = item.second->pprev;
+        const CBlockIndex* pprev = blockIndex->pprev;
         if (pprev)
             setTips.erase(pprev);
     }
@@ -882,7 +880,7 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
 
     /* Construct the output array.  */
     UniValue res(UniValue::VARR);
-    BOOST_FOREACH(const CBlockIndex* block, setTips)
+    for (const auto block : setTips)
     {
         UniValue obj(UniValue::VOBJ);
         obj.push_back(Pair("height", block->nHeight));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -672,7 +672,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     UniValue transactions(UniValue::VARR);
     map<uint256, int64_t> setTxIndex;
     int i = 0;
-    BOOST_FOREACH (const CTransaction& tx, pblock->vtx) {
+    for (const auto& tx : pblock->vtx)
+    {
         uint256 txHash = tx.GetHash();
         setTxIndex[txHash] = i++;
 
@@ -686,7 +687,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         entry.push_back(Pair("hash", txHash.GetHex()));
 
         UniValue deps(UniValue::VARR);
-        BOOST_FOREACH (const CTxIn &in, tx.vin)
+        for (const auto &in : tx.vin)
         {
             if (setTxIndex.count(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -476,9 +476,8 @@ UniValue setmocktime(const UniValue& params, bool fHelp)
     SetMockTime(params[0].get_int64());
 
     uint64_t t = GetTime();
-    BOOST_FOREACH(CNode* pnode, vNodes) {
+    for (auto pnode : vNodes)
         pnode->nLastSend = pnode->nLastRecv = t;
-    }
 
     return NullUniValue;
 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -14,9 +14,6 @@
 #include "util.h"
 #include "version.h"
 #include "deprecation.h"
-
-#include <boost/foreach.hpp>
-
 #include <univalue.h>
 
 using namespace std;
@@ -55,9 +52,8 @@ UniValue ping(const UniValue& params, bool fHelp)
     // Request that each node send a ping during next message processing pass
     LOCK2(cs_main, cs_vNodes);
 
-    BOOST_FOREACH(CNode* pNode, vNodes) {
+    for (auto pNode : vNodes)
         pNode->fPingQueued = true;
-    }
 
     return NullUniValue;
 }
@@ -68,7 +64,8 @@ static void CopyNodeStats(std::vector<CNodeStats>& vstats)
 
     LOCK(cs_vNodes);
     vstats.reserve(vNodes.size());
-    BOOST_FOREACH(CNode* pnode, vNodes) {
+    for(auto pnode : vNodes)
+    {
         CNodeStats stats;
         pnode->copyStats(stats);
         vstats.push_back(stats);
@@ -122,7 +119,8 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
 
     UniValue ret(UniValue::VARR);
 
-    BOOST_FOREACH(const CNodeStats& stats, vstats) {
+    for(const auto& stats : vstats)
+    {
         UniValue obj(UniValue::VOBJ);
         CNodeStateStats statestats;
         bool fStateStats = GetNodeStateStats(stats.nodeid, statestats);
@@ -152,9 +150,8 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
             obj.push_back(Pair("synced_headers", statestats.nSyncHeight));
             obj.push_back(Pair("synced_blocks", statestats.nCommonHeight));
             UniValue heights(UniValue::VARR);
-            BOOST_FOREACH(int height, statestats.vHeightInFlight) {
+            for (auto height : statestats.vHeightInFlight)
                 heights.push_back(height);
-            }
             obj.push_back(Pair("inflight", heights));
         }
         obj.push_back(Pair("whitelisted", stats.fWhitelisted));
@@ -276,14 +273,15 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
     if (params.size() == 1)
     {
         LOCK(cs_vAddedNodes);
-        BOOST_FOREACH(const std::string& strAddNode, vAddedNodes)
+        for(const auto& strAddNode : vAddedNodes)
             laddedNodes.push_back(strAddNode);
     }
     else
     {
         string strNode = params[1].get_str();
         LOCK(cs_vAddedNodes);
-        BOOST_FOREACH(const std::string& strAddNode, vAddedNodes) {
+        for(const auto& strAddNode : vAddedNodes)
+        {
             if (strAddNode == strNode)
             {
                 laddedNodes.push_back(strAddNode);
@@ -297,7 +295,8 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
     UniValue ret(UniValue::VARR);
     if (!fDns)
     {
-        BOOST_FOREACH (const std::string& strAddNode, laddedNodes) {
+        for (const auto& strAddNode : laddedNodes)
+        {
             UniValue obj(UniValue::VOBJ);
             obj.push_back(Pair("addednode", strAddNode));
             ret.push_back(obj);
@@ -306,7 +305,8 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
     }
 
     list<pair<string, vector<CService> > > laddedAddreses(0);
-    BOOST_FOREACH(const std::string& strAddNode, laddedNodes) {
+    for (const auto& strAddNode : laddedNodes)
+    {
         vector<CService> vservNode(0);
         if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
             laddedAddreses.push_back(make_pair(strAddNode, vservNode));
@@ -328,11 +328,13 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
 
         UniValue addresses(UniValue::VARR);
         bool fConnected = false;
-        BOOST_FOREACH(const CService& addrNode, it->second) {
+        for (const auto& addrNode : it->second)
+        {
             bool fFound = false;
             UniValue node(UniValue::VOBJ);
             node.push_back(Pair("address", addrNode.ToString()));
-            BOOST_FOREACH(CNode* pnode, vNodes) {
+            for (auto pnode : vNodes)
+            {
                 if (pnode->addr == addrNode)
                 {
                     fFound = true;
@@ -479,12 +481,12 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);
-        BOOST_FOREACH(const PAIRTYPE(CNetAddr, LocalServiceInfo) &item, mapLocalHost)
+        for (const auto &[address, svcinfo] : mapLocalHost)
         {
             UniValue rec(UniValue::VOBJ);
-            rec.push_back(Pair("address", item.first.ToString()));
-            rec.push_back(Pair("port", item.second.nPort));
-            rec.push_back(Pair("score", item.second.nScore));
+            rec.push_back(Pair("address", address.ToString()));
+            rec.push_back(Pair("port", svcinfo.nPort));
+            rec.push_back(Pair("score", svcinfo.nScore));
             localAddresses.push_back(rec);
         }
     }

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -68,10 +68,11 @@ static const std::string COOKIEAUTH_USER = "__cookie__";
 /** Default name for auth cookie file */
 static const std::string COOKIEAUTH_FILE = ".cookie";
 
-boost::filesystem::path GetAuthCookieFile()
+fs::path GetAuthCookieFile()
 {
-    boost::filesystem::path path(GetArg("-rpccookiefile", COOKIEAUTH_FILE));
-    if (!path.is_complete()) path = GetDataDir() / path;
+    fs::path path(GetArg("-rpccookiefile", COOKIEAUTH_FILE));
+    if (!path.is_absolute()) 
+        path = GetDataDir() / path;
     return path;
 }
 
@@ -85,7 +86,7 @@ bool GenerateAuthCookie(std::string *cookie_out)
      * these are set to 077 in init.cpp unless overridden with -sysperms.
      */
     std::ofstream file;
-    boost::filesystem::path filepath = GetAuthCookieFile();
+    fs::path filepath = GetAuthCookieFile();
     file.open(filepath.string().c_str());
     if (!file.is_open()) {
         LogPrintf("Unable to open cookie authentication file %s for writing\n", filepath.string());
@@ -104,7 +105,7 @@ bool GetAuthCookie(std::string *cookie_out)
 {
     std::ifstream file;
     std::string cookie;
-    boost::filesystem::path filepath = GetAuthCookieFile();
+    fs::path filepath = GetAuthCookieFile();
     file.open(filepath.string().c_str());
     if (!file.is_open())
         return false;
@@ -119,8 +120,8 @@ bool GetAuthCookie(std::string *cookie_out)
 void DeleteAuthCookie()
 {
     try {
-        boost::filesystem::remove(GetAuthCookieFile());
-    } catch (const boost::filesystem::filesystem_error& e) {
+        fs::remove(GetAuthCookieFile());
+    } catch (const fs::filesystem_error& e) {
         LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, e.what());
     }
 }

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -1,18 +1,14 @@
+#pragma once
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_RPCPROTOCOL_H
-#define BITCOIN_RPCPROTOCOL_H
-
 #include <list>
 #include <map>
 #include <stdint.h>
 #include <string>
-#include <boost/filesystem.hpp>
-
 #include <univalue.h>
+#include "fs.h"
 
 //! HTTP status codes
 enum HTTPStatusCode
@@ -82,12 +78,10 @@ std::string JSONRPCReply(const UniValue& result, const UniValue& error, const Un
 UniValue JSONRPCError(int code, const std::string& message);
 
 /** Get name of RPC authentication cookie file */
-boost::filesystem::path GetAuthCookieFile();
+fs::path GetAuthCookieFile();
 /** Generate a new RPC authentication cookie and write it to disk */
 bool GenerateAuthCookie(std::string *cookie_out);
 /** Read the RPC authentication cookie from disk */
 bool GetAuthCookie(std::string *cookie_out);
 /** Delete RPC authentication cookie from disk */
 void DeleteAuthCookie();
-
-#endif // BITCOIN_RPCPROTOCOL_H

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "scheduler.h"
-
 #include "reverselock.h"
 
 #include <assert.h>

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -1,9 +1,7 @@
+#pragma once
 // Copyright (c) 2015 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_SCHEDULER_H
-#define BITCOIN_SCHEDULER_H
 
 //
 // NOTE:
@@ -79,5 +77,3 @@ private:
     bool stopWhenEmpty;
     bool shouldStop() { return stopRequested || (stopWhenEmpty && taskQueue.empty()); }
 };
-
-#endif

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -3,15 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "script/sign.h"
-
 #include "primitives/transaction.h"
 #include "key.h"
 #include "keystore.h"
+#include "script/sign.h"
 #include "script/standard.h"
 #include "uint256.h"
-
-#include <boost/foreach.hpp>
 
 using namespace std;
 
@@ -117,7 +114,8 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
 static CScript PushAll(const vector<valtype>& values)
 {
     CScript result;
-    BOOST_FOREACH(const valtype& v, values) {
+    for (const auto &v : values)
+    {
         if (v.size() == 0) {
             result << OP_0;
         } else if (v.size() == 1 && v[0] >= 1 && v[0] <= 16) {
@@ -210,12 +208,12 @@ static vector<valtype> CombineMultisig(const CScript& scriptPubKey, const BaseSi
 {
     // Combine all the signatures we've got:
     set<valtype> allsigs;
-    BOOST_FOREACH(const valtype& v, sigs1)
+    for (const auto &v : sigs1)
     {
         if (!v.empty())
             allsigs.insert(v);
     }
-    BOOST_FOREACH(const valtype& v, sigs2)
+    for (const auto &v : sigs2)
     {
         if (!v.empty())
             allsigs.insert(v);
@@ -226,7 +224,7 @@ static vector<valtype> CombineMultisig(const CScript& scriptPubKey, const BaseSi
     unsigned int nSigsRequired = vSolutions.front()[0];
     unsigned int nPubKeys = vSolutions.size()-2;
     map<valtype, valtype> sigs;
-    BOOST_FOREACH(const valtype& sig, allsigs)
+    for(const auto& sig : allsigs)
     {
         for (unsigned int i = 0; i < nPubKeys; i++)
         {

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -4,15 +4,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "script/standard.h"
-
+#include "script/script.h"
 #include <base58.h>
 #include "pubkey.h"
-#include "script/script.h"
 #include "util.h"
 #include "utilstrencodings.h"
-
-#include <boost/foreach.hpp>
-
 using namespace std;
 
 typedef vector<unsigned char> valtype;
@@ -71,9 +67,8 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
 
     // Scan templates
     const CScript& script1 = scriptPubKey;
-    BOOST_FOREACH(const PAIRTYPE(txnouttype, CScript)& tplate, mTemplates)
+    for(const auto &[txOut, script2] : mTemplates)
     {
-        const CScript& script2 = tplate.second;
         vSolutionsRet.clear();
 
         opcodetype opcode1, opcode2;
@@ -87,7 +82,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
             if (pc1 == script1.end() && pc2 == script2.end())
             {
                 // Found a match
-                typeRet = tplate.first;
+                typeRet = txOut;
                 if (typeRet == TX_MULTISIG)
                 {
                     // Additional checks for TX_MULTISIG:
@@ -312,7 +307,7 @@ CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys)
     CScript script;
 
     script << CScript::EncodeOP_N(nRequired);
-    BOOST_FOREACH(const CPubKey& key, keys)
+    for (const auto& key : keys)
         script << ToByteVector(key);
     script << CScript::EncodeOP_N(keys.size()) << OP_CHECKMULTISIG;
     return script;

--- a/src/sendalert.cpp
+++ b/src/sendalert.cpp
@@ -97,7 +97,8 @@ void ThreadSendAlert()
     // alert.setSubVer.insert(std::string("/MagicBean:0.7.2/"));
     const std::vector<std::string> useragents = {}; //{"MagicBean", "BeanStalk", "AppleSeed", "EleosZcash"};
 
-    BOOST_FOREACH(const std::string& useragent, useragents) {
+    for (const auto& useragent : useragents)
+    {
     }
 
     // Sanity check
@@ -159,7 +160,7 @@ void ThreadSendAlert()
     int nSent = 0;
     {
         LOCK(cs_vNodes);
-        BOOST_FOREACH(CNode* pnode, vNodes)
+        for (auto pnode : vNodes)
         {
             if (alert2.RelayTo(pnode))
             {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -21,8 +21,7 @@
 #include <string.h>
 #include <utility>
 #include <vector>
-
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "prevector.h"
 
@@ -524,8 +523,8 @@ template<typename Stream, typename T, typename A> inline void Unserialize(Stream
 /**
  * optional
  */
-template<typename Stream, typename T> void Serialize(Stream& os, const boost::optional<T>& item);
-template<typename Stream, typename T> void Unserialize(Stream& is, boost::optional<T>& item);
+template<typename Stream, typename T> void Serialize(Stream& os, const std::optional<T>& item);
+template<typename Stream, typename T> void Unserialize(Stream& is, std::optional<T>& item);
 
 /**
  * array
@@ -752,7 +751,7 @@ inline void Unserialize(Stream& is, std::vector<T, A>& v)
  * optional
  */
 template<typename Stream, typename T>
-void Serialize(Stream& os, const boost::optional<T>& item)
+void Serialize(Stream& os, const std::optional<T>& item)
 {
     // If the value is there, put 0x01 and then serialize the value.
     // If it's not, put 0x00.
@@ -767,13 +766,13 @@ void Serialize(Stream& os, const boost::optional<T>& item)
 }
 
 template<typename Stream, typename T>
-void Unserialize(Stream& is, boost::optional<T>& item)
+void Unserialize(Stream& is, std::optional<T>& item)
 {
     unsigned char discriminant = 0x00;
     Unserialize(is, discriminant);
 
     if (discriminant == 0x00) {
-        item = boost::none;
+        item = std::nullopt;
     } else if (discriminant == 0x01) {
         T object;
         Unserialize(is, object);

--- a/src/support/pagelocker.h
+++ b/src/support/pagelocker.h
@@ -1,10 +1,8 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2013 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_SUPPORT_PAGELOCKER_H
-#define BITCOIN_SUPPORT_PAGELOCKER_H
 
 #include "support/cleanse.h"
 
@@ -173,5 +171,3 @@ void UnlockObject(const T& t)
     memory_cleanse((void*)(&t), sizeof(T));
     LockedPageManager::Instance().UnlockRange((void*)(&t), sizeof(T));
 }
-
-#endif // BITCOIN_SUPPORT_PAGELOCKER_H

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -3,13 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "sync.h"
-
 #include "util.h"
 #include "utilstrencodings.h"
 
 #include <stdio.h>
 
-#include <boost/foreach.hpp>
 #include <boost/thread.hpp>
 
 #ifdef DEBUG_LOCKCONTENTION
@@ -24,8 +22,8 @@ void PrintLockContention(const char* pszName, const char* pszFile, int nLine)
 //
 // Early deadlock detection.
 // Problem being solved:
-//    Thread 1 locks  A, then B, then C
-//    Thread 2 locks  D, then C, then A
+//    Thread 1 locks A, then B, then C
+//    Thread 2 locks D, then C, then A
 //     --> may result in deadlock between the two threads, depending on when they run.
 // Solution implemented here:
 // Keep track of pairs of locks: (A before B), (A before C), etc.
@@ -76,34 +74,39 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
 
     LogPrintf("POTENTIAL DEADLOCK DETECTED\n");
     LogPrintf("Previous lock order was:\n");
-    BOOST_FOREACH (const PAIRTYPE(void*, CLockLocation) & i, s2) {
-        if (i.first == mismatch.first) {
+    for (const auto &[pLock, lockLocation] : s2)
+    {
+        if (pLock == mismatch.first)
+        {
             LogPrintf(" (1)");
-            if (!firstLocked && secondLocked && i.second.fTry)
+            if (!firstLocked && secondLocked && lockLocation.fTry)
                 onlyMaybeDeadlock = true;
             firstLocked = true;
         }
-        if (i.first == mismatch.second) {
+        if (pLock == mismatch.second)
+        {
             LogPrintf(" (2)");
-            if (!secondLocked && firstLocked && i.second.fTry)
+            if (!secondLocked && firstLocked && lockLocation.fTry)
                 onlyMaybeDeadlock = true;
             secondLocked = true;
         }
-        LogPrintf(" %s\n", i.second.ToString());
+        LogPrintf(" %s\n", lockLocation.ToString());
     }
     firstLocked = false;
     secondLocked = false;
     LogPrintf("Current lock order is:\n");
-    BOOST_FOREACH (const PAIRTYPE(void*, CLockLocation) & i, s1) {
-        if (i.first == mismatch.first) {
+    for (const auto &[pLock, lockLocation] : s1) {
+        if (pLock == mismatch.first)
+        {
             LogPrintf(" (1)");
-            if (!firstLocked && secondLocked && i.second.fTry)
+            if (!firstLocked && secondLocked && lockLocation.fTry)
                 onlyMaybeDeadlock = true;
             firstLocked = true;
         }
-        if (i.first == mismatch.second) {
+        if (pLock == mismatch.second)
+        {
             LogPrintf(" (2)");
-            if (!secondLocked && firstLocked && i.second.fTry)
+            if (!secondLocked && firstLocked && lockLocation.fTry)
                 onlyMaybeDeadlock = true;
             secondLocked = true;
         }
@@ -122,16 +125,17 @@ static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
     (*lockstack).push_back(std::make_pair(c, locklocation));
 
     if (!fTry) {
-        BOOST_FOREACH (const PAIRTYPE(void*, CLockLocation) & i, (*lockstack)) {
-            if (i.first == c)
+        for (const auto &[pLock, lockLocation] : (*lockstack))
+        {
+            if (pLock == c)
                 break;
 
-            std::pair<void*, void*> p1 = std::make_pair(i.first, c);
+            std::pair<void*, void*> p1 = std::make_pair(pLock, c);
             if (lockorders.count(p1))
                 continue;
             lockorders[p1] = (*lockstack);
 
-            std::pair<void*, void*> p2 = std::make_pair(c, i.first);
+            std::pair<void*, void*> p2 = std::make_pair(c, pLock);
             if (lockorders.count(p2))
                 potential_deadlock_detected(p1, lockorders[p2], lockorders[p1]);
         }
@@ -159,15 +163,15 @@ void LeaveCritical()
 std::string LocksHeld()
 {
     std::string result;
-    BOOST_FOREACH (const PAIRTYPE(void*, CLockLocation) & i, *lockstack)
-        result += i.second.ToString() + std::string("\n");
+    for (const auto &[pLock, lockLocation] : *lockstack)
+        result += lockLocation.ToString() + std::string("\n");
     return result;
 }
 
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs)
 {
-    BOOST_FOREACH (const PAIRTYPE(void*, CLockLocation) & i, *lockstack)
-        if (i.first == cs)
+    for (const auto& [pLock, lockLocation] : *lockstack)
+        if (pLock == cs)
             return;
     fprintf(stderr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld().c_str());
     abort();

--- a/src/sync.h
+++ b/src/sync.h
@@ -1,10 +1,8 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2013 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_SYNC_H
-#define BITCOIN_SYNC_H
 
 #include "threadsafety.h"
 
@@ -252,13 +250,13 @@ public:
         grant.Release();
         grant.sem = sem;
         grant.fHaveGrant = fHaveGrant;
-        sem = NULL;
+        sem = nullptr;
         fHaveGrant = false;
     }
 
-    CSemaphoreGrant() : sem(NULL), fHaveGrant(false) {}
+    CSemaphoreGrant() : sem(nullptr), fHaveGrant(false) {}
 
-    CSemaphoreGrant(CSemaphore& sema, bool fTry = false) : sem(&sema), fHaveGrant(false)
+    explicit CSemaphoreGrant(CSemaphore& sema, bool fTry = false) : sem(&sema), fHaveGrant(false)
     {
         if (fTry)
             TryAcquire();
@@ -271,10 +269,8 @@ public:
         Release();
     }
 
-    operator bool()
+    operator bool() const noexcept
     {
         return fHaveGrant;
     }
 };
-
-#endif // BITCOIN_SYNC_H

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -23,7 +23,6 @@
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
 extern CWallet* pwalletMain;
@@ -24,10 +23,8 @@ GetResults(CWalletDB& walletdb, std::map<CAmount, CAccountingEntry>& results)
     results.clear();
     BOOST_CHECK(walletdb.ReorderTransactions(pwalletMain) == DB_LOAD_OK);
     walletdb.ListAccountCreditDebit("", aes);
-    BOOST_FOREACH(CAccountingEntry& ae, aes)
-    {
+    for (const auto& ae : aes)
         results[ae.nOrderPos] = ae;
-    }
 }
 
 BOOST_AUTO_TEST_CASE(acc_orderupgrade)

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -24,8 +24,6 @@
 
 #include <fstream>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "key.h"
@@ -262,7 +260,7 @@ struct ReadAlerts : public TestingSetup
     }
     ~ReadAlerts() { }
 
-    static std::vector<std::string> read_lines(boost::filesystem::path filepath)
+    static std::vector<std::string> read_lines(fs::path filepath)
     {
         std::vector<std::string> result;
 
@@ -285,7 +283,7 @@ BOOST_AUTO_TEST_CASE(AlertApplies)
     SetMockTime(11);
     const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::Network::MAIN).AlertKey();
 
-    BOOST_FOREACH(const CAlert& alert, alerts)
+    for (const auto& alert : alerts)
     {
         BOOST_CHECK(alert.CheckSignature(alertKey));
     }
@@ -326,12 +324,12 @@ BOOST_AUTO_TEST_CASE(AlertNotify)
     SetMockTime(11);
     const std::vector<unsigned char>& alertKey = Params(CBaseChainParams::Network::MAIN).AlertKey();
 
-    boost::filesystem::path temp = GetTempPath() /
-        boost::filesystem::unique_path("alertnotify-%%%%.txt");
+    fs::path temp = GetTempPath() /
+        fs::unique_path("alertnotify-%%%%.txt");
 
     mapArgs["-alertnotify"] = std::string("echo %s >> ") + temp.string();
 
-    BOOST_FOREACH(CAlert alert, alerts)
+    for (auto &alert : alerts)
         alert.ProcessAlert(alertKey, false);
 
     std::vector<std::string> r = read_lines(temp);
@@ -355,7 +353,7 @@ BOOST_AUTO_TEST_CASE(AlertNotify)
     BOOST_CHECK_EQUAL(r[4], "'Alert 4, reenables RPC' "); // dashes should be removed
     BOOST_CHECK_EQUAL(r[5], "'Evil Alert; /bin/ls; echo ' ");
 #endif
-    boost::filesystem::remove(temp);
+    fs::remove(temp);
 
     SetMockTime(0);
     mapAlerts.clear();

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -18,7 +18,6 @@
 
 #include <univalue.h>
 
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
 

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -84,7 +84,8 @@ void RunTest(const TestVector &test) {
     CExtPubKey pubkey;
     key.SetMaster(&seed[0], seed.size());
     pubkey = key.Neuter();
-    BOOST_FOREACH(const TestDerivation &derive, test.vDerive) {
+    for (const auto &derive : test.vDerive)
+    {
         unsigned char data[74];
         key.Encode(data);
         pubkey.Encode(data);

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/tuple/tuple.hpp>
 
 using namespace std;
 

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -11,8 +11,6 @@
 
 #include <cstdio>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>
 
 
@@ -20,7 +18,6 @@ BOOST_FIXTURE_TEST_SUITE(CheckBlock_tests, BasicTestingSetup)
 
 bool read_block(const std::string& filename, CBlock& block)
 {
-    namespace fs = boost::filesystem;
     fs::path testFile = fs::current_path() / "data" / filename;
 #ifdef TEST_DATA_DIR
     if (!fs::exists(testFile))

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -836,9 +836,8 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
                     missed_an_entry = true;
                 }
             }
-            BOOST_FOREACH(const CCoinsViewCacheTest *test, stack) {
+            for (const auto test : stack)
                 test->SelfTest();
-            }
         }
 
         if (insecure_rand() % 100 == 0) {

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -14,7 +14,7 @@
                     
 using namespace std;
 using namespace boost::assign; // bring 'operator+=()' into scope
-using namespace boost::filesystem;
+using namespace fs;
          
 // Test if a string consists entirely of null characters
 bool is_null_key(const vector<unsigned char>& key) {

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
@@ -25,7 +24,7 @@ static void ResetArgs(const std::string& strArg)
 
     // Convert to char*:
     std::vector<const char*> vecChar;
-    BOOST_FOREACH(std::string& s, vecArg)
+    for (const auto& s : vecArg)
         vecChar.push_back(s.c_str());
 
     ParseParameters(vecChar.size(), &vecChar[0]);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     SetMockTime(0);
     mempool.clear();
 
-    BOOST_FOREACH(CTransaction *tx, txFirst)
+    for (auto tx : txFirst)
         delete tx;
 
     fCheckpointsEnabled = true;

--- a/src/test/mruset_tests.cpp
+++ b/src/test/mruset_tests.cpp
@@ -53,18 +53,21 @@ BOOST_AUTO_TEST_CASE(mruset_test)
                 mruset<int> mru2 = mru; // Also try making a copy
 
                 // Check that all elements that should be in there, are in there.
-                BOOST_FOREACH(int x, rep) {
+                for (const auto x : rep)
+		{
                     BOOST_CHECK(mru.count(x));
                     BOOST_CHECK(mru2.count(x));
                 }
 
                 // Check that all elements that are in there, should be in there.
-                BOOST_FOREACH(int x, mru) {
+                for (const auto x : mru)
+		{
                     BOOST_CHECK(all.count(x));
                 }
 
                 // Check that all elements that are in there, should be in there.
-                BOOST_FOREACH(int x, mru2) {
+                for (const auto x : mru2)
+		{
                     BOOST_CHECK(all.count(x));
                 }
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -17,7 +17,6 @@
 #include "wallet/wallet_ismine.h"
 #endif
 
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
@@ -34,7 +33,7 @@ sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction,
 
     CScript result;
     result << OP_0; // CHECKMULTISIG bug workaround
-    BOOST_FOREACH(const CKey &key, keys)
+    for (const auto &key : keys)
     {
         vector<unsigned char> vchSig;
         BOOST_CHECK(key.Sign(hash, vchSig));

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -39,17 +39,21 @@ class prevector_tester {
         BOOST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
         BOOST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
         size_t pos = 0;
-        BOOST_FOREACH(const T& v, pre_vector) {
+        for (const T& v : pre_vector)
+	{
              BOOST_CHECK(v == real_vector[pos++]);
         }
-        BOOST_REVERSE_FOREACH(const T& v, pre_vector) {
-             BOOST_CHECK(v == real_vector[--pos]);
+        for (auto it = pre_vector.rbegin(); it != pre_vector.rend(); ++it)
+	{
+             BOOST_CHECK(*it == real_vector[--pos]);
         }
-        BOOST_FOREACH(const T& v, const_pre_vector) {
+        for (const T& v : const_pre_vector)
+	{
              BOOST_CHECK(v == real_vector[pos++]);
         }
-        BOOST_REVERSE_FOREACH(const T& v, const_pre_vector) {
-             BOOST_CHECK(v == real_vector[--pos]);
+        for (auto it = const_pre_vector.rbegin(); it != const_pre_vector.rend(); ++it)
+	{
+             BOOST_CHECK(*it == real_vector[--pos]);
         }
         CDataStream ss1(SER_DISK, 0);
         CDataStream ss2(SER_DISK, 0);

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -31,7 +31,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/format.hpp>
-#include <boost/filesystem.hpp>
 
 #include <univalue.h>
 
@@ -406,9 +405,9 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_exportwallet)
     BOOST_CHECK(addrs.size()==1);
 
     // Set up paths
-    boost::filesystem::path tmppath = boost::filesystem::temp_directory_path();
-    boost::filesystem::path tmpfilename = boost::filesystem::unique_path("%%%%%%%%");
-    boost::filesystem::path exportfilepath = tmppath / tmpfilename;
+    fs::path tmppath = boost::filesystem::temp_directory_path();
+    fs::path tmpfilename = boost::filesystem::unique_path("%%%%%%%%");
+    fs::path exportfilepath = tmppath / tmpfilename;
 
     // export will fail since exportdir is not set
     BOOST_CHECK_THROW(CallRPC(string("z_exportwallet ") + tmpfilename.string()), runtime_error);
@@ -492,8 +491,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_z_importwallet)
     std::string testWalletDump = (formatobject % testKey % testAddr).str();
 
     // write test data to file
-    boost::filesystem::path temp = boost::filesystem::temp_directory_path() /
-            boost::filesystem::unique_path();
+    fs::path temp = boost::filesystem::temp_directory_path() /
+            fs::unique_path();
     const std::string path = temp.string();
     std::ofstream file(path);
     file << testWalletDump;
@@ -965,26 +964,26 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_parameters)
 
     // Test constructor of AsyncRPCOperation_sendmany
     try {
-        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(boost::none, mtx, "",{}, {}, -1));
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::nullopt, mtx, "",{}, {}, -1));
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "Minconf cannot be negative"));
     }
 
     try {
-        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(boost::none, mtx, "",{}, {}, 1));
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::nullopt, mtx, "",{}, {}, 1));
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "From address parameter missing"));
     }
 
     try {
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, "tPmCf9DhN5jv5CgrxDMHRz6wsEjWwM6qJnZ", {}, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, "tPmCf9DhN5jv5CgrxDMHRz6wsEjWwM6qJnZ", {}, {}, 1) );
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "No recipients"));
     }
 
     try {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient("dummy",1.0, "") };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, "INVALID", recipients, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, "INVALID", recipients, {}, 1) );
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "Invalid from address"));
     }
@@ -992,7 +991,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_parameters)
     // Testnet payment addresses begin with 'tZ'.  This test detects an incorrect prefix.
     try {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient("dummy",1.0, "") };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, "tTWgZLnrRJ13fF6YDJmnL32QZqJJD8UfMBcjGhECgF8GTT54SrAkHyvUW5AgbqTF2v4WLRq7Nchrymbr3eyWY2RNoGJjmNL", recipients, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, "tTWgZLnrRJ13fF6YDJmnL32QZqJJD8UfMBcjGhECgF8GTT54SrAkHyvUW5AgbqTF2v4WLRq7Nchrymbr3eyWY2RNoGJjmNL", recipients, {}, 1) );
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "Invalid from address"));
     }
@@ -1001,7 +1000,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_parameters)
     // invokes a method on pwalletMain, which is undefined in the google test environment.
     try {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient("dummy",1.0, "") };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, "tZWgZLnrRJ13fF6YDJmnL32QZqJJD8UfMBcjGhECgF8GTT54SrAkHyvUW5AgbqTF2v4WLRq7Nchrymbr3eyWY2RNoGJjmNL", recipients, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, "tZWgZLnrRJ13fF6YDJmnL32QZqJJD8UfMBcjGhECgF8GTT54SrAkHyvUW5AgbqTF2v4WLRq7Nchrymbr3eyWY2RNoGJjmNL", recipients, {}, 1) );
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "no spending key found for zaddr"));
     }
@@ -1034,7 +1033,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
     // there are no utxos to spend
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1,100.0, "DEADBEEF") };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, taddr1, {}, recipients, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, taddr1, {}, recipients, 1) );
         operation->main();
         BOOST_CHECK(operation->isFailed());
         std::string msg = operation->getErrorMessage();
@@ -1045,7 +1044,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
     {
         try {
             std::vector<SendManyRecipient> recipients = {SendManyRecipient(taddr1, 100.0, "DEADBEEF")};
-            std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(boost::none, mtx, zaddr1, recipients, {}, 0));
+            std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_sendmany(std::nullopt, mtx, zaddr1, recipients, {}, 0));
             BOOST_CHECK(false); // Fail test if an exception is not thrown
         } catch (const UniValue& objError) {
             BOOST_CHECK(find_error(objError, "Minconf cannot be zero when sending from zaddr"));
@@ -1056,7 +1055,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
     // there are no unspent notes to spend
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(taddr1,100.0, "DEADBEEF") };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, zaddr1, recipients, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, zaddr1, recipients, {}, 1) );
         operation->main();
         BOOST_CHECK(operation->isFailed());
         std::string msg = operation->getErrorMessage();
@@ -1066,7 +1065,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
     // get_memo_from_hex_string())
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1,100.0, "DEADBEEF") };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, zaddr1, recipients, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, zaddr1, recipients, {}, 1) );
         std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
@@ -1117,7 +1116,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
     // add_taddr_change_output_to_tx() will append a vout to a raw transaction
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1,100.0, "DEADBEEF") };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, zaddr1, recipients, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, zaddr1, recipients, {}, 1) );
         std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
@@ -1146,7 +1145,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
             SendManyRecipient("tPhxitAoytRWebVC2kFnv8XYfdsKdBuqSkG",CAmount(4.56), ""),
             SendManyRecipient("tPViri8Zo9JTsE4gh9pU9EbtPGnm1L66y1g",CAmount(7.89), ""),
         };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, zaddr1, recipients, {}, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, zaddr1, recipients, {}, 1) );
         std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
@@ -1169,7 +1168,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         // we have the spending key for the dummy recipient zaddr1
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, 0.0005, "ABCD") };
 
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, zaddr1, {}, recipients, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, zaddr1, {}, recipients, 1) );
         std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
@@ -1194,7 +1193,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         // Dummy input so the operation object can be instantiated.
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, 0.0005, "ABCD") };
 
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(boost::none, mtx, zaddr1, {}, recipients, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(std::nullopt, mtx, zaddr1, {}, recipients, 1) );
         std::shared_ptr<AsyncRPCOperation_sendmany> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_sendmany> (operation);
         TEST_FRIEND_AsyncRPCOperation_sendmany proxy(ptr);
 
@@ -1202,7 +1201,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         static_cast<AsyncRPCOperation_sendmany *>(operation.get())->testmode = true;
 
         AsyncJoinSplitInfo info;
-        std::vector<boost::optional < SproutWitness>> witnesses;
+        std::vector<std::optional < SproutWitness>> witnesses;
         uint256 anchor;
         try {
             proxy.perform_joinsplit(info, witnesses, anchor);
@@ -1379,7 +1378,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_encrypted_wallet_zkeys)
     strWalletPass.reserve(100);
     strWalletPass = "hello";
 
-    boost::filesystem::current_path(GetArg("-datadir","/tmp/thisshouldnothappen"));
+    fs::current_path(GetArg("-datadir","/tmp/thisshouldnothappen"));
     BOOST_CHECK(pwalletMain->EncryptWallet(strWalletPass));
 
     // Verify we can still list the keys imported
@@ -1440,7 +1439,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_encrypted_wallet_sapzkeys)
     strWalletPass.reserve(100);
     strWalletPass = "hello";
 
-    boost::filesystem::current_path(GetArg("-datadir","/tmp/thisshouldnothappen"));
+    fs::current_path(GetArg("-datadir","/tmp/thisshouldnothappen"));
     BOOST_CHECK(pwalletMain->EncryptWallet(strWalletPass));
 
     // Verify we can still list the keys imported
@@ -1765,14 +1764,14 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
         "mainnet memo");
 
     try {
-        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_mergetoaddress(boost::none,  mtx, {}, {}, {}, testnetzaddr, -1 ));
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_mergetoaddress(std::nullopt,  mtx, {}, {}, {}, testnetzaddr, -1 ));
         BOOST_FAIL("Should have caused an error");
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "Fee is out of range"));
     }
 
     try {
-        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_mergetoaddress(boost::none, mtx, {}, {}, {}, testnetzaddr, 1));
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, {}, {}, {}, testnetzaddr, 1));
         BOOST_FAIL("Should have caused an error");
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "No inputs"));
@@ -1782,7 +1781,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
 
     try {
         MergeToAddressRecipient badaddr("", "memo");
-        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_mergetoaddress(boost::none, mtx, inputs, {}, {}, badaddr, 1));
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, {}, {}, badaddr, 1));
         BOOST_FAIL("Should have caused an error");
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "Recipient parameter missing"));
@@ -1795,7 +1794,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
 
     // Sprout and Sapling inputs -> throw
     try {
-        auto operation = new AsyncRPCOperation_mergetoaddress(boost::none, mtx, inputs, sproutNoteInputs, saplingNoteInputs, testnetzaddr, 1);
+        auto operation = new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, sproutNoteInputs, saplingNoteInputs, testnetzaddr, 1);
         BOOST_FAIL("Should have caused an error");
     } catch (const UniValue& objError) {
         BOOST_CHECK(find_error(objError, "Cannot send from both Sprout and Sapling addresses using z_mergetoaddress"));
@@ -1811,7 +1810,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
     // Testnet payment addresses begin with 'tZ'.  This test detects an incorrect prefix.
     try {
         std::vector<MergeToAddressInputUTXO> inputs = { MergeToAddressInputUTXO{ COutPoint{uint256(), 0}, 0, CScript()} };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(boost::none, mtx, inputs, {}, {}, mainnetzaddr, 1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, {}, {}, mainnetzaddr, 1) );
         BOOST_FAIL("Should have caused an error");
     } catch (const UniValue& objError) {
         BOOST_CHECK( find_error(objError, "Invalid recipient address"));
@@ -1844,7 +1843,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
     // Insufficient funds
     {
         std::vector<MergeToAddressInputUTXO> inputs = { MergeToAddressInputUTXO{COutPoint{uint256(),0},0, CScript()} };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(boost::none, mtx, inputs, {}, {}, zaddr1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, {}, {}, zaddr1) );
         operation->main();
         BOOST_CHECK(operation->isFailed());
         std::string msg = operation->getErrorMessage();
@@ -1854,7 +1853,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
     // get_memo_from_hex_string())
     {
         std::vector<MergeToAddressInputUTXO> inputs = { MergeToAddressInputUTXO{COutPoint{uint256(),0},100000, CScript()} };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(boost::none, mtx, inputs, {}, {}, zaddr1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, {}, {}, zaddr1) );
         std::shared_ptr<AsyncRPCOperation_mergetoaddress> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_mergetoaddress> (operation);
         TEST_FRIEND_AsyncRPCOperation_mergetoaddress proxy(ptr);
 
@@ -1908,7 +1907,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
     {
         // Dummy input so the operation object can be instantiated.
         std::vector<MergeToAddressInputUTXO> inputs = { MergeToAddressInputUTXO{COutPoint{uint256(),0},100000, CScript()} };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(boost::none, mtx, inputs, {}, {}, zaddr1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, {}, {}, zaddr1) );
         std::shared_ptr<AsyncRPCOperation_mergetoaddress> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_mergetoaddress> (operation);
         TEST_FRIEND_AsyncRPCOperation_mergetoaddress proxy(ptr);
 
@@ -1916,7 +1915,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
         static_cast<AsyncRPCOperation_sendmany *>(operation.get())->testmode = true;
 
         MergeToAddressJSInfo info;
-        std::vector<boost::optional < SproutWitness>> witnesses;
+        std::vector<std::optional < SproutWitness>> witnesses;
         uint256 anchor;
         try {
             proxy.perform_joinsplit(info, witnesses, anchor);
@@ -1969,7 +1968,7 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_internals)
 
         // we have the spending key for the dummy recipient zaddr1
         std::vector<MergeToAddressInputUTXO> inputs = { MergeToAddressInputUTXO{COutPoint{uint256(),0},100000, CScript()} };
-        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(boost::none, mtx, inputs, {}, {}, zaddr1) );
+        std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, {}, {}, zaddr1) );
         std::shared_ptr<AsyncRPCOperation_mergetoaddress> ptr = std::dynamic_pointer_cast<AsyncRPCOperation_mergetoaddress> (operation);
         TEST_FRIEND_AsyncRPCOperation_mergetoaddress proxy(ptr);
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -25,7 +25,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
 
@@ -547,7 +546,8 @@ BOOST_AUTO_TEST_CASE(script_build)
     std::string strGood;
     std::string strBad;
 
-    BOOST_FOREACH(TestBuilder& test, good) {
+    for(auto& test : good)
+    {
         test.Test(true);
         std::string str = test.GetJSON().write();
 #ifndef UPDATE_JSON_TESTS
@@ -557,7 +557,8 @@ BOOST_AUTO_TEST_CASE(script_build)
 #endif
         strGood += str + ",\n";
     }
-    BOOST_FOREACH(TestBuilder& test, bad) {
+    for (auto& test : bad)
+    {
         test.Test(false);
         std::string str = test.GetJSON().write();
 #ifndef UPDATE_JSON_TESTS
@@ -688,7 +689,7 @@ sign_multisig(CScript scriptPubKey, std::vector<CKey> keys, CTransaction transac
     // and vice-versa)
     //
     result << OP_0;
-    BOOST_FOREACH(const CKey &key, keys)
+    for (const auto &key : keys)
     {
         vector<unsigned char> vchSig;
         BOOST_CHECK(key.Sign(hash, vchSig));

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -12,7 +12,6 @@
 #include <stdint.h>
 
 #include <boost/test/unit_test.hpp>
-#include <boost/optional.hpp>
 
 using namespace std;
 
@@ -83,15 +82,15 @@ public:
 
 BOOST_AUTO_TEST_CASE(boost_optional)
 {
-    check_ser_rep<boost::optional<unsigned char>>(0xff, {0x01, 0xff});
-    check_ser_rep<boost::optional<unsigned char>>(boost::none, {0x00});
-    check_ser_rep<boost::optional<std::string>>(std::string("Test"), {0x01, 0x04, 'T', 'e', 's', 't'});
+    check_ser_rep<std::optional<unsigned char>>(0xff, {0x01, 0xff});
+    check_ser_rep<std::optional<unsigned char>>(std::nullopt, {0x00});
+    check_ser_rep<std::optional<std::string>>(std::string("Test"), {0x01, 0x04, 'T', 'e', 's', 't'});
 
     {
         // Ensure that canonical optional discriminant is used
         CDataStream ss(SER_DISK, 0);
         ss.write("\x02\x04Test", 6);
-        boost::optional<std::string> into;
+        std::optional<std::string> into;
 
         BOOST_CHECK_THROW(ss >> into, std::ios_base::failure);
     }

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -11,7 +11,6 @@
 
 #include <vector>
 
-#include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace std;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -22,7 +22,6 @@
 #include "wallet/wallet.h"
 #endif
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
@@ -42,16 +41,16 @@ extern void noui_connect();
 
 JoinSplitTestingSetup::JoinSplitTestingSetup()
 {
-    boost::filesystem::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
-    boost::filesystem::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
+    fs::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
+    fs::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
     pzcashParams = ZCJoinSplit::Prepared(vk_path.string(), pk_path.string());
 
-    boost::filesystem::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
-    boost::filesystem::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
-    boost::filesystem::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
+    fs::path sapling_spend = ZC_GetParamsDir() / "sapling-spend.params";
+    fs::path sapling_output = ZC_GetParamsDir() / "sapling-output.params";
+    fs::path sprout_groth16 = ZC_GetParamsDir() / "sprout-groth16.params";
 
     static_assert(
-        sizeof(boost::filesystem::path::value_type) == sizeof(codeunit),
+        sizeof(fs::path::value_type) == sizeof(codeunit),
         "librustzcash not configured correctly");
     auto sapling_spend_str = sapling_spend.native();
     auto sapling_output_str = sapling_output.native();
@@ -101,11 +100,11 @@ TestingSetup::TestingSetup()
 #endif
 
         // Save current path, in case a test changes it
-        orig_current_path = boost::filesystem::current_path();
+        orig_current_path = fs::current_path();
 
         ClearDatadirCache();
         pathTemp = GetTempPath() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
-        boost::filesystem::create_directories(pathTemp);
+        fs::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();
         pblocktree = new CBlockTreeDB(1 << 20, true);
         pcoinsdbview = new CCoinsViewDB(1 << 23, true);
@@ -143,9 +142,8 @@ TestingSetup::~TestingSetup()
 #endif
 
         // Restore the previous current path so temporary directory can be deleted
-        boost::filesystem::current_path(orig_current_path);
-
-        boost::filesystem::remove_all(pathTemp);
+        fs::current_path(orig_current_path);
+        fs::remove_all(pathTemp);
 }
 
 

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -5,7 +5,6 @@
 #include "pubkey.h"
 #include "txdb.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
 /** Basic testing setup.
@@ -30,8 +29,8 @@ struct JoinSplitTestingSetup: public BasicTestingSetup {
  */
 struct TestingSetup: public JoinSplitTestingSetup {
     CCoinsViewDB *pcoinsdbview;
-    boost::filesystem::path orig_current_path;
-    boost::filesystem::path pathTemp;
+    fs::path orig_current_path;
+    fs::path pathTemp;
     boost::thread_group threadGroup;
 
     TestingSetup();

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -65,7 +65,7 @@ unsigned int ParseScriptFlags(string strFlags)
     vector<string> words;
     boost::algorithm::split(words, strFlags, boost::algorithm::is_any_of(","));
 
-    BOOST_FOREACH(string word, words)
+    for (const auto &word : words)
     {
         if (!mapFlagNames.count(word))
             BOOST_ERROR("Bad test: unknown verification flag '" << word << "'");

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -9,9 +9,6 @@
 #include "ui_interface.h"
 #include "util.h"
 #include "utilstrencodings.h"
-
-#include <boost/foreach.hpp>
-
 using namespace std;
 
 static CCriticalSection cs_nTimeOffset;
@@ -92,9 +89,11 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
             {
                 // If nobody has a time different than ours but within 5 minutes of ours, give a warning
                 bool fMatch = false;
-                BOOST_FOREACH(int64_t nOffset, vSorted)
+                for (const auto &nOffset : vSorted)
+                {
                     if (nOffset != 0 && abs64(nOffset) < 5 * 60)
                         fMatch = true;
+                }
 
                 if (!fMatch)
                 {
@@ -107,7 +106,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
             }
         }
         if (fDebug) {
-            BOOST_FOREACH(int64_t n, vSorted)
+            for (const auto &n : vSorted)
                 LogPrintf("%+d  ", n);
             LogPrintf("|  ");
         }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -17,7 +17,6 @@
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -488,7 +487,8 @@ void TorController::add_onion_cb(TorControlConnection& conn, const TorControlRep
 {
     if (reply.code == 250) {
         LogPrint("tor", "tor: ADD_ONION successful\n");
-        BOOST_FOREACH(const std::string &s, reply.lines) {
+        for (const auto &s : reply.lines)
+        {
             std::map<std::string,std::string> m = ParseTorReplyMapping(s);
             std::map<std::string,std::string>::iterator i;
             if ((i = m.find("ServiceID")) != m.end())
@@ -618,7 +618,8 @@ void TorController::protocolinfo_cb(TorControlConnection& conn, const TorControl
          * 250-AUTH METHODS=NULL
          * 250-AUTH METHODS=HASHEDPASSWORD
          */
-        BOOST_FOREACH(const std::string &s, reply.lines) {
+        for (const auto &s : reply.lines)
+        {
             std::pair<std::string,std::string> l = SplitTorReplyLine(s);
             if (l.first == "AUTH") {
                 std::map<std::string,std::string> m = ParseTorReplyMapping(l.second);
@@ -635,9 +636,8 @@ void TorController::protocolinfo_cb(TorControlConnection& conn, const TorControl
                 }
             }
         }
-        BOOST_FOREACH(const std::string &s, methods) {
+        for (const auto &s : methods)
             LogPrint("tor", "tor: Supported authentication method: %s\n", s);
-        }
         // Prefer NULL, otherwise SAFECOOKIE. If a password is provided, use HASHEDPASSWORD
         /* Authentication:
          *   cookie:   hex-encoded ~/.tor/control_auth_cookie

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -1,3 +1,4 @@
+#pragma once
 // Copyright (c) 2015 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -5,9 +6,6 @@
 /**
  * Functionality for communicating with Tor.
  */
-#ifndef BITCOIN_TORCONTROL_H
-#define BITCOIN_TORCONTROL_H
-
 #include "scheduler.h"
 
 extern const std::string DEFAULT_TOR_CONTROL;
@@ -16,5 +14,3 @@ static const bool DEFAULT_LISTEN_ONION = true;
 void StartTorControl(boost::thread_group& threadGroup, CScheduler& scheduler);
 void InterruptTorControl();
 void StopTorControl();
-
-#endif /* BITCOIN_TORCONTROL_H */

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -26,25 +26,21 @@ TransactionBuilderResult::TransactionBuilderResult(const CTransaction& tx) : may
 
 TransactionBuilderResult::TransactionBuilderResult(const std::string& error) : maybeError(error) {}
 
-bool TransactionBuilderResult::IsTx() { return maybeTx != boost::none; }
+bool TransactionBuilderResult::IsTx() { return maybeTx != std::nullopt; }
 
-bool TransactionBuilderResult::IsError() { return maybeError != boost::none; }
+bool TransactionBuilderResult::IsError() { return maybeError != std::nullopt; }
 
 CTransaction TransactionBuilderResult::GetTxOrThrow() {
-    if (maybeTx) {
-        return maybeTx.get();
-    } else {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Failed to build transaction: " + GetError());
-    }
+    if (maybeTx.has_value())
+        return maybeTx.value();
+    throw JSONRPCError(RPC_WALLET_ERROR, "Failed to build transaction: " + GetError());
 }
 
 std::string TransactionBuilderResult::GetError() {
-    if (maybeError) {
-        return maybeError.get();
-    } else {
-        // This can only happen if isTx() is true in which case we should not call getError()
-        throw std::runtime_error("getError() was called in TransactionBuilderResult, but the result was not initialized as an error.");
-    }
+    if (maybeError.has_value())
+        return maybeError.value();
+    // This can only happen if isTx() is true in which case we should not call getError()
+    throw std::runtime_error("getError() was called in TransactionBuilderResult, but the result was not initialized as an error.");
 }
 
 TransactionBuilder::TransactionBuilder(
@@ -120,7 +116,7 @@ void TransactionBuilder::SetFee(CAmount fee)
 void TransactionBuilder::SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk)
 {
     zChangeAddr = std::make_pair(ovk, changeAddr);
-    tChangeAddr = boost::none;
+    tChangeAddr = std::nullopt;
 }
 
 void TransactionBuilder::SendChangeTo(CTxDestination& changeAddr)
@@ -130,7 +126,7 @@ void TransactionBuilder::SendChangeTo(CTxDestination& changeAddr)
     }
 
     tChangeAddr = changeAddr;
-    zChangeAddr = boost::none;
+    zChangeAddr = std::nullopt;
 }
 
 TransactionBuilderResult TransactionBuilder::Build()
@@ -231,7 +227,7 @@ TransactionBuilderResult TransactionBuilder::Build()
             librustzcash_sapling_proving_ctx_free(ctx);
             return TransactionBuilderResult("Failed to encrypt note");
         }
-        auto enc = res.get();
+        auto enc = res.value();
         auto encryptor = enc.second;
 
         OutputDescription odesc;

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -15,8 +15,7 @@
 #include "zcash/IncrementalMerkleTree.hpp"
 #include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
-
-#include <boost/optional.hpp>
+#include <optional>
 
 struct SpendDescriptionInfo {
     libzcash::SaplingExpandedSpendingKey expsk;
@@ -54,8 +53,8 @@ struct TransparentInputInfo {
 
 class TransactionBuilderResult {
 private:
-    boost::optional<CTransaction> maybeTx;
-    boost::optional<std::string> maybeError;
+    std::optional<CTransaction> maybeTx;
+    std::optional<std::string> maybeError;
 public:
     TransactionBuilderResult() = delete;
     TransactionBuilderResult(const CTransaction& tx);
@@ -79,8 +78,8 @@ private:
     std::vector<OutputDescriptionInfo> outputs;
     std::vector<TransparentInputInfo> tIns;
 
-    boost::optional<std::pair<uint256, libzcash::SaplingPaymentAddress>> zChangeAddr;
-    boost::optional<CTxDestination> tChangeAddr;
+    std::optional<std::pair<uint256, libzcash::SaplingPaymentAddress>> zChangeAddr;
+    std::optional<CTxDestination> tChangeAddr;
 
 public:
     TransactionBuilder() {}

--- a/src/util.h
+++ b/src/util.h
@@ -1,3 +1,4 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
@@ -7,9 +8,6 @@
  * Server/client environment: argument handling, config file parsing,
  * logging, thread wrappers
  */
-#ifndef BITCOIN_UTIL_H
-#define BITCOIN_UTIL_H
-
 #if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
 #endif
@@ -17,6 +15,7 @@
 #include "compat.h"
 #include "tinyformat.h"
 #include "utiltime.h"
+#include "fs.h"
 
 #include <atomic>
 #include <exception>
@@ -24,8 +23,8 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <optional>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
 
@@ -56,12 +55,12 @@ extern CTranslationInterface translationInterface;
 [[noreturn]] extern void new_handler_terminate();
 
 /**
- * Translation function: Call Translate signal on UI interface, which returns a boost::optional result.
+ * Translation function: Call Translate signal on UI interface, which returns a std::optional result.
  * If no translation slot is registered, nothing is returned, and simply return the input.
  */
 inline std::string _(const char* psz)
 {
-    boost::optional<std::string> rv = translationInterface.Translate(psz);
+    auto rv = translationInterface.Translate(psz);
     return rv ? (*rv) : psz;
 }
 
@@ -99,7 +98,7 @@ bool error(const char* fmt, const Args&... args)
     return false;
 }
 
-const boost::filesystem::path &ZC_GetParamsDir();
+const fs::path& ZC_GetParamsDir();
 
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
 void ParseParameters(int argc, const char*const argv[]);
@@ -107,15 +106,15 @@ void FileCommit(FILE *fileout);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
-bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);
-bool TryCreateDirectory(const boost::filesystem::path& p);
-boost::filesystem::path GetDefaultDataDir();
-const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
+bool RenameOver(fs::path src, fs::path dest);
+bool TryCreateDirectory(const fs::path& p);
+fs::path GetDefaultDataDir();
+const fs::path& GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
-boost::filesystem::path GetConfigFile();
+fs::path GetConfigFile();
 #ifndef WIN32
-boost::filesystem::path GetPidFile();
-void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
+fs::path GetPidFile();
+void CreatePidFile(const fs::path& path, pid_t pid);
 #endif
 class missing_pastel_conf : public std::runtime_error {
 public:
@@ -123,13 +122,13 @@ public:
 };
 void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
 #ifdef WIN32
-boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
-boost::filesystem::path GetTempPath();
+fs::path GetTempPath();
 void OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(const std::string& strCommand);
-const boost::filesystem::path GetExportDir();
+const fs::path GetExportDir();
 
 /** Returns privacy notice (for -version, -help and metrics screen) */
 std::string PrivacyInfo();
@@ -270,5 +269,3 @@ public:
         return ((nRw << 16) + nRz) % nMax;
     }
 };
-
-#endif // BITCOIN_UTIL_H

--- a/src/wallet/asyncrpcoperation_mergetoaddress.h
+++ b/src/wallet/asyncrpcoperation_mergetoaddress.h
@@ -48,7 +48,7 @@ struct MergeToAddressJSInfo {
 
 // A struct to help us track the witness and anchor for a given JSOutPoint
 struct MergeToAddressWitnessAnchorData {
-    boost::optional<SproutWitness> witness;
+    std::optional<SproutWitness> witness;
     uint256 anchor;
 };
 
@@ -56,7 +56,7 @@ class AsyncRPCOperation_mergetoaddress : public AsyncRPCOperation
 {
 public:
     AsyncRPCOperation_mergetoaddress(
-        boost::optional<TransactionBuilder> builder,
+        std::optional<TransactionBuilder> builder,
         CMutableTransaction contextualTx,
         std::vector<MergeToAddressInputUTXO> utxoInputs,
         std::vector<MergeToAddressInputSproutNote> sproutNoteInputs,
@@ -120,7 +120,7 @@ private:
     // JoinSplit where you have the witnesses and anchor
     UniValue perform_joinsplit(
         MergeToAddressJSInfo& info,
-        std::vector<boost::optional<SproutWitness>> witnesses,
+        std::vector<std::optional<SproutWitness>> witnesses,
         uint256 anchor);
 
     void sign_send_raw_transaction(UniValue obj); // throws exception if there was an error
@@ -180,7 +180,7 @@ public:
 
     UniValue perform_joinsplit(
         MergeToAddressJSInfo& info,
-        std::vector<boost::optional<SproutWitness>> witnesses,
+        std::vector<std::optional<SproutWitness>> witnesses,
         uint256 anchor)
     {
         return delegate->perform_joinsplit(info, witnesses, anchor);

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -46,14 +46,14 @@ struct AsyncJoinSplitInfo
 
 // A struct to help us track the witness and anchor for a given JSOutPoint
 struct WitnessAnchorData {
-	boost::optional<SproutWitness> witness;
+	std::optional<SproutWitness> witness;
 	uint256 anchor;
 };
 
 class AsyncRPCOperation_sendmany : public AsyncRPCOperation {
 public:
     AsyncRPCOperation_sendmany(
-        boost::optional<TransactionBuilder> builder,
+        std::optional<TransactionBuilder> builder,
         CMutableTransaction contextualTx,
         std::string fromAddress,
         std::vector<SendManyRecipient> tOutputs,
@@ -124,7 +124,7 @@ private:
     // JoinSplit where you have the witnesses and anchor
     UniValue perform_joinsplit(
         AsyncJoinSplitInfo & info,
-        std::vector<boost::optional < SproutWitness>> witnesses,
+        std::vector<std::optional < SproutWitness>> witnesses,
         uint256 anchor);
 
     void sign_send_raw_transaction(UniValue obj);     // throws exception if there was an error
@@ -185,7 +185,7 @@ public:
 
     UniValue perform_joinsplit(
         AsyncJoinSplitInfo & info,
-        std::vector<boost::optional < SproutWitness>> witnesses,
+        std::vector<std::optional < SproutWitness>> witnesses,
         uint256 anchor)
     {
         return delegate->perform_joinsplit(info, witnesses, anchor);

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <vector>
-#include <boost/foreach.hpp>
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 
@@ -572,7 +571,7 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
             }
             hdSeed = HDSeed();
         }
-        BOOST_FOREACH(KeyMap::value_type& mKey, mapKeys)
+        for (const auto& mKey : mapKeys)
         {
             const CKey &key = mKey.second;
             CPubKey vchPubKey = key.GetPubKey();
@@ -586,7 +585,7 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
             }
         }
         mapKeys.clear();
-        BOOST_FOREACH(SproutSpendingKeyMap::value_type& mSproutSpendingKey, mapSproutSpendingKeys)
+        for (const auto& mSproutSpendingKey : mapSproutSpendingKeys)
         {
             const libzcash::SproutSpendingKey &sk = mSproutSpendingKey.second;
             CSecureDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
@@ -603,7 +602,7 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
         }
         mapSproutSpendingKeys.clear();
         //! Sapling key support
-        BOOST_FOREACH(SaplingSpendingKeyMap::value_type& mSaplingSpendingKey, mapSaplingSpendingKeys)
+        for (const auto& mSaplingSpendingKey : mapSaplingSpendingKeys)
         {
             const auto &sk = mSaplingSpendingKey.second;
             CSecureDataStream ss(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -17,7 +17,6 @@
 #include <sys/stat.h>
 #endif
 
-#include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 #include <boost/version.hpp>
 
@@ -71,7 +70,7 @@ void CDBEnv::Close()
     EnvShutdown();
 }
 
-bool CDBEnv::Open(const boost::filesystem::path& pathIn)
+bool CDBEnv::Open(const fs::path& pathIn)
 {
     if (fDbEnvInit)
         return true;
@@ -79,9 +78,9 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
     boost::this_thread::interruption_point();
 
     strPath = pathIn.string();
-    boost::filesystem::path pathLogDir = pathIn / "database";
+    fs::path pathLogDir = pathIn / "database";
     TryCreateDirectory(pathLogDir);
-    boost::filesystem::path pathErrorFile = pathIn / "db.log";
+    fs::path pathErrorFile = pathIn / "db.log";
     LogPrintf("CDBEnv::Open: LogDir=%s ErrorFile=%s\n", pathLogDir.string(), pathErrorFile.string());
 
     unsigned int nEnvFlags = 0;
@@ -455,7 +454,7 @@ void CDBEnv::Flush(bool fShutdown)
                 dbenv->log_archive(&listp, DB_ARCH_REMOVE);
                 Close();
                 if (!fMockDb)
-                    boost::filesystem::remove_all(boost::filesystem::path(strPath) / "database");
+                    fs::remove_all(fs::path(strPath) / "database");
             }
         }
     }

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -16,8 +16,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem/path.hpp>
-
 #include <db_cxx.h>
 
 extern unsigned int nWalletDBUpdated;
@@ -27,7 +25,7 @@ class CDBEnv
 private:
     bool fDbEnvInit;
     bool fMockDb;
-    // Don't change into boost::filesystem::path, as that can result in
+    // Don't change into fs::path, as that can result in
     // shutdown problems/crashes caused by a static initialized internal pointer.
     std::string strPath;
 
@@ -66,7 +64,7 @@ public:
     typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char> > KeyValPair;
     bool Salvage(const std::string& strFile, bool fAggressive, std::vector<KeyValPair>& vResult);
 
-    bool Open(const boost::filesystem::path& path);
+    bool Open(const fs::path& path);
     void Close();
     void Flush(bool fShutdown);
     void CheckpointLSN(const std::string& strFile);

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -15,8 +15,6 @@
 #include "zcash/Note.hpp"
 #include "zcash/NoteEncryption.hpp"
 
-#include <boost/filesystem.hpp>
-
 using ::testing::Return;
 
 extern ZCJoinSplit* params;
@@ -124,8 +122,8 @@ std::pair<JSOutPoint, SaplingOutPoint> CreateValidBlock(TestWallet& wallet,
 std::pair<uint256, uint256> GetWitnessesAndAnchors(TestWallet& wallet,
                                 std::vector<JSOutPoint>& sproutNotes,
                                 std::vector<SaplingOutPoint>& saplingNotes,
-                                std::vector<boost::optional<SproutWitness>>& sproutWitnesses,
-                                std::vector<boost::optional<SaplingWitness>>& saplingWitnesses) {
+                                std::vector<std::optional<SproutWitness>>& sproutWitnesses,
+                                std::vector<std::optional<SaplingWitness>>& saplingWitnesses) {
     sproutWitnesses.clear();
     saplingWitnesses.clear();
     uint256 sproutAnchor;
@@ -137,8 +135,8 @@ std::pair<uint256, uint256> GetWitnessesAndAnchors(TestWallet& wallet,
 
 TEST(WalletTests, SetupDatadirLocationRunAsFirstTest) {
     // Get temporary and unique path for file.
-    boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
-    boost::filesystem::create_directories(pathTemp);
+    fs::path pathTemp = fs::temp_directory_path() / fs::unique_path();
+    fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 }
 
@@ -372,7 +370,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
     auto pk = sk.DefaultAddress();
 
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().get();
+    auto cm = note.cm().value();
     SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
@@ -380,7 +378,7 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx) {
 
     auto nf = note.nullifier(fvk, witness.position());
     ASSERT_TRUE(nf);
-    uint256 nullifier = nf.get();
+    uint256 nullifier = nf.value();
 
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
@@ -493,7 +491,7 @@ TEST(WalletTests, FindMySaplingNotes) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().get();
+    auto cm = note.cm().value();
     SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
@@ -631,7 +629,7 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
 
     // Generate note A
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().get();
+    auto cm = note.cm().value();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();
@@ -679,15 +677,15 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
             wtx.vShieldedOutput[0].ephemeralKey,
             wtx.vShieldedOutput[0].cm);
     ASSERT_EQ(static_cast<bool>(maybe_pt), true);
-    auto maybe_note = maybe_pt.get().note(ivk);
+    auto maybe_note = maybe_pt.value().note(ivk);
     ASSERT_EQ(static_cast<bool>(maybe_note), true);
-    auto note2 = maybe_note.get();
+    auto note2 = maybe_note.value();
 
     SaplingOutPoint sop0(wtx.GetHash(), 0);
     auto spend_note_witness =  wtx.mapSaplingNoteData[sop0].witnesses.front();
     auto maybe_nf = note2.nullifier(fvk, spend_note_witness.position());
     ASSERT_EQ(static_cast<bool>(maybe_nf), true);
-    auto nullifier2 = maybe_nf.get();
+    auto nullifier2 = maybe_nf.value();
 
     anchor = saplingTree.root();
 
@@ -790,7 +788,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().get();
+    auto cm = note.cm().value();
     SaplingMerkleTree tree;
     tree.append(cm);
     auto anchor = tree.root();
@@ -809,7 +807,7 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     // Manually compute the nullifier based on the known position
     auto nf = note.nullifier(fvk, witness.position());
     ASSERT_TRUE(nf);
-    uint256 nullifier = nf.get();
+    uint256 nullifier = nf.value();
 
     // Verify note has not been spent
     EXPECT_FALSE(wallet.IsSaplingSpent(nullifier));
@@ -885,7 +883,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().get();
+    auto cm = note.cm().value();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();
@@ -904,7 +902,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     // Manually compute the nullifier based on the expected position
     auto nf = note.nullifier(fvk, witness.position());
     ASSERT_TRUE(nf);
-    uint256 nullifier = nf.get();
+    uint256 nullifier = nf.value();
 
     // Verify dummy note is unspent
     EXPECT_FALSE(wallet.IsSaplingSpent(nullifier));
@@ -956,7 +954,7 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
         EXPECT_EQ(hash, op.hash);
         EXPECT_EQ(1, nd.witnesses.size());
         ASSERT_TRUE(nd.nullifier);
-        auto nf = nd.nullifier.get();
+        auto nf = nd.nullifier.value();
         EXPECT_EQ(1, wallet.mapSaplingNullifiersToNotes.count(nf));
         EXPECT_EQ(op.hash, wallet.mapSaplingNullifiersToNotes[nf].hash);
         EXPECT_EQ(op.n, wallet.mapSaplingNullifiersToNotes[nf].n);
@@ -1019,7 +1017,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
 
     // Generate Sapling note A
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().get();
+    auto cm = note.cm().value();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();
@@ -1071,7 +1069,7 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     // Manually compute the nullifier and check map entry does not exist
     auto nf = note.nullifier(fvk, witness.position());
     ASSERT_TRUE(nf);
-    ASSERT_FALSE(wallet.mapSaplingNullifiersToNotes.count(nf.get()));
+    ASSERT_FALSE(wallet.mapSaplingNullifiersToNotes.count(nf.value()));
 
     // Decrypt note B
     auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
@@ -1080,16 +1078,16 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
         wtx.vShieldedOutput[0].ephemeralKey,
         wtx.vShieldedOutput[0].cm);
     ASSERT_EQ(static_cast<bool>(maybe_pt), true);
-    auto maybe_note = maybe_pt.get().note(ivk);
+    auto maybe_note = maybe_pt.value().note(ivk);
     ASSERT_EQ(static_cast<bool>(maybe_note), true);
-    auto note2 = maybe_note.get();
+    auto note2 = maybe_note.value();
 
     // Get witness to retrieve position of note B we want to spend
     SaplingOutPoint sop0(wtx.GetHash(), 0);
     auto spend_note_witness =  wtx.mapSaplingNoteData[sop0].witnesses.front();
     auto maybe_nf = note2.nullifier(fvk, spend_note_witness.position());
     ASSERT_EQ(static_cast<bool>(maybe_nf), true);
-    auto nullifier2 = maybe_nf.get();
+    auto nullifier2 = maybe_nf.value();
 
     // NOTE: Not updating the anchor results in a core dump.  Shouldn't builder just return error?
     // *** Error in `./zcash-gtest': double free or corruption (out): 0x00007ffd8755d990 ***
@@ -1170,8 +1168,8 @@ TEST(WalletTests, CachedWitnessesEmptyChain) {
     std::vector<JSOutPoint> sproutNotes {jsoutpt, jsoutpt2};
     std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
 
-    std::vector<boost::optional<SproutWitness>> sproutWitnesses;
-    std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
+    std::vector<std::optional<SproutWitness>> sproutWitnesses;
+    std::vector<std::optional<SaplingWitness>> saplingWitnesses;
 
     ::GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -1224,8 +1222,8 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         // Called to fetch anchor
         std::vector<JSOutPoint> sproutNotes {outpts.first};
         std::vector<SaplingOutPoint> saplingNotes {outpts.second};
-        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
-        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
+        std::vector<std::optional<SproutWitness>> sproutWitnesses;
+        std::vector<std::optional<SaplingWitness>> saplingWitnesses;
 
         anchors1 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
         EXPECT_NE(anchors1.first, anchors1.second);
@@ -1246,8 +1244,8 @@ TEST(WalletTests, CachedWitnessesChainTip) {
         wallet.AddToWallet(wtx, true, NULL);
 
         std::vector<JSOutPoint> sproutNotes {jsoutpt};
-        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
-        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
+        std::vector<std::optional<SproutWitness>> sproutWitnesses;
+        std::vector<std::optional<SaplingWitness>> saplingWitnesses;
 
         GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -1294,8 +1292,8 @@ TEST(WalletTests, CachedWitnessesChainTip) {
 
         // Incrementing with the same block again should not change the cache
         wallet.IncrementNoteWitnesses(&index2, &block2, sproutTree, saplingTree);
-        std::vector<boost::optional<SproutWitness>> sproutWitnesses5;
-        std::vector<boost::optional<SaplingWitness>> saplingWitnesses5;
+        std::vector<std::optional<SproutWitness>> sproutWitnesses5;
+        std::vector<std::optional<SaplingWitness>> saplingWitnesses5;
 
         auto anchors5 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses5, saplingWitnesses5);
         EXPECT_NE(anchors5.first, anchors5.second);
@@ -1335,8 +1333,8 @@ TEST(WalletTests, CachedWitnessesDecrementFirst) {
         // Called to fetch anchor
         std::vector<JSOutPoint> sproutNotes {outpts.first};
         std::vector<SaplingOutPoint> saplingNotes {outpts.second};
-        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
-        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
+        std::vector<std::optional<SproutWitness>> sproutWitnesses;
+        std::vector<std::optional<SaplingWitness>> saplingWitnesses;
         anchors2 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
     }
 
@@ -1355,8 +1353,8 @@ TEST(WalletTests, CachedWitnessesDecrementFirst) {
         wallet.AddToWallet(wtx, true, NULL);
 
         std::vector<JSOutPoint> sproutNotes {jsoutpt};
-        std::vector<boost::optional<SproutWitness>> sproutWitnesses;
-        std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
+        std::vector<std::optional<SproutWitness>> sproutWitnesses;
+        std::vector<std::optional<SaplingWitness>> saplingWitnesses;
 
         auto anchors3 = GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
 
@@ -1399,8 +1397,8 @@ TEST(WalletTests, CachedWitnessesCleanIndex) {
     SproutMerkleTree sproutRiTree = sproutTree;
     SaplingMerkleTree saplingTree;
     SaplingMerkleTree saplingRiTree = saplingTree;
-    std::vector<boost::optional<SproutWitness>> sproutWitnesses;
-    std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
+    std::vector<std::optional<SproutWitness>> sproutWitnesses;
+    std::vector<std::optional<SaplingWitness>> saplingWitnesses;
 
     auto sk = libzcash::SproutSpendingKey::random();
     wallet.AddSproutSpendingKey(sk);
@@ -1507,8 +1505,8 @@ TEST(WalletTests, ClearNoteWitnessCache) {
     wallet.AddToWallet(wtx, true, NULL);
 
     std::vector<JSOutPoint> sproutNotes {jsoutpt, jsoutpt2};
-    std::vector<boost::optional<SproutWitness>> sproutWitnesses;
-    std::vector<boost::optional<SaplingWitness>> saplingWitnesses;
+    std::vector<std::optional<SproutWitness>> sproutWitnesses;
+    std::vector<std::optional<SaplingWitness>> saplingWitnesses;
 
     // Before clearing, we should have a witness for one note
     GetWitnessesAndAnchors(wallet, sproutNotes, saplingNotes, sproutWitnesses, saplingWitnesses);
@@ -1808,7 +1806,7 @@ TEST(WalletTests, UpdatedSaplingNoteData) {
 
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pk, 50000);
-    auto cm = note.cm().get();
+    auto cm = note.cm().value();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
     auto anchor = saplingTree.root();
@@ -2011,9 +2009,9 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
             tx1.vShieldedOutput[0].encCiphertext, ivk, tx1.vShieldedOutput[0].ephemeralKey, tx1.vShieldedOutput[0].cm);
     ASSERT_EQ(static_cast<bool>(maybe_pt), true);
-    auto maybe_note = maybe_pt.get().note(ivk);
+    auto maybe_note = maybe_pt.value().note(ivk);
     ASSERT_EQ(static_cast<bool>(maybe_note), true);
-    auto note = maybe_note.get();
+    auto note = maybe_note.value();
     auto anchor = saplingTree.root();
     auto witness = saplingTree.witness();
 

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -5,8 +5,6 @@
 #include "wallet/walletdb.h"
 #include "util.h"
 
-#include <boost/filesystem.hpp>
-
 /**
  * This test covers Sapling methods on CWallet
  * GenerateNewSaplingZKey()
@@ -68,7 +66,7 @@ TEST(wallet_zkeys_tests, StoreAndLoadSaplingZkeys) {
     // If we can't get an early diversified address, we are very unlucky
     blob88 diversifier;
     diversifier.begin()[0] = 10;
-    auto dpa = sk.ToXFVK().Address(diversifier).get().second;
+    auto dpa = sk.ToXFVK().Address(diversifier).value().second;
 
     // verify wallet only has the default address
     EXPECT_TRUE(wallet.HaveSaplingIncomingViewingKey(sk.DefaultAddress()));
@@ -96,7 +94,7 @@ TEST(wallet_zkeys_tests, StoreAndLoadSaplingZkeys) {
     ASSERT_EQ(wallet.mapSaplingZKeyMetadata[ivk2].nCreateTime, now);
 
     // Load a diversified address for the third key into the wallet
-    auto dpa2 = sk2.ToXFVK().Address(diversifier).get().second;
+    auto dpa2 = sk2.ToXFVK().Address(diversifier).value().second;
     EXPECT_TRUE(wallet.HaveSaplingIncomingViewingKey(sk2.DefaultAddress()));
     EXPECT_FALSE(wallet.HaveSaplingIncomingViewingKey(dpa2));
     EXPECT_TRUE(wallet.LoadSaplingPaymentAddress(dpa2, ivk2));
@@ -217,8 +215,8 @@ TEST(wallet_zkeys_tests, write_zkey_direct_to_db) {
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths
-    boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
-    boost::filesystem::create_directories(pathTemp);
+    fs::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
@@ -289,8 +287,8 @@ TEST(wallet_zkeys_tests, WriteViewingKeyDirectToDB) {
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths
-    boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
-    boost::filesystem::create_directories(pathTemp);
+    fs::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
@@ -334,8 +332,8 @@ TEST(wallet_zkeys_tests, write_cryptedzkey_direct_to_db) {
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths
-    boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
-    boost::filesystem::create_directories(pathTemp);
+    fs::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
@@ -408,8 +406,8 @@ TEST(wallet_zkeys_tests, WriteCryptedSaplingZkeyDirectToDb) {
 
     // Get temporary and unique path for file.
     // Note: / operator to append paths
-    boost::filesystem::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
-    boost::filesystem::create_directories(pathTemp);
+    fs::path pathTemp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    fs::create_directories(pathTemp);
     mapArgs["-datadir"] = pathTemp.string();
 
     bool fFirstRun;
@@ -440,7 +438,7 @@ TEST(wallet_zkeys_tests, WriteCryptedSaplingZkeyDirectToDb) {
     EXPECT_TRUE(wallet.GetSaplingExtendedSpendingKey(address, extsk));
     blob88 diversifier;
     diversifier.begin()[0] = 10;
-    auto dpa = extsk.ToXFVK().Address(diversifier).get().second;
+    auto dpa = extsk.ToXFVK().Address(diversifier).value().second;
 
     // Add diversified address to the wallet
     auto ivk = extsk.expsk.full_viewing_key().in_viewing_key();

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -50,7 +50,8 @@ int64_t static DecodeDumpTime(const std::string &str) {
 
 std::string static EncodeDumpString(const std::string &str) {
     std::stringstream ret;
-    BOOST_FOREACH(unsigned char c, str) {
+    for (const auto &c : str)
+    {
         if (c <= 32 || c >= 128 || c == '%') {
             ret << '%' << HexStr(&c, &c + 1);
         } else {
@@ -302,8 +303,8 @@ UniValue importwallet_impl(const UniValue& params, bool fHelp, bool fImportZKeys
             auto spendingkey = DecodeSpendingKey(vstr[0]);
             int64_t nTime = DecodeDumpTime(vstr[1]);
             // Only include hdKeypath and seedFpStr if we have both
-            boost::optional<std::string> hdKeypath = (vstr.size() > 3) ? boost::optional<std::string>(vstr[2]) : boost::none;
-            boost::optional<std::string> seedFpStr = (vstr.size() > 3) ? boost::optional<std::string>(vstr[3]) : boost::none;
+            std::optional<std::string> hdKeypath = (vstr.size() > 3) ? std::optional<std::string>(vstr[2]) : std::nullopt;
+            std::optional<std::string> seedFpStr = (vstr.size() > 3) ? std::optional<std::string>(vstr[3]) : std::nullopt;
             if (IsValidSpendingKey(spendingkey)) {
                 auto addResult = boost::apply_visitor(
                     AddSpendingKeyToWallet(pwalletMain, Params().GetConsensus(), nTime, hdKeypath, seedFpStr, true), spendingkey);
@@ -465,7 +466,7 @@ UniValue dumpwallet_impl(const UniValue& params, bool fHelp, bool fDumpZKeys)
 
     EnsureWalletIsUnlocked();
 
-    boost::filesystem::path exportdir;
+    fs::path exportdir;
     try {
         exportdir = GetExportDir();
     } catch (const std::runtime_error& e) {
@@ -479,9 +480,9 @@ UniValue dumpwallet_impl(const UniValue& params, bool fHelp, bool fDumpZKeys)
     if (clean.compare(unclean) != 0) {
         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Filename is invalid as only alphanumeric characters are allowed.  Try '%s' instead.", clean));
     }
-    boost::filesystem::path exportfilepath = exportdir / clean;
+    fs::path exportfilepath = exportdir / clean;
 
-    if (boost::filesystem::exists(exportfilepath)) {
+    if (fs::exists(exportfilepath)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot overwrite existing file " + exportfilepath.string());
     }
 
@@ -798,7 +799,7 @@ UniValue z_exportkey(const UniValue& params, bool fHelp)
     if (!sk) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Wallet does not hold private zkey for this zaddr");
     }
-    return EncodeSpendingKey(sk.get());
+    return EncodeSpendingKey(sk.value());
 }
 
 UniValue z_exportviewingkey(const UniValue& params, bool fHelp)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -215,7 +215,7 @@ public:
      * transactions they are spent in. This is the same security semantics as
      * for transparent addresses.
      */
-    boost::optional<uint256> nullifier;
+    std::optional<uint256> nullifier;
 
     /**
      * Cached incremental witnesses for spendable Notes.
@@ -278,7 +278,7 @@ public:
     std::list<SaplingWitness> witnesses;
     int witnessHeight;
     libzcash::SaplingIncomingViewingKey ivk;
-    boost::optional<uint256> nullifier;
+    std::optional<uint256> nullifier;
 
     ADD_SERIALIZE_METHODS;
 
@@ -1111,7 +1111,7 @@ public:
     void EraseFromWallet(const uint256 &hash);
     void WitnessNoteCommitment(
          std::vector<uint256> commitments,
-         std::vector<boost::optional<SproutWitness>>& witnesses,
+         std::vector<std::optional<SproutWitness>>& witnesses,
          uint256 &final_anchor);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
@@ -1145,7 +1145,7 @@ public:
 
     std::set<CTxDestination> GetAccountAddresses(const std::string& strAccount) const;
 
-    boost::optional<uint256> GetSproutNoteNullifier(
+    std::optional<uint256> GetSproutNoteNullifier(
         const JSDescription& jsdesc,
         const libzcash::SproutPaymentAddress& address,
         const ZCNoteDecryption& dec,
@@ -1158,11 +1158,11 @@ public:
 
     void GetSproutNoteWitnesses(
          std::vector<JSOutPoint> notes,
-         std::vector<boost::optional<SproutWitness>>& witnesses,
+         std::vector<std::optional<SproutWitness>>& witnesses,
          uint256 &final_anchor);
     void GetSaplingNoteWitnesses(
          std::vector<SaplingOutPoint> notes,
-         std::vector<boost::optional<SaplingWitness>>& witnesses,
+         std::vector<std::optional<SaplingWitness>>& witnesses,
          uint256 &final_anchor);
 
     isminetype IsMine(const CTxIn& txin) const;
@@ -1380,16 +1380,16 @@ public:
     bool operator()(const libzcash::InvalidEncoding& no) const;
 };
 
-class GetSpendingKeyForPaymentAddress : public boost::static_visitor<boost::optional<libzcash::SpendingKey>>
+class GetSpendingKeyForPaymentAddress : public boost::static_visitor<std::optional<libzcash::SpendingKey>>
 {
 private:
     CWallet *m_wallet;
 public:
     GetSpendingKeyForPaymentAddress(CWallet *wallet) : m_wallet(wallet) {}
 
-    boost::optional<libzcash::SpendingKey> operator()(const libzcash::SproutPaymentAddress &zaddr) const;
-    boost::optional<libzcash::SpendingKey> operator()(const libzcash::SaplingPaymentAddress &zaddr) const;
-    boost::optional<libzcash::SpendingKey> operator()(const libzcash::InvalidEncoding& no) const;
+    std::optional<libzcash::SpendingKey> operator()(const libzcash::SproutPaymentAddress &zaddr) const;
+    std::optional<libzcash::SpendingKey> operator()(const libzcash::SaplingPaymentAddress &zaddr) const;
+    std::optional<libzcash::SpendingKey> operator()(const libzcash::InvalidEncoding& no) const;
 };
 
 enum SpendingKeyAddResult {
@@ -1404,18 +1404,18 @@ private:
     CWallet *m_wallet;
     const Consensus::Params &params;
     int64_t nTime;
-    boost::optional<std::string> hdKeypath; // currently sapling only
-    boost::optional<std::string> seedFpStr; // currently sapling only
+    std::optional<std::string> hdKeypath; // currently sapling only
+    std::optional<std::string> seedFpStr; // currently sapling only
     bool log;
 public: 
     AddSpendingKeyToWallet(CWallet *wallet, const Consensus::Params &params) :
-        m_wallet(wallet), params(params), nTime(1), hdKeypath(boost::none), seedFpStr(boost::none), log(false) {}
+        m_wallet(wallet), params(params), nTime(1), hdKeypath(std::nullopt), seedFpStr(std::nullopt), log(false) {}
     AddSpendingKeyToWallet(
         CWallet *wallet,
         const Consensus::Params &params,
         int64_t _nTime,
-        boost::optional<std::string> _hdKeypath,
-        boost::optional<std::string> _seedFp,
+        std::optional<std::string> _hdKeypath,
+        std::optional<std::string> _seedFp,
         bool _log
     ) : m_wallet(wallet), params(params), nTime(_nTime), hdKeypath(_hdKeypath), seedFpStr(_seedFp), log(_log) {}
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -16,11 +16,8 @@
 #include "wallet/wallet.h"
 #include "zcash/Proof.hpp"
 
-#include <boost/filesystem.hpp>
-#include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
-
 using namespace std;
 
 static uint64_t nAccountingEntryNumber = 0;
@@ -292,7 +289,7 @@ CAmount CWalletDB::GetAccountCreditDebit(const string& strAccount)
     ListAccountCreditDebit(strAccount, entries);
 
     CAmount nCreditDebit = 0;
-    BOOST_FOREACH (const CAccountingEntry& entry, entries)
+    for (const auto& entry : entries)
         nCreditDebit += entry.nCreditDebit;
 
     return nCreditDebit;
@@ -359,10 +356,8 @@ DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
     }
     list<CAccountingEntry> acentries;
     ListAccountCreditDebit("", acentries);
-    BOOST_FOREACH(CAccountingEntry& entry, acentries)
-    {
+    for (auto& entry : acentries)
         txByTime.insert(make_pair(entry.nTime, TxPair((CWalletTx*)0, &entry)));
-    }
 
     int64_t& nOrderPosNext = pwallet->nOrderPosNext;
     nOrderPosNext = 0;
@@ -390,7 +385,7 @@ DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
         else
         {
             int64_t nOrderPosOff = 0;
-            BOOST_FOREACH(const int64_t& nOffsetStart, nOrderPosOffsets)
+            for(const auto& nOffsetStart : nOrderPosOffsets)
             {
                 if (nOrderPos >= nOffsetStart)
                     ++nOrderPosOff;
@@ -955,7 +950,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     if ((wss.nKeys + wss.nCKeys) != wss.nKeyMeta)
         pwallet->nTimeFirstKey = 1; // 0 would be considered 'no value'
 
-    BOOST_FOREACH(uint256 hash, wss.vWalletUpgrade)
+    for (auto &hash : wss.vWalletUpgrade)
         WriteTx(hash, pwallet->mapWallet[hash]);
 
     // Rewrite encrypted wallets of versions 0.4.0 and 0.5.0rc:
@@ -1055,7 +1050,8 @@ DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, vector<CWalletTx>& vWtx)
         return err;
 
     // erase each wallet TX
-    BOOST_FOREACH (uint256& hash, vTxHash) {
+    for (auto& hash : vTxHash)
+    {
         if (!EraseTx(hash))
             return DB_CORRUPT;
     }
@@ -1141,16 +1137,16 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                 bitdb.mapFileUseCount.erase(wallet.strWalletFile);
 
                 // Copy wallet.dat
-                boost::filesystem::path pathSrc = GetDataDir() / wallet.strWalletFile;
-                boost::filesystem::path pathDest(strDest);
-                if (boost::filesystem::is_directory(pathDest))
+                fs::path pathSrc = GetDataDir() / wallet.strWalletFile;
+                fs::path pathDest(strDest);
+                if (fs::is_directory(pathDest))
                     pathDest /= wallet.strWalletFile;
 
                 try {
-                    boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_option::overwrite_if_exists);
+                    fs::copy_file(pathSrc, pathDest, fs::copy_option::overwrite_if_exists);
                     LogPrintf("copied wallet.dat to %s\n", pathDest.string());
                     return true;
-                } catch (const boost::filesystem::filesystem_error& e) {
+                } catch (const fs::filesystem_error& e) {
                     LogPrintf("error copying wallet.dat to %s - %s\n", pathDest.string(), e.what());
                     return false;
                 }
@@ -1211,7 +1207,7 @@ bool CWalletDB::Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKe
     CWalletScanState wss;
 
     DbTxn* ptxn = dbenv.TxnBegin();
-    BOOST_FOREACH(CDBEnv::KeyValPair& row, salvagedData)
+    for (auto& row : salvagedData)
     {
         if (fOnlyKeys)
         {

--- a/src/zcash/Address.cpp
+++ b/src/zcash/Address.cpp
@@ -92,20 +92,20 @@ SaplingSpendingKey SaplingSpendingKey::random() {
     }
 }
 
-boost::optional<SaplingPaymentAddress> SaplingIncomingViewingKey::address(diversifier_t d) const {
+std::optional<SaplingPaymentAddress> SaplingIncomingViewingKey::address(diversifier_t d) const {
     uint256 pk_d;
     if (librustzcash_check_diversifier(d.data())) {
         librustzcash_ivk_to_pkd(this->begin(), d.data(), pk_d.begin());
         return SaplingPaymentAddress(d, pk_d);
     } else {
-        return boost::none;
+        return std::nullopt;
     }
 }
 
 SaplingPaymentAddress SaplingSpendingKey::default_address() const {
     // Iterates within default_diversifier to ensure a valid address is returned
     auto addrOpt = full_viewing_key().in_viewing_key().address(default_diversifier(*this));
-    assert(addrOpt != boost::none);
+    assert(addrOpt != std::nullopt);
     return addrOpt.value();
 }
 

--- a/src/zcash/Address.hpp
+++ b/src/zcash/Address.hpp
@@ -136,7 +136,7 @@ public:
     SaplingIncomingViewingKey(uint256 ivk) : uint256(ivk) { }
     
     // Can pass in diversifier for Sapling addr
-    boost::optional<SaplingPaymentAddress> address(diversifier_t d) const;
+    std::optional<SaplingPaymentAddress> address(diversifier_t d) const;
 };
 
 class SaplingFullViewingKey {

--- a/src/zcash/IncrementalMerkleTree.cpp
+++ b/src/zcash/IncrementalMerkleTree.cpp
@@ -1,7 +1,5 @@
 #include <stdexcept>
 
-#include <boost/foreach.hpp>
-
 #include "zcash/IncrementalMerkleTree.hpp"
 #include "crypto/sha256.h"
 #include "zcash/util.h"
@@ -142,17 +140,17 @@ void IncrementalMerkleTree<Depth, Hash>::append(Hash obj) {
         right = obj;
     } else {
         // Combine the leaves and propagate it up the tree
-        boost::optional<Hash> combined = Hash::combine(*left, *right, 0);
+        std::optional<Hash> combined = Hash::combine(*left, *right, 0);
 
         // Set the "left" leaf to the object and make the "right" leaf none
         left = obj;
-        right = boost::none;
+        right = std::nullopt;
 
         for (size_t i = 0; i < Depth; i++) {
             if (i < parents.size()) {
                 if (parents[i]) {
                     combined = Hash::combine(*parents[i], *combined, i+1);
-                    parents[i] = boost::none;
+                    parents[i] = std::nullopt;
                 } else {
                     parents[i] = *combined;
                     break;
@@ -178,10 +176,10 @@ bool IncrementalMerkleTree<Depth, Hash>::is_complete(size_t depth) const {
         return false;
     }
 
-    BOOST_FOREACH(const boost::optional<Hash>& parent, parents) {
-        if (!parent) {
+    for (const auto& parent : parents)
+    {
+        if (!parent)
             return false;
-        }
     }
 
     return true;
@@ -208,16 +206,15 @@ size_t IncrementalMerkleTree<Depth, Hash>::next_depth(size_t skip) const {
     }
 
     size_t d = 1;
-
-    BOOST_FOREACH(const boost::optional<Hash>& parent, parents) {
-        if (!parent) {
-            if (skip) {
+    for (const auto& parent : parents)
+    {
+        if (!parent)
+        {
+            if (skip)
                 skip--;
-            } else {
+            else
                 return d;
-            }
         }
-
         d++;
     }
 
@@ -237,13 +234,12 @@ Hash IncrementalMerkleTree<Depth, Hash>::root(size_t depth,
 
     size_t d = 1;
 
-    BOOST_FOREACH(const boost::optional<Hash>& parent, parents) {
-        if (parent) {
+    for (const auto& parent : parents)
+    {
+        if (parent)
             root = Hash::combine(*parent, root, d);
-        } else {
+        else
             root = Hash::combine(root, filler.next(d), d);
-        }
-
         d++;
     }
 
@@ -280,7 +276,8 @@ MerklePath IncrementalMerkleTree<Depth, Hash>::path(std::deque<Hash> filler_hash
 
     size_t d = 1;
 
-    BOOST_FOREACH(const boost::optional<Hash>& parent, parents) {
+    for (const auto& parent : parents)
+    {
         if (parent) {
             index.push_back(true);
             path.push_back(*parent);
@@ -299,10 +296,9 @@ MerklePath IncrementalMerkleTree<Depth, Hash>::path(std::deque<Hash> filler_hash
     }
 
     std::vector<std::vector<bool>> merkle_path;
-    BOOST_FOREACH(Hash b, path)
+    for (const Hash &b : path)
     {
         std::vector<unsigned char> hashv(b.begin(), b.end());
-
         merkle_path.push_back(convertBytesVectorToVector(hashv));
     }
 
@@ -330,7 +326,7 @@ void IncrementalWitness<Depth, Hash>::append(Hash obj) {
 
         if (cursor->is_complete(cursor_depth)) {
             filled.push_back(cursor->root(cursor_depth));
-            cursor = boost::none;
+            cursor = std::nullopt;
         }
     } else {
         cursor_depth = tree.next_depth(filled.size());

--- a/src/zcash/IncrementalMerkleTree.hpp
+++ b/src/zcash/IncrementalMerkleTree.hpp
@@ -3,7 +3,7 @@
 
 #include <array>
 #include <deque>
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/static_assert.hpp>
 
 #include "uint256.h"
@@ -131,11 +131,11 @@ public:
 
 private:
     static EmptyMerkleRoots<Depth, Hash> emptyroots;
-    boost::optional<Hash> left;
-    boost::optional<Hash> right;
+    std::optional<Hash> left;
+    std::optional<Hash> right;
 
     // Collapsed "left" subtrees ordered toward the root of the tree.
-    std::vector<boost::optional<Hash>> parents;
+    std::vector<std::optional<Hash>> parents;
     MerklePath path(std::deque<Hash> filler_hashes = std::deque<Hash>()) const;
     Hash root(size_t depth, std::deque<Hash> filler_hashes = std::deque<Hash>()) const;
     bool is_complete(size_t depth = Depth) const;
@@ -198,7 +198,7 @@ public:
 private:
     IncrementalMerkleTree<Depth, Hash> tree;
     std::vector<Hash> filled;
-    boost::optional<IncrementalMerkleTree<Depth, Hash>> cursor;
+    std::optional<IncrementalMerkleTree<Depth, Hash>> cursor;
     size_t cursor_depth = 0;
     std::deque<Hash> partial_path() const;
     IncrementalWitness(IncrementalMerkleTree<Depth, Hash> tree) : tree(tree) {}

--- a/src/zcash/JoinSplit.cpp
+++ b/src/zcash/JoinSplit.cpp
@@ -5,11 +5,10 @@
 #include "zcash/util.h"
 
 #include <memory>
-
-#include <boost/foreach.hpp>
-#include <boost/format.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <fstream>
+
+#include <boost/format.hpp>
 #include <libsnark/common/default_types/r1cs_ppzksnark_pp.hpp>
 #include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>
 #include <libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp>

--- a/src/zcash/Note.hpp
+++ b/src/zcash/Note.hpp
@@ -7,7 +7,7 @@
 #include "NoteEncryption.hpp"
 
 #include <array>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace libzcash {
 
@@ -56,8 +56,8 @@ public:
 
     virtual ~SaplingNote() {};
 
-    boost::optional<uint256> cm() const;
-    boost::optional<uint256> nullifier(const SaplingFullViewingKey &vk, const uint64_t position) const;
+    std::optional<uint256> cm() const;
+    std::optional<uint256> nullifier(const SaplingFullViewingKey &vk, const uint64_t position) const;
 };
 
 class BaseNotePlaintext {
@@ -127,14 +127,14 @@ public:
 
     SaplingNotePlaintext(const SaplingNote& note, std::array<unsigned char, ZC_MEMO_SIZE> memo);
 
-    static boost::optional<SaplingNotePlaintext> decrypt(
+    static std::optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext &ciphertext,
         const uint256 &ivk,
         const uint256 &epk,
         const uint256 &cmu
     );
 
-    static boost::optional<SaplingNotePlaintext> decrypt(
+    static std::optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext &ciphertext,
         const uint256 &epk,
         const uint256 &esk,
@@ -142,7 +142,7 @@ public:
         const uint256 &cmu
     );
 
-    boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
+    std::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
 
     virtual ~SaplingNotePlaintext() {}
 
@@ -163,7 +163,7 @@ public:
         READWRITE(memo_);       // 512 bytes
     }
 
-    boost::optional<SaplingNotePlaintextEncryptionResult> encrypt(const uint256& pk_d) const;
+    std::optional<SaplingNotePlaintextEncryptionResult> encrypt(const uint256& pk_d) const;
 };
 
 class SaplingOutgoingPlaintext
@@ -184,7 +184,7 @@ public:
         READWRITE(esk);         // 8 bytes
     }
 
-    static boost::optional<SaplingOutgoingPlaintext> decrypt(
+    static std::optional<SaplingOutgoingPlaintext> decrypt(
         const SaplingOutCiphertext &ciphertext,
         const uint256& ovk,
         const uint256& cv,

--- a/src/zcash/NoteEncryption.cpp
+++ b/src/zcash/NoteEncryption.cpp
@@ -101,7 +101,7 @@ void KDF(unsigned char K[NOTEENCRYPTION_CIPHER_KEYSIZE],
 
 namespace libzcash {
 
-boost::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(diversifier_t d) {
+std::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(diversifier_t d) {
     uint256 epk;
     uint256 esk;
 
@@ -110,13 +110,13 @@ boost::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(di
 
     // Compute epk given the diversifier
     if (!librustzcash_sapling_ka_derivepublic(d.data(), esk.begin(), epk.begin())) {
-        return boost::none;
+        return std::nullopt;
     }
 
     return SaplingNoteEncryption(epk, esk);
 }
 
-boost::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipient(
+std::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipient(
     const uint256 &pk_d,
     const SaplingEncPlaintext &message
 )
@@ -128,7 +128,7 @@ boost::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipien
     uint256 dhsecret;
 
     if (!librustzcash_sapling_ka_agree(pk_d.begin(), esk.begin(), dhsecret.begin())) {
-        return boost::none;
+        return std::nullopt;
     }
 
     // Construct the symmetric key
@@ -152,7 +152,7 @@ boost::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipien
     return ciphertext;
 }
 
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
+std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     const SaplingEncCiphertext &ciphertext,
     const uint256 &ivk,
     const uint256 &epk
@@ -161,7 +161,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     uint256 dhsecret;
 
     if (!librustzcash_sapling_ka_agree(epk.begin(), ivk.begin(), dhsecret.begin())) {
-        return boost::none;
+        return std::nullopt;
     }
 
     // Construct the symmetric key
@@ -181,13 +181,13 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
         0,
         cipher_nonce, K) != 0)
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return plaintext;
 }
 
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
+std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,
@@ -197,7 +197,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     uint256 dhsecret;
 
     if (!librustzcash_sapling_ka_agree(pk_d.begin(), esk.begin(), dhsecret.begin())) {
-        return boost::none;
+        return std::nullopt;
     }
 
     // Construct the symmetric key
@@ -217,7 +217,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
         0,
         cipher_nonce, K) != 0)
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return plaintext;
@@ -256,7 +256,7 @@ SaplingOutCiphertext SaplingNoteEncryption::encrypt_to_ourselves(
     return ciphertext;
 }
 
-boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
+std::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
     const SaplingOutCiphertext &ciphertext,
     const uint256 &ovk,
     const uint256 &cv,
@@ -281,7 +281,7 @@ boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
         0,
         cipher_nonce, K) != 0)
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     return plaintext;

--- a/src/zcash/NoteEncryption.hpp
+++ b/src/zcash/NoteEncryption.hpp
@@ -42,9 +42,9 @@ protected:
 
 public:
 
-    static boost::optional<SaplingNoteEncryption> FromDiversifier(diversifier_t d);
+    static std::optional<SaplingNoteEncryption> FromDiversifier(diversifier_t d);
 
-    boost::optional<SaplingEncCiphertext> encrypt_to_recipient(
+    std::optional<SaplingEncCiphertext> encrypt_to_recipient(
         const uint256 &pk_d,
         const SaplingEncPlaintext &message
     );
@@ -67,7 +67,7 @@ public:
 
 // Attempts to decrypt a Sapling note. This will not check that the contents
 // of the ciphertext are correct.
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
+std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     const SaplingEncCiphertext &ciphertext,
     const uint256 &ivk,
     const uint256 &epk
@@ -75,7 +75,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
 
 // Attempts to decrypt a Sapling note using outgoing plaintext.
 // This will not check that the contents of the ciphertext are correct.
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
+std::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,
@@ -84,7 +84,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
 
 // Attempts to decrypt a Sapling note. This will not check that the contents
 // of the ciphertext are correct.
-boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
+std::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
     const SaplingOutCiphertext &ciphertext,
     const uint256 &ovk,
     const uint256 &cv,

--- a/src/zcash/circuit/utils.tcc
+++ b/src/zcash/circuit/utils.tcc
@@ -4,9 +4,8 @@ template<typename FieldT>
 pb_variable_array<FieldT> from_bits(std::vector<bool> bits, pb_variable<FieldT>& ZERO) {
     pb_variable_array<FieldT> acc;
 
-    BOOST_FOREACH(bool bit, bits) {
+    for (const auto &bit : bits)
         acc.emplace_back(bit ? ONE : ZERO);
-    }
 
     return acc;
 }

--- a/src/zcash/zip32.cpp
+++ b/src/zcash/zip32.cpp
@@ -59,7 +59,7 @@ uint256 ovkForShieldingFromTaddr(HDSeed& seed) {
 
 namespace libzcash {
 
-boost::optional<SaplingExtendedFullViewingKey> SaplingExtendedFullViewingKey::Derive(uint32_t i) const
+std::optional<SaplingExtendedFullViewingKey> SaplingExtendedFullViewingKey::Derive(uint32_t i) const
 {
     CDataStream ss_p(SER_NETWORK, PROTOCOL_VERSION);
     ss_p << *this;
@@ -76,11 +76,11 @@ boost::optional<SaplingExtendedFullViewingKey> SaplingExtendedFullViewingKey::De
         ss_i >> xfvk_i;
         return xfvk_i;
     } else {
-        return boost::none;
+        return std::nullopt;
     }
 }
 
-boost::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
+std::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
     SaplingExtendedFullViewingKey::Address(diversifier_index_t j) const
 {
     CDataStream ss_xfvk(SER_NETWORK, PROTOCOL_VERSION);
@@ -98,7 +98,7 @@ boost::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
         ss_addr >> addr;
         return std::make_pair(j_ret, addr);
     } else {
-        return boost::none;
+        return std::nullopt;
     }
 }
 
@@ -110,7 +110,7 @@ libzcash::SaplingPaymentAddress SaplingExtendedFullViewingKey::DefaultAddress() 
     if (!addr) {
         throw std::runtime_error("SaplingExtendedFullViewingKey::DefaultAddress(): No valid diversifiers out of 2^88!");
     }
-    return addr.get().second;
+    return addr.value().second;
 }
 
 SaplingExtendedSpendingKey SaplingExtendedSpendingKey::Master(const HDSeed& seed)

--- a/src/zcash/zip32.h
+++ b/src/zcash/zip32.h
@@ -10,7 +10,7 @@
 #include "uint256.h"
 #include "zcash/Address.hpp"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 const uint32_t ZIP32_HARDENED_KEY_LIMIT = 0x80000000;
 const size_t ZIP32_XFVK_SIZE = 169;
@@ -69,12 +69,12 @@ struct SaplingExtendedFullViewingKey {
         READWRITE(dk);
     }
 
-    boost::optional<SaplingExtendedFullViewingKey> Derive(uint32_t i) const;
+    std::optional<SaplingExtendedFullViewingKey> Derive(uint32_t i) const;
 
     // Returns the first index starting from j that generates a valid
     // payment address, along with the corresponding address. Returns
     // an error if the diversifier space is exhausted.
-    boost::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
+    std::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
         Address(diversifier_index_t j) const;
 
     libzcash::SaplingPaymentAddress DefaultAddress() const;

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -3,7 +3,6 @@
 #include <map>
 #include <thread>
 #include <unistd.h>
-#include <boost/filesystem.hpp>
 
 #include "coins.h"
 #include "util.h"
@@ -94,8 +93,8 @@ double benchmark_sleep()
 double benchmark_parameter_loading()
 {
     // FIXME: this is duplicated with the actual loading code
-    boost::filesystem::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
-    boost::filesystem::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
+    fs::path pk_path = ZC_GetParamsDir() / "sprout-proving.key";
+    fs::path vk_path = ZC_GetParamsDir() / "sprout-verifying.key";
 
     struct timeval tv_start;
     timer_start(tv_start);
@@ -483,7 +482,7 @@ double benchmark_create_sapling_spend()
     SaplingNote note(address, GetRand(MAX_MONEY));
     SaplingMerkleTree tree;
     auto maybe_cm = note.cm();
-    tree.append(maybe_cm.get());
+    tree.append(maybe_cm.value());
     auto anchor = tree.root();
     auto witness = tree.witness();
     auto maybe_nf = note.nullifier(expsk.full_viewing_key(), witness.position());
@@ -540,7 +539,7 @@ double benchmark_create_sapling_output()
         throw JSONRPCError(RPC_INTERNAL_ERROR, "SaplingNotePlaintext::encrypt() failed");
     }
 
-    auto enc = res.get();
+    auto enc = res.value();
     auto encryptor = enc.second;
 
     auto ctx = librustzcash_sapling_proving_ctx_init();


### PR DESCRIPTION
lot of boost libraries became part of c++17 standard
Migrated the following boost classes to std c++17:
  -boost::optional -> std::optional; boost::none -> std::nullopt;
-BOOST_FOREACH -> used standard range-based for (for vectors),
structured bindings for maps
  -boost::shared_ptr -> std::shared_ptr
  -boost::tuple -> std::tuple
  -added fs.h with namespace alias fs for boost::filesystem
-replaced boost::filesystem with fs (for easy migration to
std::filesystem)
  -removed boost includes, replaced with std
  <boost/foreach.hpp>
  <boost/optional.hpp>
  <boost/shared_ptr.hpp>
  <boost/tuple/tuple.hpp>
-set default enable_mining flag to no
-ported qa/test-suite python scripts to v3