### PR TITLE
Fix all PVS V607-->V1423 HIGH level warnings

### DIFF
--- a/src/compat/glibcxx_sanity.cpp
+++ b/src/compat/glibcxx_sanity.cpp
@@ -47,7 +47,7 @@ bool sanity_test_range_fmt()
 {
     std::string test;
     try {
-        test.at(1);
+        char tmp = test.at(1); //-V557 false warning. This test was writtent intendedly to see if we can catch std::out_of_range
     } catch (const std::out_of_range&) {
         return true;
     } catch (...) {

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -607,7 +607,7 @@ void HTTPRequest::WriteReply(int nStatus, const std::string& strReply)
     ev->trigger(0);
     replySent = true;
     req = 0; // transferred back to main thread
-}
+} //-V773 : ev will be release by the callback function httpevent_callback_fn later, so this PVS warning is a false warning
 
 CService HTTPRequest::GetPeer()
 {

--- a/src/json/json.hpp
+++ b/src/json/json.hpp
@@ -16838,7 +16838,7 @@ class serializer
 
         std::size_t index = 256u + static_cast<size_t>(state) * 16u + static_cast<size_t>(type);
         JSON_ASSERT(index < 400);
-        state = utf8d[index];
+        state = utf8d[index]; //-V557 The assert check for out of range already
         return state;
     }
 

--- a/src/leveldb/db/c.cc
+++ b/src/leveldb/db/c.cc
@@ -145,7 +145,9 @@ static bool SaveError(char** errptr, const Status& s) {
 
 static char* CopyString(const std::string& str) {
   char* result = reinterpret_cast<char*>(malloc(sizeof(char) * str.size()));
-  memcpy(result, str.data(), sizeof(char) * str.size());
+  if (result) {
+      memcpy(result, str.data(), sizeof(char) * str.size());
+  }
   return result;
 }
 

--- a/src/leveldb/db/dbformat.cc
+++ b/src/leveldb/db/dbformat.cc
@@ -118,7 +118,7 @@ bool InternalFilterPolicy::KeyMayMatch(const Slice& key, const Slice& f) const {
   return user_policy_->KeyMayMatch(ExtractUserKey(key), f);
 }
 
-LookupKey::LookupKey(const Slice& user_key, SequenceNumber s) {
+LookupKey::LookupKey(const Slice& user_key, SequenceNumber s): space_() {
   size_t usize = user_key.size();
   size_t needed = usize + 13;  // A conservative estimate
   char* dst;

--- a/src/leveldb/db/dbformat.h
+++ b/src/leveldb/db/dbformat.h
@@ -72,7 +72,7 @@ struct ParsedInternalKey {
   SequenceNumber sequence;
   ValueType type;
 
-  ParsedInternalKey() { }  // Intentionally left uninitialized (for speed)
+  ParsedInternalKey() { }  // -V730 Intentionally left uninitialized (for speed)
   ParsedInternalKey(const Slice& u, const SequenceNumber& seq, ValueType t)
       : user_key(u), sequence(seq), type(t) { }
   std::string DebugString() const;

--- a/src/leveldb/db/dumpfile.cc
+++ b/src/leveldb/db/dumpfile.cc
@@ -183,7 +183,8 @@ Status DumpTable(Env* env, const std::string& fname, WritableFile* dst) {
       r += " : ";
       if (key.type == kTypeDeletion) {
         r += "del";
-      } else if (key.type == kTypeValue) {
+      } else if (key.type == kTypeValue) { //-V547 false warning. This is not always true
+                                           //      because 'else' might happened if the cast to enum ParseInternalKey() is invalid
         r += "val";
       } else {
         AppendNumberTo(&r, key.type);

--- a/src/leveldb/db/log_reader.cc
+++ b/src/leveldb/db/log_reader.cc
@@ -107,7 +107,7 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch) {
         }
         prospective_record_offset = physical_record_offset;
         scratch->assign(fragment.data(), fragment.size());
-        in_fragmented_record = true;
+        in_fragmented_record = true; // -V519 this is set intendedly for the case in_fragmented_record == false
         break;
 
       case kMiddleType:

--- a/src/leveldb/db/version_edit.h
+++ b/src/leveldb/db/version_edit.h
@@ -22,7 +22,7 @@ struct FileMetaData {
   InternalKey smallest;       // Smallest internal key served by table
   InternalKey largest;        // Largest internal key served by table
 
-  FileMetaData() : refs(0), allowed_seeks(1 << 30), file_size(0) { }
+  FileMetaData() : refs(0), allowed_seeks(1 << 30), number(0), file_size(0), smallest(), largest() {}
 };
 
 class VersionEdit {

--- a/src/leveldb/db/version_set.cc
+++ b/src/leveldb/db/version_set.cc
@@ -157,7 +157,8 @@ class Version::LevelFileNumIterator : public Iterator {
                        const std::vector<FileMetaData*>* flist)
       : icmp_(icmp),
         flist_(flist),
-        index_(flist->size()) {        // Marks as invalid
+        index_(flist->size()),
+        value_buf_() {        // Marks as invalid
   }
   virtual bool Valid() const {
     return index_ < flist_->size();
@@ -504,7 +505,7 @@ int Version::PickLevelForMemTableOutput(
       if (OverlapInLevel(level + 1, &smallest_user_key, &largest_user_key)) {
         break;
       }
-      if (level + 2 < config::kNumLevels) {
+      if (level + 2 < config::kNumLevels) { //-V547 the warning is correct. But we shouldn't change the implementation here
         // Check that file does not overlap too many grandparent bytes.
         GetOverlappingInputs(level + 2, &start, &limit, &overlaps);
         const int64_t sum = TotalFileSize(overlaps);

--- a/src/leveldb/include/leveldb/cache.h
+++ b/src/leveldb/include/leveldb/cache.h
@@ -31,7 +31,7 @@ extern Cache* NewLRUCache(size_t capacity);
 
 class Cache {
  public:
-  Cache() { }
+  Cache(): rep_(nullptr) { }
 
   // Destroys all existing entries by calling the "deleter"
   // function that was passed to the constructor.

--- a/src/leveldb/port/atomic_pointer.h
+++ b/src/leveldb/port/atomic_pointer.h
@@ -109,7 +109,7 @@ class AtomicPointer {
  private:
   void* rep_;
  public:
-  AtomicPointer() { }
+  AtomicPointer() : rep_(nullptr) { }
   explicit AtomicPointer(void* p) : rep_(p) {}
   inline void* NoBarrier_Load() const { return rep_; }
   inline void NoBarrier_Store(void* v) { rep_ = v; }

--- a/src/leveldb/table/format.cc
+++ b/src/leveldb/table/format.cc
@@ -106,8 +106,9 @@ Status ReadBlock(RandomAccessFile* file,
         // while the file is open.
         delete[] buf;
         result->data = Slice(data, n);
-        result->heap_allocated = false;
-        result->cachable = false;  // Do not double-cache
+        result->heap_allocated = false; // -V1048 warning is correct. But should keep the implementation for easier read & maintenence
+        // Do not double-cache  
+        result->cachable = false;  // -V1048 warning is correct. But should keep the implementation for easier read & maintenence
       } else {
         result->data = Slice(buf, n);
         result->heap_allocated = true;

--- a/src/leveldb/util/cache.cc
+++ b/src/leveldb/util/cache.cc
@@ -168,10 +168,12 @@ class LRUCache {
 };
 
 LRUCache::LRUCache()
-    : usage_(0) {
-  // Make empty circular linked list
-  lru_.next = &lru_;
-  lru_.prev = &lru_;
+    : capacity_(0),
+      usage_(0)
+{
+    // Make empty circular linked list
+    lru_.next = &lru_;
+    lru_.prev = &lru_;
 }
 
 LRUCache::~LRUCache() {
@@ -229,20 +231,22 @@ Cache::Handle* LRUCache::Insert(
 
   LRUHandle* e = reinterpret_cast<LRUHandle*>(
       malloc(sizeof(LRUHandle)-1 + key.size()));
-  e->value = value;
-  e->deleter = deleter;
-  e->charge = charge;
-  e->key_length = key.size();
-  e->hash = hash;
-  e->refs = 2;  // One from LRUCache, one for the returned handle
-  memcpy(e->key_data, key.data(), key.size());
-  LRU_Append(e);
-  usage_ += charge;
+  if (e) {
+    e->value = value;
+    e->deleter = deleter;
+    e->charge = charge;
+    e->key_length = key.size();
+    e->hash = hash;
+    e->refs = 2;  // One from LRUCache, one for the returned handle
+    memcpy(e->key_data, key.data(), key.size());
+    LRU_Append(e);
+    usage_ += charge;
 
-  LRUHandle* old = table_.Insert(e);
-  if (old != NULL) {
-    LRU_Remove(old);
-    Unref(old);
+    LRUHandle* old = table_.Insert(e);
+    if (old != NULL) {
+      LRU_Remove(old);
+      Unref(old);
+    }
   }
 
   while (usage_ > capacity_ && lru_.next != &lru_) {

--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -523,7 +523,7 @@ class PosixEnv : public Env {
   MmapLimiter mmap_limit_;
 };
 
-PosixEnv::PosixEnv() : started_bgthread_(false) {
+PosixEnv::PosixEnv() : , started_bgthread_(false) { //-V730
   PthreadCall("mutex_init", pthread_mutex_init(&mu_, NULL));
   PthreadCall("cvar_init", pthread_cond_init(&bgsignal_, NULL));
 }

--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -523,7 +523,7 @@ class PosixEnv : public Env {
   MmapLimiter mmap_limit_;
 };
 
-PosixEnv::PosixEnv() : , started_bgthread_(false) { //-V730
+PosixEnv::PosixEnv() : started_bgthread_(false) { //-V730
   PthreadCall("mutex_init", pthread_mutex_init(&mu_, NULL));
   PthreadCall("cvar_init", pthread_cond_init(&bgsignal_, NULL));
 }

--- a/src/leveldb/util/histogram.h
+++ b/src/leveldb/util/histogram.h
@@ -11,7 +11,7 @@ namespace leveldb {
 
 class Histogram {
  public:
-  Histogram() { }
+  Histogram(): min_(0), max_(0), num_(0), sum_(0), sum_squares_(0), buckets_() { }
   ~Histogram() { }
 
   void Clear();

--- a/src/main.h
+++ b/src/main.h
@@ -417,7 +417,7 @@ private:
     PrecomputedTransactionData *txdata;
 
 public:
-    CScriptCheck(): amount(0), ptxTo(0), nIn(0), nFlags(0), cacheStore(false), consensusBranchId(0), error(SCRIPT_ERR_UNKNOWN_ERROR) {}
+    CScriptCheck(): amount(0), ptxTo(0), nIn(0), nFlags(0), cacheStore(false), consensusBranchId(0), error(SCRIPT_ERR_UNKNOWN_ERROR), txdata(nullptr) {}
     CScriptCheck(const CCoins& txFromIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn, uint32_t consensusBranchIdIn, PrecomputedTransactionData* txdataIn) :
         scriptPubKey(txFromIn.vout[txToIn.vin[nInIn].prevout.n].scriptPubKey), amount(txFromIn.vout[txToIn.vin[nInIn].prevout.n].nValue),
         ptxTo(&txToIn), nIn(nInIn), nFlags(nFlagsIn), cacheStore(cacheIn), consensusBranchId(consensusBranchIdIn), error(SCRIPT_ERR_UNKNOWN_ERROR), txdata(txdataIn) { }

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -80,7 +80,7 @@ void ThreadShowMetricsScreen();
  * Zcash: img2txt -W 40 -H 20 -f utf8 -d none -g 0.7 Z-yellow.orange-logo.png
  * Heart: img2txt -W 40 -H 20 -f utf8 -d none 2000px-Heart_corazón.svg.png
  */
-const std::string METRICS_ART =
+inline const std::string METRICS_ART =
 "              [0;34;40m            [0m                                                      \n"
 "          [0;34;40m                    [0m                                                  \n"
 "       [0;34;40m      [0;31;40m:8[0;33;5;40;100m8[0;1;30;90;43mSX@888@@X[0;31;5;40;100m8[0;31;40m:[0;34;40m      [0m              [0;31;5;41;101m8;     %[0;1;31;91;41mX[0m        [0;1;31;91;41mX[0;31;5;41;101m%     ;8[0m       \n"

--- a/src/mnode/mnode-manager.cpp
+++ b/src/mnode/mnode-manager.cpp
@@ -59,6 +59,7 @@ struct CompareByAddr
 
 CMasternodeMan::CMasternodeMan()
 : cs(),
+  nCachedBlockHeight(0),
   mapMasternodes(),
   mAskedUsForMasternodeList(),
   mWeAskedForMasternodeList(),

--- a/src/mnode/mnode-pastel.cpp
+++ b/src/mnode/mnode-pastel.cpp
@@ -1131,7 +1131,7 @@ CArtTradeTicket CArtTradeTicket::Create(std::string _sellTnxId, std::string _buy
     auto sellTicket = dynamic_cast<CArtSellTicket*>(pSellTicket.get());
     if (!sellTicket)
         throw std::runtime_error(tfm::format("The Art Sell ticket [txid=%s] referred by this Art Buy ticket is not in the blockchain. [txid=%s]",
-                                             ticket.sellTnxId, _buyTnxId));
+                                             ticket.sellTnxId, ticket.buyTnxId));
 
     ticket.artTnxId = sellTicket->artTnxId;
     ticket.price = sellTicket->askedPrice;

--- a/src/mnode/mnode-payments.h
+++ b/src/mnode/mnode-payments.h
@@ -161,7 +161,7 @@ public:
     std::map<COutPoint, int> mapMasternodesLastVote;
     std::map<COutPoint, int> mapMasternodesDidNotVote;
 
-    CMasternodePayments() : nStorageCoeff(1.25), nMinBlocksToStore(5000) {}
+    CMasternodePayments() : nStorageCoeff(1.25), nMinBlocksToStore(5000), nCachedBlockHeight(0) {}
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/pow/tromp/equi_miner.h
+++ b/src/pow/tromp/equi_miner.h
@@ -223,7 +223,7 @@ struct equi {
   pthread_barrier_t barry;
 #endif
 
-  equi(const u32 n_threads)
+  equi(const u32 n_threads): blake_ctx(), nsols(0), xfull(0), hfull(0), bfull(0)
   {
     assert(sizeof(hashunit) == 4);
     nthreads = n_threads;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -217,7 +217,7 @@ public:
         }
     }
 
-    prevector() : _size(0) {}
+    prevector() : _size(0), _union() {}
 
     explicit prevector(size_type n) : _size(0) {
         resize(n);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -739,7 +739,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.pushKV("sizelimit", (int64_t)MAX_BLOCK_SIZE);
     result.pushKV("curtime", pblock->GetBlockTime());
     result.pushKV("bits", strprintf("%08x", pblock->nBits));
-    result.pushKV("height", (int64_t)(pindexPrev->nHeight+1));
+    result.pushKV("height", (int64_t)(pindexPrev->nHeight) + 1);
 
     //PASTEL-->
     //MN payment

--- a/src/secp256k1/src/ecmult_gen_impl.h
+++ b/src/secp256k1/src/ecmult_gen_impl.h
@@ -80,8 +80,10 @@ static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context *ctx
         secp256k1_ge_set_all_gej_var(prec, precj, 1024, cb);
     }
     for (j = 0; j < 64; j++) {
-        for (i = 0; i < 16; i++) {
-            secp256k1_ge_to_storage(&(*ctx->prec)[j][i], &prec[j*16 + i]);
+        if (ctx->prec) {
+            for (i = 0; i < 16; i++) {
+                secp256k1_ge_to_storage(&(*ctx->prec)[j][i], &prec[j * 16 + i]);
+            }
         }
     }
 #else
@@ -102,7 +104,9 @@ static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context *dst
     } else {
 #ifndef USE_ECMULT_STATIC_PRECOMPUTATION
         dst->prec = (secp256k1_ge_storage (*)[64][16])checked_malloc(cb, sizeof(*dst->prec));
-        memcpy(dst->prec, src->prec, sizeof(*dst->prec));
+        if (dst->prec) {
+            memcpy(dst->prec, src->prec, sizeof(*dst->prec));
+        }
 #else
         (void)cb;
         dst->prec = src->prec;

--- a/src/secp256k1/src/field_10x26_impl.h
+++ b/src/secp256k1/src/field_10x26_impl.h
@@ -809,11 +809,11 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
      *  Note that [x 0 0 0 0 0 0 0 0 0 0] = [x*R1 x*R0].
      */
 
-    d  = (uint64_t)(a[0]*2) * a[9]
-       + (uint64_t)(a[1]*2) * a[8]
-       + (uint64_t)(a[2]*2) * a[7]
-       + (uint64_t)(a[3]*2) * a[6]
-       + (uint64_t)(a[4]*2) * a[5];
+    d  = ( (uint64_t)a[0]*2 ) * a[9]
+       + ( (uint64_t)a[1]*2 ) * a[8]
+       + ( (uint64_t)a[2]*2 ) * a[7]
+       + ( (uint64_t)a[3]*2 ) * a[6]
+       + ( (uint64_t)a[4]*2 ) * a[5];
     /* VERIFY_BITS(d, 64); */
     /* [d 0 0 0 0 0 0 0 0 0] = [p9 0 0 0 0 0 0 0 0 0] */
     t9 = d & M; d >>= 26;
@@ -824,10 +824,10 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     c  = (uint64_t)a[0] * a[0];
     VERIFY_BITS(c, 60);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p9 0 0 0 0 0 0 0 0 p0] */
-    d += (uint64_t)(a[1]*2) * a[9]
-       + (uint64_t)(a[2]*2) * a[8]
-       + (uint64_t)(a[3]*2) * a[7]
-       + (uint64_t)(a[4]*2) * a[6]
+    d += ( (uint64_t)a[1]*2) * a[9]
+       + ( (uint64_t)a[2]*2) * a[8]
+       + ( (uint64_t)a[3]*2) * a[7]
+       + ( (uint64_t)a[4]*2) * a[6]
        + (uint64_t)a[5] * a[5];
     VERIFY_BITS(d, 63);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
@@ -842,13 +842,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u0 t9 0 0 0 0 0 0 0 c-u0*R1 t0-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[1];
+    c += ( (uint64_t)a[0]*2) * a[1];
     VERIFY_BITS(c, 62);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    d += (uint64_t)(a[2]*2) * a[9]
-       + (uint64_t)(a[3]*2) * a[8]
-       + (uint64_t)(a[4]*2) * a[7]
-       + (uint64_t)(a[5]*2) * a[6];
+    d += ( (uint64_t)a[2]*2) * a[9]
+       + ( (uint64_t)a[3]*2) * a[8]
+       + ( (uint64_t)a[4]*2) * a[7]
+       + ( (uint64_t)a[5]*2) * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     u1 = d & M; d >>= 26; c += u1 * R0;
@@ -862,14 +862,14 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u1 0 t9 0 0 0 0 0 0 c-u1*R1 t1-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[2]
-       + (uint64_t)a[1] * a[1];
+    c += ( (uint64_t)a[0]*2) * a[2]
+       + ( (uint64_t)a[1] * a[1];
     VERIFY_BITS(c, 62);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    d += (uint64_t)(a[3]*2) * a[9]
-       + (uint64_t)(a[4]*2) * a[8]
-       + (uint64_t)(a[5]*2) * a[7]
-       + (uint64_t)a[6] * a[6];
+    d += ( (uint64_t)a[3]*2) * a[9]
+       + ( (uint64_t)a[4]*2) * a[8]
+       + ( (uint64_t)a[5]*2) * a[7]
+       + ( (uint64_t)a[6] * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     u2 = d & M; d >>= 26; c += u2 * R0;
@@ -883,13 +883,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u2 0 0 t9 0 0 0 0 0 c-u2*R1 t2-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[3]
-       + (uint64_t)(a[1]*2) * a[2];
+    c += ( (uint64_t)a[0]*2) * a[3]
+       + ( (uint64_t)a[1]*2) * a[2];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    d += (uint64_t)(a[4]*2) * a[9]
-       + (uint64_t)(a[5]*2) * a[8]
-       + (uint64_t)(a[6]*2) * a[7];
+    d += ( (uint64_t)a[4]*2) * a[9]
+       + ( (uint64_t)a[5]*2) * a[8]
+       + ( (uint64_t)a[6]*2) * a[7];
     VERIFY_BITS(d, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     u3 = d & M; d >>= 26; c += u3 * R0;
@@ -903,14 +903,14 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u3 0 0 0 t9 0 0 0 0 c-u3*R1 t3-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[4]
-       + (uint64_t)(a[1]*2) * a[3]
+    c += ( (uint64_t)a[0]*2) * a[4]
+       + ( (uint64_t)a[1]*2) * a[3]
        + (uint64_t)a[2] * a[2];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[5]*2) * a[9]
-       + (uint64_t)(a[6]*2) * a[8]
-       + (uint64_t)a[7] * a[7];
+    d += ( (uint64_t)a[5]*2) * a[9]
+       + ( (uint64_t)a[6]*2) * a[8]
+       + ( (uint64_t)a[7] * a[7];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     u4 = d & M; d >>= 26; c += u4 * R0;
@@ -924,13 +924,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u4 0 0 0 0 t9 0 0 0 c-u4*R1 t4-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[5]
-       + (uint64_t)(a[1]*2) * a[4]
-       + (uint64_t)(a[2]*2) * a[3];
+    c += ( (uint64_t)a[0]*2) * a[5]
+       + ( (uint64_t)a[1]*2) * a[4]
+       + ( (uint64_t)a[2]*2) * a[3];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[6]*2) * a[9]
-       + (uint64_t)(a[7]*2) * a[8];
+    d += ( (uint64_t)a[6]*2) * a[9]
+       + ( (uint64_t)a[7]*2) * a[8];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     u5 = d & M; d >>= 26; c += u5 * R0;
@@ -944,13 +944,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u5 0 0 0 0 0 t9 0 0 c-u5*R1 t5-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[6]
-       + (uint64_t)(a[1]*2) * a[5]
-       + (uint64_t)(a[2]*2) * a[4]
+    c += ( (uint64_t)a[0]*2) * a[6]
+       + ( (uint64_t)a[1]*2) * a[5]
+       + ( (uint64_t)a[2]*2) * a[4]
        + (uint64_t)a[3] * a[3];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[7]*2) * a[9]
+    d += ( (uint64_t)a[7]*2) * a[9]
        + (uint64_t)a[8] * a[8];
     VERIFY_BITS(d, 61);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
@@ -965,14 +965,14 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u6 0 0 0 0 0 0 t9 0 c-u6*R1 t6-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[7]
-       + (uint64_t)(a[1]*2) * a[6]
-       + (uint64_t)(a[2]*2) * a[5]
-       + (uint64_t)(a[3]*2) * a[4];
+    c += ( (uint64_t)a[0]*2) * a[7]
+       + ( (uint64_t)a[1]*2) * a[6]
+       + ( (uint64_t)a[2]*2) * a[5]
+       + ( (uint64_t)a[3]*2) * a[4];
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x8000007C00000007ULL);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[8]*2) * a[9];
+    d += ( (uint64_t)a[8]*2) * a[9];
     VERIFY_BITS(d, 58);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     u7 = d & M; d >>= 26; c += u7 * R0;
@@ -987,10 +987,10 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u7 0 0 0 0 0 0 0 t9 c-u7*R1 t7-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[8]
-       + (uint64_t)(a[1]*2) * a[7]
-       + (uint64_t)(a[2]*2) * a[6]
-       + (uint64_t)(a[3]*2) * a[5]
+    c += ( (uint64_t)a[0]*2) * a[8]
+       + ( (uint64_t)a[1]*2) * a[7]
+       + ( (uint64_t)a[2]*2) * a[6]
+       + ( (uint64_t)a[3]*2) * a[5]
        + (uint64_t)a[4] * a[4];
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x9000007B80000008ULL);

--- a/src/secp256k1/src/field_10x26_impl.h
+++ b/src/secp256k1/src/field_10x26_impl.h
@@ -863,13 +863,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
 
     c += ( (uint64_t)a[0]*2) * a[2]
-       + ( (uint64_t)a[1] * a[1];
+       + (uint64_t)a[1] * a[1];
     VERIFY_BITS(c, 62);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     d += ( (uint64_t)a[3]*2) * a[9]
        + ( (uint64_t)a[4]*2) * a[8]
        + ( (uint64_t)a[5]*2) * a[7]
-       + ( (uint64_t)a[6] * a[6];
+       + (uint64_t)a[6] * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     u2 = d & M; d >>= 26; c += u2 * R0;
@@ -910,7 +910,7 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     d += ( (uint64_t)a[5]*2) * a[9]
        + ( (uint64_t)a[6]*2) * a[8]
-       + ( (uint64_t)a[7] * a[7];
+       + (uint64_t)a[7] * a[7];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     u4 = d & M; d >>= 26; c += u4 * R0;

--- a/src/secp256k1/src/field_10x26_impl.h
+++ b/src/secp256k1/src/field_10x26_impl.h
@@ -809,11 +809,11 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
      *  Note that [x 0 0 0 0 0 0 0 0 0 0] = [x*R1 x*R0].
      */
 
-    d  = ( (uint64_t)a[0]*2 ) * a[9]
-       + ( (uint64_t)a[1]*2 ) * a[8]
-       + ( (uint64_t)a[2]*2 ) * a[7]
-       + ( (uint64_t)a[3]*2 ) * a[6]
-       + ( (uint64_t)a[4]*2 ) * a[5];
+    d  = (uint64_t)(a[0]*2) * a[9]
+       + (uint64_t)(a[1]*2) * a[8]
+       + (uint64_t)(a[2]*2) * a[7]
+       + (uint64_t)(a[3]*2) * a[6]
+       + (uint64_t)(a[4]*2) * a[5];
     /* VERIFY_BITS(d, 64); */
     /* [d 0 0 0 0 0 0 0 0 0] = [p9 0 0 0 0 0 0 0 0 0] */
     t9 = d & M; d >>= 26;
@@ -824,10 +824,10 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     c  = (uint64_t)a[0] * a[0];
     VERIFY_BITS(c, 60);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p9 0 0 0 0 0 0 0 0 p0] */
-    d += ( (uint64_t)a[1]*2) * a[9]
-       + ( (uint64_t)a[2]*2) * a[8]
-       + ( (uint64_t)a[3]*2) * a[7]
-       + ( (uint64_t)a[4]*2) * a[6]
+    d += (uint64_t)(a[1]*2) * a[9]
+       + (uint64_t)(a[2]*2) * a[8]
+       + (uint64_t)(a[3]*2) * a[7]
+       + (uint64_t)(a[4]*2) * a[6]
        + (uint64_t)a[5] * a[5];
     VERIFY_BITS(d, 63);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
@@ -842,13 +842,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u0 t9 0 0 0 0 0 0 0 c-u0*R1 t0-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[1];
+    c += (uint64_t)(a[0]*2) * a[1];
     VERIFY_BITS(c, 62);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    d += ( (uint64_t)a[2]*2) * a[9]
-       + ( (uint64_t)a[3]*2) * a[8]
-       + ( (uint64_t)a[4]*2) * a[7]
-       + ( (uint64_t)a[5]*2) * a[6];
+    d += (uint64_t)(a[2]*2) * a[9]
+       + (uint64_t)(a[3]*2) * a[8]
+       + (uint64_t)(a[4]*2) * a[7]
+       + (uint64_t)(a[5]*2) * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     u1 = d & M; d >>= 26; c += u1 * R0;
@@ -862,13 +862,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u1 0 t9 0 0 0 0 0 0 c-u1*R1 t1-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[2]
+    c += (uint64_t)(a[0]*2) * a[2]
        + (uint64_t)a[1] * a[1];
     VERIFY_BITS(c, 62);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    d += ( (uint64_t)a[3]*2) * a[9]
-       + ( (uint64_t)a[4]*2) * a[8]
-       + ( (uint64_t)a[5]*2) * a[7]
+    d += (uint64_t)(a[3]*2) * a[9]
+       + (uint64_t)(a[4]*2) * a[8]
+       + (uint64_t)(a[5]*2) * a[7]
        + (uint64_t)a[6] * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
@@ -883,13 +883,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u2 0 0 t9 0 0 0 0 0 c-u2*R1 t2-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[3]
-       + ( (uint64_t)a[1]*2) * a[2];
+    c += (uint64_t)(a[0]*2) * a[3]
+       + (uint64_t)(a[1]*2) * a[2];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    d += ( (uint64_t)a[4]*2) * a[9]
-       + ( (uint64_t)a[5]*2) * a[8]
-       + ( (uint64_t)a[6]*2) * a[7];
+    d += (uint64_t)(a[4]*2) * a[9]
+       + (uint64_t)(a[5]*2) * a[8]
+       + (uint64_t)(a[6]*2) * a[7];
     VERIFY_BITS(d, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     u3 = d & M; d >>= 26; c += u3 * R0;
@@ -903,13 +903,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u3 0 0 0 t9 0 0 0 0 c-u3*R1 t3-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[4]
-       + ( (uint64_t)a[1]*2) * a[3]
+    c += (uint64_t)(a[0]*2) * a[4]
+       + (uint64_t)(a[1]*2) * a[3]
        + (uint64_t)a[2] * a[2];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    d += ( (uint64_t)a[5]*2) * a[9]
-       + ( (uint64_t)a[6]*2) * a[8]
+    d += (uint64_t)(a[5]*2) * a[9]
+       + (uint64_t)(a[6]*2) * a[8]
        + (uint64_t)a[7] * a[7];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
@@ -924,13 +924,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u4 0 0 0 0 t9 0 0 0 c-u4*R1 t4-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[5]
-       + ( (uint64_t)a[1]*2) * a[4]
-       + ( (uint64_t)a[2]*2) * a[3];
+    c += (uint64_t)(a[0]*2) * a[5]
+       + (uint64_t)(a[1]*2) * a[4]
+       + (uint64_t)(a[2]*2) * a[3];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    d += ( (uint64_t)a[6]*2) * a[9]
-       + ( (uint64_t)a[7]*2) * a[8];
+    d += (uint64_t)(a[6]*2) * a[9]
+       + (uint64_t)(a[7]*2) * a[8];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     u5 = d & M; d >>= 26; c += u5 * R0;
@@ -944,13 +944,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u5 0 0 0 0 0 t9 0 0 c-u5*R1 t5-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[6]
-       + ( (uint64_t)a[1]*2) * a[5]
-       + ( (uint64_t)a[2]*2) * a[4]
+    c += (uint64_t)(a[0]*2) * a[6]
+       + (uint64_t)(a[1]*2) * a[5]
+       + (uint64_t)(a[2]*2) * a[4]
        + (uint64_t)a[3] * a[3];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    d += ( (uint64_t)a[7]*2) * a[9]
+    d += (uint64_t)(a[7]*2) * a[9]
        + (uint64_t)a[8] * a[8];
     VERIFY_BITS(d, 61);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
@@ -965,14 +965,14 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u6 0 0 0 0 0 0 t9 0 c-u6*R1 t6-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[7]
-       + ( (uint64_t)a[1]*2) * a[6]
-       + ( (uint64_t)a[2]*2) * a[5]
-       + ( (uint64_t)a[3]*2) * a[4];
+    c += (uint64_t)(a[0]*2) * a[7]
+       + (uint64_t)(a[1]*2) * a[6]
+       + (uint64_t)(a[2]*2) * a[5]
+       + (uint64_t)(a[3]*2) * a[4];
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x8000007C00000007ULL);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    d += ( (uint64_t)a[8]*2) * a[9];
+    d += (uint64_t)(a[8]*2) * a[9];
     VERIFY_BITS(d, 58);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     u7 = d & M; d >>= 26; c += u7 * R0;
@@ -987,10 +987,10 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u7 0 0 0 0 0 0 0 t9 c-u7*R1 t7-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += ( (uint64_t)a[0]*2) * a[8]
-       + ( (uint64_t)a[1]*2) * a[7]
-       + ( (uint64_t)a[2]*2) * a[6]
-       + ( (uint64_t)a[3]*2) * a[5]
+    c += (uint64_t)(a[0]*2) * a[8]
+       + (uint64_t)(a[1]*2) * a[7]
+       + (uint64_t)(a[2]*2) * a[6]
+       + (uint64_t)(a[3]*2) * a[5]
        + (uint64_t)a[4] * a[4];
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x9000007B80000008ULL);

--- a/src/secp256k1/src/group_impl.h
+++ b/src/secp256k1/src/group_impl.h
@@ -133,7 +133,7 @@ static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a
     size_t count = 0;
     az = (secp256k1_fe *)checked_malloc(cb, sizeof(secp256k1_fe) * len);
     for (i = 0; i < len; i++) {
-        if (!a[i].infinity) {
+        if (!a[i].infinity && az) {
             az[count++] = a[i].z;
         }
     }
@@ -145,7 +145,7 @@ static void secp256k1_ge_set_all_gej_var(secp256k1_ge *r, const secp256k1_gej *a
     count = 0;
     for (i = 0; i < len; i++) {
         r[i].infinity = a[i].infinity;
-        if (!a[i].infinity) {
+        if (!a[i].infinity  && azi) {
             secp256k1_ge_set_gej_zinv(&r[i], &a[i], &azi[count++]);
         }
     }

--- a/src/secp256k1/src/scalar_8x32_impl.h
+++ b/src/secp256k1/src/scalar_8x32_impl.h
@@ -422,7 +422,7 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint32_t *l) 
 
     /* Reduce 385 bits into 258. */
     /* p[0..8] = m[0..7] + m[8..12] * SECP256K1_N_C. */
-    c0 = m0; c1 = 0; c2 = 0;
+    c0 = m0; c1 = 0; c2 = 0; //-V1048 false warning. The value was, and will, be used/assigned by macro function muladd()
     muladd_fast(m8, SECP256K1_N_C_0);
     extract_fast(p0);
     sumadd_fast(m1);
@@ -572,7 +572,8 @@ static void secp256k1_scalar_mul_512(uint32_t *l, const secp256k1_scalar *a, con
     extract(l[13]);
     muladd_fast(a->d[7], b->d[7]);
     extract_fast(l[14]);
-    VERIFY_CHECK(c1 == 0);
+    VERIFY_CHECK(c1 == 0); //-V547 false warning. c1 value was used/assigned in muladd() macro function.
+                           //      Bad practice. But we shouldn't change the logic/implementation here
     l[15] = c0;
 }
 
@@ -632,7 +633,8 @@ static void secp256k1_scalar_sqr_512(uint32_t *l, const secp256k1_scalar *a) {
     extract(l[13]);
     muladd_fast(a->d[7], a->d[7]);
     extract_fast(l[14]);
-    VERIFY_CHECK(c1 == 0);
+    VERIFY_CHECK(c1 == 0); //-V547 false warning. c1 value was used/assigned in muladd() macro function.
+                           //      Bad practice. But we shouldn't change the logic/implementation here
     l[15] = c0;
 }
 

--- a/src/secp256k1/src/secp256k1.c
+++ b/src/secp256k1/src/secp256k1.c
@@ -57,24 +57,26 @@ struct secp256k1_context_struct {
 
 secp256k1_context* secp256k1_context_create(unsigned int flags) {
     secp256k1_context* ret = (secp256k1_context*)checked_malloc(&default_error_callback, sizeof(secp256k1_context));
-    ret->illegal_callback = default_illegal_callback;
-    ret->error_callback = default_error_callback;
+    if (ret) {
+        ret->illegal_callback = default_illegal_callback;
+        ret->error_callback = default_error_callback;
 
-    if (EXPECT((flags & SECP256K1_FLAGS_TYPE_MASK) != SECP256K1_FLAGS_TYPE_CONTEXT, 0)) {
-            secp256k1_callback_call(&ret->illegal_callback,
-                                    "Invalid flags");
-            free(ret);
-            return NULL;
-    }
+        if (EXPECT((flags & SECP256K1_FLAGS_TYPE_MASK) != SECP256K1_FLAGS_TYPE_CONTEXT, 0)) {
+                secp256k1_callback_call(&ret->illegal_callback,
+                                        "Invalid flags");
+                free(ret);
+                return NULL;
+        }
 
-    secp256k1_ecmult_context_init(&ret->ecmult_ctx);
-    secp256k1_ecmult_gen_context_init(&ret->ecmult_gen_ctx);
+        secp256k1_ecmult_context_init(&ret->ecmult_ctx);
+        secp256k1_ecmult_gen_context_init(&ret->ecmult_gen_ctx);
 
-    if (flags & SECP256K1_FLAGS_BIT_CONTEXT_SIGN) {
-        secp256k1_ecmult_gen_context_build(&ret->ecmult_gen_ctx, &ret->error_callback);
-    }
-    if (flags & SECP256K1_FLAGS_BIT_CONTEXT_VERIFY) {
-        secp256k1_ecmult_context_build(&ret->ecmult_ctx, &ret->error_callback);
+        if (flags & SECP256K1_FLAGS_BIT_CONTEXT_SIGN) {
+            secp256k1_ecmult_gen_context_build(&ret->ecmult_gen_ctx, &ret->error_callback);
+        }
+        if (flags & SECP256K1_FLAGS_BIT_CONTEXT_VERIFY) {
+            secp256k1_ecmult_context_build(&ret->ecmult_ctx, &ret->error_callback);
+        }
     }
 
     return ret;
@@ -82,10 +84,12 @@ secp256k1_context* secp256k1_context_create(unsigned int flags) {
 
 secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
     secp256k1_context* ret = (secp256k1_context*)checked_malloc(&ctx->error_callback, sizeof(secp256k1_context));
-    ret->illegal_callback = ctx->illegal_callback;
-    ret->error_callback = ctx->error_callback;
-    secp256k1_ecmult_context_clone(&ret->ecmult_ctx, &ctx->ecmult_ctx, &ctx->error_callback);
-    secp256k1_ecmult_gen_context_clone(&ret->ecmult_gen_ctx, &ctx->ecmult_gen_ctx, &ctx->error_callback);
+    if (ret) {
+        ret->illegal_callback = ctx->illegal_callback;
+        ret->error_callback = ctx->error_callback;
+        secp256k1_ecmult_context_clone(&ret->ecmult_ctx, &ctx->ecmult_ctx, &ctx->error_callback);
+        secp256k1_ecmult_gen_context_clone(&ret->ecmult_gen_ctx, &ctx->ecmult_gen_ctx, &ctx->error_callback);
+    }
     return ret;
 }
 

--- a/src/snark/libsnark/algebra/scalar_multiplication/wnaf.tcc
+++ b/src/snark/libsnark/algebra/scalar_multiplication/wnaf.tcc
@@ -28,10 +28,10 @@ std::vector<int64_t> find_wnaf(const size_t window_size, const bigint<n> &scalar
         int64_t u;
         if ((c.data[0] & 1) == 1)
         {
-            u = c.data[0] % (1u << (window_size+1));
+            u = c.data[0] % ((uint64_t)1 << (window_size+1));
             if (u > (1 << window_size))
             {
-                u = u - (1 << (window_size+1));
+                u = u - ((uint64_t)1 << (window_size+1));
             }
 
             if (u > 0)

--- a/src/snark/libsnark/gadgetlib1/gadgets/hashes/hash_io.tcc
+++ b/src/snark/libsnark/gadgetlib1/gadgets/hashes/hash_io.tcc
@@ -67,8 +67,9 @@ block_variable<FieldT>::block_variable(protoboard<FieldT> &pb,
 template<typename FieldT>
 block_variable<FieldT>::block_variable(protoboard<FieldT> &pb,
                                        const std::vector<pb_variable_array<FieldT> > &parts,
-                                       const std::string &annotation_prefix) :
-    gadget<FieldT>(pb, annotation_prefix)
+                                       const std::string &annotation_prefix) : 
+    gadget<FieldT>(pb, annotation_prefix),
+    block_size(0)
 {
     for (auto &part : parts)
     {

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1843,14 +1843,14 @@ BOOST_AUTO_TEST_CASE(rpc_z_mergetoaddress_parameters)
 
     // Sprout and Sapling inputs -> throw
     try {
-        auto operation = new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, sproutNoteInputs, saplingNoteInputs, testnetzaddr, 1);
+        std::shared_ptr<AsyncRPCOperation>  operation(new AsyncRPCOperation_mergetoaddress(std::nullopt, mtx, inputs, sproutNoteInputs, saplingNoteInputs, testnetzaddr, 1));
         BOOST_FAIL("Should have caused an error");
     } catch (const UniValue& objError) {
         BOOST_CHECK(find_error(objError, "Cannot send from both Sprout and Sapling addresses using z_mergetoaddress"));
     }
     // Sprout inputs and TransactionBuilder -> throw
     try {
-        auto operation = new AsyncRPCOperation_mergetoaddress(TransactionBuilder(), mtx, inputs, sproutNoteInputs, {}, testnetzaddr, 1);
+        std::shared_ptr<AsyncRPCOperation> operation(new AsyncRPCOperation_mergetoaddress(TransactionBuilder(), mtx, inputs, sproutNoteInputs, {}, testnetzaddr, 1));
         BOOST_FAIL("Should have caused an error");
     } catch (const UniValue& objError) {
         BOOST_CHECK(find_error(objError, "Sprout notes are not supported by the TransactionBuilder"));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -20,7 +20,7 @@ using namespace std;
 
 CTxMemPoolEntry::CTxMemPoolEntry():
     nFee(0), nTxSize(0), nModSize(0), nUsageSize(0), nTime(0), dPriority(0.0),
-    hadNoDependencies(false), spendsCoinbase(false)
+    hadNoDependencies(false), spendsCoinbase(false), nBranchId(0)
 {
     nHeight = MEMPOOL_HEIGHT;
 }
@@ -54,12 +54,17 @@ CTxMemPoolEntry::GetPriority(unsigned int currentHeight) const
 }
 
 CTxMemPool::CTxMemPool(const CFeeRate& _minRelayFee) :
-    nTransactionsUpdated(0)
+    nCheckFrequency(0), 
+    nTransactionsUpdated(0), 
+    minerPolicyEstimator(nullptr),
+    totalTxSize(0),
+    cachedInnerUsage(0),
+    mapSproutNullifiers(),
+    mapSaplingNullifiers()
 {
     // Sanity checks off by default for performance, because otherwise
     // accepting transactions becomes O(N^2) where N is the number
     // of transactions in the pool
-    nCheckFrequency = 0;
 
     minerPolicyEstimator = new CBlockPolicyEstimator(_minRelayFee);
 }

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -21,7 +21,7 @@ static bool ParsePrechecks(const std::string& str)
 {
     if (str.empty()) // No empty string allowed
         return false;
-    if (str.size() >= 1 && (json_isspace(str[0]) || json_isspace(str[str.size()-1]))) // No padding allowed
+    if (json_isspace(str[0]) || json_isspace(str[str.size()-1])) // No padding allowed
         return false;
     if (str.size() != strlen(str.c_str())) // No embedded NUL characters allowed
         return false;

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -265,7 +265,7 @@ static bool ParsePrechecks(const std::string& str)
 {
     if (str.empty()) // No empty string allowed
         return false;
-    if (str.size() >= 1 && (isspace(str[0]) || isspace(str[str.size()-1]))) // No padding allowed
+    if (isspace(str[0]) || isspace(str[str.size()-1])) // No padding allowed
         return false;
     if (str.size() != strlen(str.c_str())) // No embedded NUL characters allowed
         return false;

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -396,8 +396,8 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                         bitdb.CloseDb(strFile);
                         if (pdbCopy->close(0))
                             fSuccess = false;
-                        delete pdbCopy;
                     }
+                    delete pdbCopy;
                 }
                 if (fSuccess) {
                     Db dbA(bitdb.dbenv, 0);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -701,11 +701,14 @@ bool CWallet::SetMinVersion(enum WalletFeature nVersion, CWalletDB* pwalletdbIn,
 
     if (fFileBacked)
     {
-        CWalletDB* pwalletdb = pwalletdbIn ? pwalletdbIn : new CWalletDB(strWalletFile);
-        if (nWalletVersion > 40000)
-            pwalletdb->WriteMinVersion(nWalletVersion);
-        if (!pwalletdbIn)
-            delete pwalletdb;
+        if (nWalletVersion > 40000) {
+            if (pwalletdbIn) {
+                pwalletdbIn->WriteMinVersion(nWalletVersion);
+            } else {
+                CWalletDB pwalletdb(strWalletFile);
+                pwalletdb.WriteMinVersion(nWalletVersion);
+            }
+        }
     }
 
     return true;

--- a/src/zcash/Note.cpp
+++ b/src/zcash/Note.cpp
@@ -142,7 +142,10 @@ ZCNoteEncryption::Ciphertext SproutNotePlaintext::encrypt(ZCNoteEncryption& encr
 // Construct and populate SaplingNotePlaintext for a given note and memo.
 SaplingNotePlaintext::SaplingNotePlaintext(
     const SaplingNote& note,
-    std::array<unsigned char, ZC_MEMO_SIZE> memo) : BaseNotePlaintext(note, memo)
+    std::array<unsigned char, ZC_MEMO_SIZE> memo) : 
+    BaseNotePlaintext(note, memo),
+    rseed(),
+    leadingByte()
 {
     d = note.d;
     rcm = note.r;

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -38,7 +38,7 @@ void pre_wallet_load()
 {
     LogPrintf("%s: In progress...\n", __func__);
     if (ShutdownRequested())
-        throw new std::runtime_error("The node is shutting down");
+        throw std::runtime_error("The node is shutting down");
 
     if (pwalletMain)
         pwalletMain->Flush(false);
@@ -401,7 +401,7 @@ double benchmark_connectblock_slow()
     SelectParams(CBaseChainParams::Network::MAIN);
     CBlock block;
     FILE* fp = fopen((GetDataDir() / "benchmark/block-107134.dat").string().c_str(), "rb");
-    if (!fp) throw new std::runtime_error("Failed to open block data file");
+    if (!fp) throw std::runtime_error("Failed to open block data file");
     CAutoFile blkFile(fp, SER_DISK, CLIENT_VERSION);
     blkFile >> block;
     blkFile.fclose();


### PR DESCRIPTION
This commit is about to fix all the HIGH level warnings that was report by PVS. Most of the MEDIUM warnings were fixed also in this patch.
Please note that only warnings in Pastel code, and 3rd party code will be fixed. Dependencies code were left unfixed.
Details can be referred in below table.
![Capture](https://user-images.githubusercontent.com/42252263/120927222-4c61a480-c70a-11eb-9361-f5a2e7565a4e.PNG)

Result: 
    - Built successfully
    - PVS report show no warnings for all the issues on column (Pastel (Fixed by this commit))
    - Passed all circleci test cases
    - Passed all below test suite on local machine:
              cd qa/test-suite
              ./full_test_suite.py btest
              ./full_test_suite.py gtest
              ./full_test_suite.py sec-hard
              ./full_test_suite.py no-dot-so
              ./full_test_suite.py util-test
              ./full_test_suite.py secp256k1
              ./full_test_suite.py libsnark
              ./full_test_suite.py univalue
              ./full_test_suite.py rpc-common
              ./full_test_suite.py rpc-ext
   - Test case that took too long to complete, and failed some test cases while running:
              ./full_test_suite.py rpc-mn