### PR TITLE
Fix HIGH PVS warnings for secp256 arithmetic

### DIFF
--- a/qa/rpc-tests/mn_governance__custom_test.py
+++ b/qa/rpc-tests/mn_governance__custom_test.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2021 The Pastel Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_greater_than, initialize_chain_clean, \
+    initialize_datadir, start_nodes, start_node, connect_nodes_bi, \
+    pasteld_processes, wait_and_assert_operationid_status, p2p_port, \
+    stop_node
+from mn_common import MasterNodeCommon
+import argparse
+
+import os
+import sys
+import time
+
+from decimal import Decimal, getcontext
+getcontext().prec = 16
+
+
+TEST_CASE_EXEC_NR = 40104682; # Default: 1st subtask of 38980425
+
+# 12 Master Nodes
+private_keys_list = ["91sY9h4AQ62bAhNk1aJ7uJeSnQzSFtz7QmW5imrKmiACm7QJLXe", #0 
+                     "923JtwGJqK6mwmzVkLiG6mbLkhk1ofKE1addiM8CYpCHFdHDNGo", #1
+                     "91wLgtFJxdSRLJGTtbzns5YQYFtyYLwHhqgj19qnrLCa1j5Hp5Z", #2
+                     "92XctTrjQbRwEAAMNEwKqbiSAJsBNuiR2B8vhkzDX4ZWQXrckZv", #3
+                     "923JCnYet1pNehN6Dy4Ddta1cXnmpSiZSLbtB9sMRM1r85TWym6", #4
+                     "93BdbmxmGp6EtxFEX17FNqs2rQfLD5FMPWoN1W58KEQR24p8A6j", #5
+                     "92av9uhRBgwv5ugeNDrioyDJ6TADrM6SP7xoEqGMnRPn25nzviq", #6
+                     "91oHXFR2NVpUtBiJk37i8oBMChaQRbGjhnzWjN9KQ8LeAW7JBdN", #7
+                     "92MwGh67mKTcPPTCMpBA6tPkEE5AK3ydd87VPn8rNxtzCmYf9Yb", #8
+                     "92VSXXnFgArfsiQwuzxSAjSRuDkuirE1Vf7KvSX7JE51dExXtrc", #9
+                     "91hruvJfyRFjo7JMKnAPqCXAMiJqecSfzn9vKWBck2bKJ9CCRuo", #10
+                     "92sYv5JQHzn3UDU6sYe5kWdoSWEc6B98nyY5JN7FnTTreP8UNrq"  #11
+                    ]
+
+class MasterNodeGovernanceTest (MasterNodeCommon):
+    number_of_master_nodes = len(private_keys_list)
+    number_of_simple_nodes = 2
+    total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
+    mining_node_num = number_of_master_nodes
+    hot_node_num = number_of_master_nodes+1
+    Test_func_dictionary = {
+        40104615: "test_40104615",
+        40104682: "test_40104682"
+    } 
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, self.total_number_of_nodes)
+
+    def setup_network(self, split=False):
+        self.nodes = []
+        self.is_network_split = False
+        self.setup_masternodes_network(private_keys_list, self.number_of_simple_nodes)
+
+    def run_test (self):
+        self.mining_enough(self.mining_node_num, self.number_of_master_nodes)
+        cold_nodes = {k: v for k, v in enumerate(private_keys_list)}
+        _, _, _ = self.start_mn(self.mining_node_num, self.hot_node_num, cold_nodes, self.total_number_of_nodes)
+
+        self.reconnect_nodes(0, self.number_of_master_nodes)
+        self.sync_all()
+
+        print("Run freedcamp ID specific test")
+        
+        if(TEST_CASE_EXEC_NR == 40104682):
+            self.test_40104682()
+
+    def test_40104615 (self):
+        print("Register first ticket")
+        #####################################
+        #              NODE 0               #
+        ######################################
+
+        # NODE #0: 1. First ticket registration
+        address1 = self.nodes[0].getnewaddress()
+        res1 = self.nodes[0].governance("ticket", "add", address1, "1000", "test", "yes")
+        assert_equal(res1['result'], 'successful')
+        ticket1_id = res1['ticketId']
+        print(ticket1_id)
+        # ticket1_id now: 1 yes
+
+        #This is a failed TICKET re-REGISTRATION with YES 
+        print("NODE #0: This is a failed TICKET re-REGISTRATION with YES")
+        res1 = self.nodes[0].governance("ticket", "add", address1, "1000", "test", "yes")
+        assert_equal(res1['result'], 'failed')
+
+        #This is a failed TICKET re-REGISTRATION with NO 
+        print("NODE #0: This is a failed TICKET re-REGISTRATION with NO")
+        res1 = self.nodes[0].governance("ticket", "add", address1, "1000", "test", "no")
+        assert_equal(res1['result'], 'failed')
+
+        #This is a failed TICKET VOTE with YES - already voted yes
+        print("NODE #0: This is a failed TICKET VOTE with YES - already voted yes")
+        res1 = self.nodes[0].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'failed')
+        
+        #This is a failed TICKET VOTE with NO - one-time change shall be possible only
+        print("NODE #0: This is a failed TICKET VOTE with NO - first change to: no -> no change accepted")
+        res1 = self.nodes[0].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'failed')
+        
+        #MINIG
+        print ("Minig...")
+        self.slow_mine(2, 10, 2, 0.5)
+        #This is a failed TICKET VOTE with NO - one-time change shall be possible
+        print("NODE #0: This is a failed TICKET VOTE with NO - already voted no in another block")
+        res1 = self.nodes[0].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'failed')
+
+        #This is a failed TICKET VOTE with YES - already voted yes in another block
+        print("NODE #0: This is a failed TICKET VOTE with YES - already voted with yes in another block")
+        res1 = self.nodes[0].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'failed')
+
+        #If we reach this point it means we did not allow it to vote
+        print("Yes! It was not able to vote !")
+
+        time.sleep(3)
+        print ("Let's have some votes and ticket registration from another nodes")
+        #####################################
+        #              NODE 1               #
+        #####################################    
+        # First vote 'NO' with NODE 1    
+        print("NODE #1: This is a passed TICKET VOTE with NO - from Node #1")
+        res1 = self.nodes[1].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'successful')
+
+        # Vote again ->not accepted anymore
+        print("NODE #1: This is a failed TICKET VOTE with YES - first change not yet allowed, from Node #1")
+        res1 = self.nodes[1].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'failed')
+        
+        print ("Minig...")
+        self.slow_mine(2, 10, 2, 0.5)
+
+        #Now new blocks are mined and it should not accept the voting again.
+        print("NODE #1: This is a failed TICKET re-VOTE with YES - already there, from Node #1")
+        res1 = self.nodes[1].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'failed')
+
+        #Now new blocks are mined and it should not accept the voting again.
+        print("NODE #1: This is a failed TICKET re-VOTE with No - already voted, from Node #1")
+        res1 = self.nodes[1].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'failed')
+
+        
+        #Node #1 shall not re-register already existing ticket
+        print("NODE #1: This is a failed TICKET re-Registration from Node #1")
+        res1 = self.nodes[1].governance("ticket", "add", address1, "1000", "test", "no")
+        assert_equal(res1['result'], 'failed')
+
+        time.sleep(3)
+        #####################################
+        #              NODE 2               #
+        #####################################  
+         # First vote 'NO' with NODE 2 - passed
+        print("NODE #2: This is a passed TICKET VOTE with NO - from Node #2")
+        res1 = self.nodes[2].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'successful')
+
+        # First vote 'YES' with NODE 2 -> failed not allowed anymore 
+        print("NODE #2: This is a failed TICKET VOTE with YES - from Node #2")
+        res1 = self.nodes[2].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'failed')
+        # ticket1_id now: 1 yes
+
+        # Second change it is not allowed
+        print("NODE #2: This is a failed TICKET VOTE with NO - from Node #2")
+        res1 = self.nodes[2].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'failed')
+
+        print ("Minig...")
+        self.slow_mine(2, 10, 2, 0.5)
+
+        # Second change it is not allowed
+        print("NODE #2: This is a failed TICKET VOTE with NO - from Node #2 - already voted in another block")
+        res1 = self.nodes[2].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'failed')
+        time.sleep(3)
+        
+        #Only active masternode can vote or add ticket!
+        res1 = self.nodes[self.mining_node_num].governance("ticket", "add", address1, str(self.collateral), "test", "no")
+        assert_equal(res1['result'], 'failed')
+
+        res1 = self.nodes[self.mining_node_num].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'failed')
+
+        address2 = self.nodes[self.mining_node_num].getnewaddress()
+        res1 = self.nodes[self.mining_node_num].governance("ticket", "add", address2, str(self.collateral), "test", "yes")
+        assert_equal(res1['errorMessage'], "Only Active Master Node can vote")
+
+        time.sleep(3)
+
+        #Just to have a winning ticket let gather some yes votes
+        print("Make a ticket a winning ticket!")
+        print("NODE #3: This is a passed TICKET VOTE with YES - from Node #3")
+        res1 = self.nodes[3].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'successful')
+
+        print("NODE #4: This is a passed TICKET VOTE with YES - from Node #4")
+        res1 = self.nodes[4].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'successful')
+
+        print ("Minig...")
+        self.slow_mine(2, 10, 2, 0.5)
+
+        print("Register second ticket")
+        #2. Second ticket
+        res1 = self.nodes[2].governance("ticket", "add", address2, "2000", "test", "yes")
+        assert_equal(res1['result'], 'successful')
+        ticket2_id = res1['ticketId']
+
+        print ("Minig after 2nd ticket...")
+        time.sleep(3)
+        self.slow_mine(2, 10, 2, 0.5)
+
+        #Add some votes for the second ticket
+        print("NODE #4: This is a passed TICKET VOTE with YES - from Node #4")
+        res1 = self.nodes[0].governance("ticket", "vote", ticket2_id, "yes")
+        assert_equal(res1['result'], 'successful')
+        print("NODE #5: This is a passed TICKET VOTE with No - from Node #5")
+        res1 = self.nodes[5].governance("ticket", "vote", ticket2_id, "no")
+        assert_equal(res1['result'], 'successful')
+
+        self.nodes[self.mining_node_num].generate(5)
+
+        print("Waiting 60 seconds")
+        time.sleep(60)
+
+        #Mining to have a winner ticket :)
+        print ("Minig...")
+        self.slow_mine(2, 10, 2, 0.5)
+        print ("Minig...")
+        self.slow_mine(2, 10, 2, 0.5)
+
+        #Currently disable to check the status of a possible bug!
+        #Mining to have everyone in 'synch'. (qucik and slow)
+        self.nodes[self.mining_node_num].generate(150)
+        print ("Minig...")
+        self.slow_mine(2, 10, 2, 0.5)
+
+        #Simply print all nodes ticket list
+        for i in range(0, self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+            print ("\n\nNode : {}. tickets are: \n\n".format(i))
+            res1 = self.nodes[i].governance("list", "tickets")
+
+        print("\n\nTesting  tickets votes\n")
+        #3. Preliminary test, should be 2 tickets: 1st ticket - 3 votes, 2 yes; 2nd ticket - 1 vote, 1 yes
+        for i in range(0, self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+            print ("Node : {}. tickets are: \n".format(i))
+            res1 = self.nodes[i].governance("list", "tickets")
+            print(res1)
+            for j in range(0, 2):
+                if res1[j]['id'] == ticket1_id:
+                    print(res1[j]['ticket'])
+                    assert_equal("Total votes: 6, Yes votes: 4" in res1[j]['ticket'], True) #nnot necessarily correct
+                elif res1[j]['id'] == ticket2_id:
+                    print(res1[j]['ticket'])
+                    assert_equal("Total votes: 1, Yes votes: 1" in res1[j]['ticket'], True)
+                else:
+                    assert_equal(res1[0]['id'], res1[1]['id'])
+
+    def test_40104682 (self):
+        print ("Wait 3min")
+        time.sleep(180)
+        print("Register first ticket")
+        #####################################
+        #              NODE 0               #
+        ######################################
+
+        # NODE #0: 1. First ticket registration
+        address1 = self.nodes[0].getnewaddress()
+        res1 = self.nodes[0].governance("ticket", "add", address1, "300", "test", "yes")
+        assert_equal(res1['result'], 'successful')
+        ticket1_id = res1['ticketId']
+        print(ticket1_id)
+
+        time.sleep(3)
+        print ("Let's have some votes and ticket registration from another nodes")
+        #####################################
+        #              NODE 1               #
+        #####################################    
+        # First vote 'NO' with NODE 1    
+        print("NODE #1: This is a passed TICKET VOTE with NO - from Node #1")
+        res1 = self.nodes[1].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'successful')
+
+        print ("Minig...")
+        self.slow_mine(2, 5, 2, 2)
+        print ("Wait 10 seconds")
+        time.sleep(10)
+
+        
+        time.sleep(3)
+        #####################################
+        #              NODE 2               #
+        #####################################  
+         # First vote 'NO' with NODE 2 - passed
+        print("NODE #2: This is a passed TICKET VOTE with NO - from Node #2")
+        res1 = self.nodes[2].governance("ticket", "vote", ticket1_id, "no")
+        assert_equal(res1['result'], 'successful')
+
+        print ("Minig...")
+        self.slow_mine(2, 5, 2, 2)
+
+        time.sleep(3)
+
+        #Just to have a winning ticket let's gather some yes votes
+        print("Make ticket1 a winning ticket!")
+        print("NODE #3: This is a passed TICKET VOTE with YES - from Node #3")
+        res1 = self.nodes[3].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'successful')
+
+        print("NODE #4: This is a passed TICKET VOTE with YES - from Node #4")
+        res1 = self.nodes[4].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'successful')
+
+        print("NODE #5: This is a passed TICKET VOTE with NO - from Node #5 and vote is accepted but not counted by itself?")
+        res1 = self.nodes[5].governance("ticket", "vote", ticket1_id, "yes")
+        assert_equal(res1['result'], 'successful')
+
+        print ("Minig...")
+        self.slow_mine(2, 5, 2, 2)
+        print("Waiting 20 seconds")
+        time.sleep(20)
+
+        print("Register second ticket")
+        #2. Second ticket
+        address2 = self.nodes[self.mining_node_num].getnewaddress()
+        res1 = self.nodes[2].governance("ticket", "add", address2, "110", "test", "yes")
+        assert_equal(res1['result'], 'successful')
+        ticket2_id = res1['ticketId']
+
+        print ("Minig after 2nd ticket...")
+        #time.sleep(3)
+        print ("Minig...")
+        self.slow_mine(2, 5, 2, 2)
+        print("Waiting 20 seconds")
+        time.sleep(20)
+
+        #Add some votes for the second ticket
+        print("NODE #4: This is a passed TICKET VOTE with YES - from Node #4")
+        res1 = self.nodes[0].governance("ticket", "vote", ticket2_id, "yes")
+        assert_equal(res1['result'], 'successful')
+        print("NODE #5: This is a passed TICKET VOTE with No - from Node #5")
+        res1 = self.nodes[5].governance("ticket", "vote", ticket2_id, "no")
+        assert_equal(res1['result'], 'successful')
+
+        print ("Minig...")
+        self.slow_mine(2, 5, 2, 2)
+        print("Waiting 20 minutes") # 25 minute works
+        time.sleep(60)
+
+        #Simply print all nodes ticket list
+        for i in range(0, self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+            print ("\n\nNode : {}. tickets are: \n\n".format(i))
+            res1 = self.nodes[i].governance("list", "tickets")
+
+        #Mining blocks to have at least one winning ticket:
+
+        #First without waiting too much and printing status
+        # Theoretically baseed on testing 516 tickets shall be mined to have a winning ticket
+        print ("Minig...")
+        self.slow_mine(5, 100, 7, 7)
+        print ("Almost last mining finshed wait 60 seconds!")
+        #Checkout how to reproduce not in-synch nodes
+        #time.sleep(60)
+
+        print ("Mine last blocks before stopVoteHeight!")
+        self.nodes[self.mining_node_num].generate(15)
+        time.sleep(20)
+
+        print ("Mine 'over' stopVoteHeight and restart and read ticket list")
+        self.nodes[self.mining_node_num].generate(3)
+
+        time.sleep(20)
+
+        time.sleep(10)
+        print ("Generate some more blocks just to be sure")
+        self.nodes[self.mining_node_num].generate(3)
+
+        time.sleep(10)
+        actual_block_height=self.nodes[0].getblockcount()
+        print ("Generate even more, to be right in front of ticket1 close. Node 0 blockheight: {}".format(actual_block_height))
+        self.nodes[self.mining_node_num].generate(3)
+        
+        print("Last wait time for 25 min")
+        time.sleep(1500)
+        print ("Hopefully this time we have a borken network")
+        
+        for i in range(8, 12):
+            self.generate_split_ticket(i)
+
+        print("3-4 new ticket created...Wait 2 min and let's see")
+        print("T+10 is the nFirstPaymentBloc now. Let's see!")
+        
+        time.sleep(180)
+        print("generate T-2 and wait 1 min")
+        for i in range(self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+        self.nodes[self.mining_node_num].generate(1)
+        for i in range(self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+        time.sleep(60)
+        print("generate T-1 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        for i in range(self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+        time.sleep(60)
+        print("generate T and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        for i in range(self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+        time.sleep(60)
+        print("generate T+1 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        for i in range(self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+        time.sleep(60)
+        print("generate T+2 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        print("generate T+2 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+        print("generate T+4 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+        print("generate T+5 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+        print("generate T+6 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+        print("generate T+7 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+        print("generate T+8 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+        print("generate T+9 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+        print("generate T+10 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        print("generate T+11 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        print("generate T+12 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        print("generate T+13 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        print("generate T+14 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        print("generate T+15 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        print("generate T+16 and wait")
+        self.nodes[self.mining_node_num].generate(1)
+        time.sleep(60)
+
+        # This could be a reference point to examine log results
+        print("Wait for 5 min")
+        time.sleep(300)
+
+        print("\n\n\n Check if tickets are raised 1 or 2 chains: \n")
+
+        for i in range(self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+            print ("\n\nNode : {}. tickets are: \n\n".format(i))
+            res1 = self.nodes[i].governance("list", "tickets")
+
+        print ("\nSecond long iteration of block generation.\n")
+        print ("Minig...")
+        print ("\nMine 100 more !")
+        for x in range(100):
+            self.nodes[self.mining_node_num].generate(1)
+            time.sleep(7)
+        
+        # This will be a second iteration point
+        print("\nWait for 10 min")
+        time.sleep(600)
+
+        print("\n\n\n Last iteration if tickets are raised 1 or 2 chains: \n")
+
+        for i in range(self.total_number_of_nodes):
+            blocckount=self.nodes[i].getblockcount()
+            print("Node:{} block_count: {}".format(i,blocckount))
+            print ("\n\nNode : {}. tickets are: \n\n".format(i))
+            res1 = self.nodes[i].governance("list", "tickets")
+        
+
+    def generate_split_ticket(self, node_nr):
+        address = self.nodes[node_nr].getnewaddress()
+        tcket_amount = node_nr*10 +1
+        res1 = self.nodes[0].governance("ticket", "add", address, tcket_amount, "Splitted_by_node_{}".format(node_nr), "yes")
+    
+        #Implement "mining" actually
+    def slow_mine(self, number_of_bursts, num_in_each_burst, wait_between_bursts, wait_inside_burst):
+        for x in range(number_of_bursts):
+            for y in range(num_in_each_burst):
+                self.nodes[self.mining_node_num].generate(1)
+                time.sleep(wait_inside_burst)
+            time.sleep(wait_between_bursts)
+
+if __name__ == '__main__':
+    #parser = argparse.ArgumentParser()
+    #parser.add_argument('freedcamp', help='Freedcamp ID to test against')
+    #args = parser.parse_args()
+    #TEST_CASE_EXEC_NR = args.freedcamp
+    MasterNodeGovernanceTest ().main ()

--- a/src/mnode/mnode-governance.h
+++ b/src/mnode/mnode-governance.h
@@ -53,8 +53,8 @@ public:
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << vinMasternode.prevout;
         ss << ticketId;
-        ss << nVoteBlockHeight;
-        ss << bVote;
+        //ss << nVoteBlockHeight; -> removed from Sign()
+        //ss << bVote; -> removed from Sign()
         return ss.GetHash();
     }
 
@@ -137,7 +137,7 @@ public:
     bool VoteOpen();
     bool AddVote(CGovernanceVote& voteNew, std::string& strErrorRet);
     bool IsWinner(int height);
-    bool IsPayed() {return nAmountPaid >= nAmountToPay;}
+    bool IsPaid() {return nAmountPaid >= nAmountToPay;}
 
     uint256 GetHash() const;
 

--- a/src/mnode/mnode-rpc.cpp
+++ b/src/mnode/mnode-rpc.cpp
@@ -2482,7 +2482,7 @@ static const CRPCCommand commands[] =
     { "mnode",               "masternodelist",         &masternodelist,         true  },
     { "mnode",               "masternodebroadcast",    &masternodebroadcast,    true  },
     { "mnode",               "mnsync",                 &mnsync,                 true  },
-//    { "mnode",               "governance",             &governance,             true  },
+    { "mnode",               "governance",             &governance,             true  },
     { "mnode",               "pastelid",               &pastelid,               true  },
     { "mnode",               "storagefee",             &storagefee,             true  },
     { "mnode",               "chaindata",              &chaindata,              true  },

--- a/src/mnode/mnode-validation.cpp
+++ b/src/mnode/mnode-validation.cpp
@@ -107,7 +107,7 @@ void FillOtherBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmoun
 {
     // Fill Governance payment
     //TODO: Fix governance tickets processing
-//    masterNodeCtrl.masternodeGovernance.FillGovernancePayment(txNew, nBlockHeight, blockReward, txoutGovernanceRet);
+    masterNodeCtrl.masternodeGovernance.FillGovernancePayment(txNew, nBlockHeight, blockReward, txoutGovernanceRet);
     
     // FILL BLOCK PAYEE WITH MASTERNODE PAYMENT
     masterNodeCtrl.masternodePayments.FillMasterNodePayment(txNew, nBlockHeight, blockReward, txoutMasternodeRet);

--- a/src/secp256k1/src/field_10x26_impl.h
+++ b/src/secp256k1/src/field_10x26_impl.h
@@ -11,6 +11,8 @@
 #include "num.h"
 #include "field.h"
 
+#define SECP256_PVS_FIX
+
 #ifdef VERIFY
 static void secp256k1_fe_verify(const secp256k1_fe *a) {
     const uint32_t *d = a->n;
@@ -809,11 +811,20 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
      *  Note that [x 0 0 0 0 0 0 0 0 0 0] = [x*R1 x*R0].
      */
 
+#ifdef SECP256_PVS_FIX
     d  = ( (uint64_t)a[0]*2 ) * a[9]
        + ( (uint64_t)a[1]*2 ) * a[8]
        + ( (uint64_t)a[2]*2 ) * a[7]
        + ( (uint64_t)a[3]*2 ) * a[6]
        + ( (uint64_t)a[4]*2 ) * a[5];
+#else // !SECP256_PVS_FIX
+    d  = (uint64_t)(a[0]*2) * a[9]  // -V1028
+       + (uint64_t)(a[1]*2) * a[8]  // -V1028
+       + (uint64_t)(a[2]*2) * a[7]  // -V1028
+       + (uint64_t)(a[3]*2) * a[6]  // -V1028
+       + (uint64_t)(a[4]*2) * a[5]; // -V1028
+#endif // SECP256_PVS_FIX
+
     /* VERIFY_BITS(d, 64); */
     /* [d 0 0 0 0 0 0 0 0 0] = [p9 0 0 0 0 0 0 0 0 0] */
     t9 = d & M; d >>= 26;
@@ -824,11 +835,20 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     c  = (uint64_t)a[0] * a[0];
     VERIFY_BITS(c, 60);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p9 0 0 0 0 0 0 0 0 p0] */
+
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[1]*2) * a[9]
        + ( (uint64_t)a[2]*2) * a[8]
        + ( (uint64_t)a[3]*2) * a[7]
        + ( (uint64_t)a[4]*2) * a[6]
        + (uint64_t)a[5] * a[5];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[1]*2) * a[9]  // -V1028
+       + (uint64_t)(a[2]*2) * a[8]  // -V1028
+       + (uint64_t)(a[3]*2) * a[7]  // -V1028
+       + (uint64_t)(a[4]*2) * a[6]  // -V1028
+       + (uint64_t)a[5] * a[5];
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 63);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
     u0 = d & M; d >>= 26; c += u0 * R0;
@@ -842,13 +862,26 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u0 t9 0 0 0 0 0 0 0 c-u0*R1 t0-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[1];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[1];  // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 62);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 p1 p0] */
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[2]*2) * a[9]
        + ( (uint64_t)a[3]*2) * a[8]
        + ( (uint64_t)a[4]*2) * a[7]
        + ( (uint64_t)a[5]*2) * a[6];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[2]*2) * a[9]  // -V1028
+       + (uint64_t)(a[3]*2) * a[8]  // -V1028
+       + (uint64_t)(a[4]*2) * a[7]  // -V1028
+       + (uint64_t)(a[5]*2) * a[6]; // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 63);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     u1 = d & M; d >>= 26; c += u1 * R0;
@@ -862,14 +895,28 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u1 0 t9 0 0 0 0 0 0 c-u1*R1 t1-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[2]
        + (uint64_t)a[1] * a[1];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[2]  // -V1028
+       + (uint64_t)a[1] * a[1];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 62);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[3]*2) * a[9]
        + ( (uint64_t)a[4]*2) * a[8]
        + ( (uint64_t)a[5]*2) * a[7]
        + (uint64_t)a[6] * a[6];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[3]*2) * a[9]  // -V1028
+       + (uint64_t)(a[4]*2) * a[8]  // -V1028
+       + (uint64_t)(a[5]*2) * a[7]  // -V1028
+       + (uint64_t)a[6] * a[6];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     u2 = d & M; d >>= 26; c += u2 * R0;
@@ -883,13 +930,25 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u2 0 0 t9 0 0 0 0 0 c-u2*R1 t2-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[3]
        + ( (uint64_t)a[1]*2) * a[2];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[3]  // -V1028
+       + (uint64_t)(a[1]*2) * a[2]; // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[4]*2) * a[9]
        + ( (uint64_t)a[5]*2) * a[8]
        + ( (uint64_t)a[6]*2) * a[7];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[4]*2) * a[9]  // -V1028
+       + (uint64_t)(a[5]*2) * a[8]  // -V1028
+       + (uint64_t)(a[6]*2) * a[7]; // -V1028
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     u3 = d & M; d >>= 26; c += u3 * R0;
@@ -903,14 +962,28 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u3 0 0 0 t9 0 0 0 0 c-u3*R1 t3-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[4]
        + ( (uint64_t)a[1]*2) * a[3]
        + (uint64_t)a[2] * a[2];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[4]  // -V1028
+       + (uint64_t)(a[1]*2) * a[3]  // -V1028
+       + (uint64_t)a[2] * a[2];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[5]*2) * a[9]
        + ( (uint64_t)a[6]*2) * a[8]
        + (uint64_t)a[7] * a[7];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[5]*2) * a[9]  // -V1028
+       + (uint64_t)(a[6]*2) * a[8]  // -V1028
+       + (uint64_t)a[7] * a[7];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     u4 = d & M; d >>= 26; c += u4 * R0;
@@ -924,13 +997,25 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u4 0 0 0 0 t9 0 0 0 c-u4*R1 t4-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[5]
        + ( (uint64_t)a[1]*2) * a[4]
        + ( (uint64_t)a[2]*2) * a[3];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[5]  // -V1028
+       + (uint64_t)(a[1]*2) * a[4]  // -V1028
+       + (uint64_t)(a[2]*2) * a[3]; // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[6]*2) * a[9]
        + ( (uint64_t)a[7]*2) * a[8];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[6]*2) * a[9]  // -V1028
+       + (uint64_t)(a[7]*2) * a[8]; // -V1028
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     u5 = d & M; d >>= 26; c += u5 * R0;
@@ -944,14 +1029,28 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u5 0 0 0 0 0 t9 0 0 c-u5*R1 t5-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[6]
        + ( (uint64_t)a[1]*2) * a[5]
        + ( (uint64_t)a[2]*2) * a[4]
        + (uint64_t)a[3] * a[3];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[6]  // -V1028
+       + (uint64_t)(a[1]*2) * a[5]  // -V1028
+       + (uint64_t)(a[2]*2) * a[4]  // -V1028
+       + (uint64_t)a[3] * a[3];
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(c, 63);
+
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[7]*2) * a[9]
        + (uint64_t)a[8] * a[8];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[7]*2) * a[9]  // -V1028
+       + (uint64_t)a[8] * a[8];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 61);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
     u6 = d & M; d >>= 26; c += u6 * R0;
@@ -965,14 +1064,26 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u6 0 0 0 0 0 0 t9 0 c-u6*R1 t6-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[7]
        + ( (uint64_t)a[1]*2) * a[6]
        + ( (uint64_t)a[2]*2) * a[5]
        + ( (uint64_t)a[3]*2) * a[4];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[7]  // -V1028
+       + (uint64_t)(a[1]*2) * a[6]  // -V1028
+       + (uint64_t)(a[2]*2) * a[5]  // -V1028
+       + (uint64_t)(a[3]*2) * a[4]; // -V1028
+#endif // SECP256_PVS_FIX
+
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x8000007C00000007ULL);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
+#ifdef SECP256_PVS_FIX
     d += ( (uint64_t)a[8]*2) * a[9];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[8]*2) * a[9]; // -V1028
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 58);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     u7 = d & M; d >>= 26; c += u7 * R0;
@@ -987,11 +1098,20 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u7 0 0 0 0 0 0 0 t9 c-u7*R1 t7-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
 
+#ifdef SECP256_PVS_FIX
     c += ( (uint64_t)a[0]*2) * a[8]
        + ( (uint64_t)a[1]*2) * a[7]
        + ( (uint64_t)a[2]*2) * a[6]
        + ( (uint64_t)a[3]*2) * a[5]
        + (uint64_t)a[4] * a[4];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[8]  // -V1028
+       + (uint64_t)(a[1]*2) * a[7]  // -V1028
+       + (uint64_t)(a[2]*2) * a[6]  // -V1028
+       + (uint64_t)(a[3]*2) * a[5]  // -V1028
+       + (uint64_t)a[4] * a[4];
+#endif // SECP256_PVS_FIX
+
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x9000007B80000008ULL);
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */

--- a/src/secp256k1/src/field_10x26_impl.h
+++ b/src/secp256k1/src/field_10x26_impl.h
@@ -809,11 +809,11 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
      *  Note that [x 0 0 0 0 0 0 0 0 0 0] = [x*R1 x*R0].
      */
 
-    d  = (uint64_t)(a[0]*2) * a[9]
-       + (uint64_t)(a[1]*2) * a[8]
-       + (uint64_t)(a[2]*2) * a[7]
-       + (uint64_t)(a[3]*2) * a[6]
-       + (uint64_t)(a[4]*2) * a[5];
+    d  = ( (uint64_t)a[0]*2 ) * a[9]
+       + ( (uint64_t)a[1]*2 ) * a[8]
+       + ( (uint64_t)a[2]*2 ) * a[7]
+       + ( (uint64_t)a[3]*2 ) * a[6]
+       + ( (uint64_t)a[4]*2 ) * a[5];
     /* VERIFY_BITS(d, 64); */
     /* [d 0 0 0 0 0 0 0 0 0] = [p9 0 0 0 0 0 0 0 0 0] */
     t9 = d & M; d >>= 26;
@@ -824,10 +824,10 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     c  = (uint64_t)a[0] * a[0];
     VERIFY_BITS(c, 60);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p9 0 0 0 0 0 0 0 0 p0] */
-    d += (uint64_t)(a[1]*2) * a[9]
-       + (uint64_t)(a[2]*2) * a[8]
-       + (uint64_t)(a[3]*2) * a[7]
-       + (uint64_t)(a[4]*2) * a[6]
+    d += ( (uint64_t)a[1]*2) * a[9]
+       + ( (uint64_t)a[2]*2) * a[8]
+       + ( (uint64_t)a[3]*2) * a[7]
+       + ( (uint64_t)a[4]*2) * a[6]
        + (uint64_t)a[5] * a[5];
     VERIFY_BITS(d, 63);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
@@ -842,13 +842,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u0 t9 0 0 0 0 0 0 0 c-u0*R1 t0-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[1];
+    c += ( (uint64_t)a[0]*2) * a[1];
     VERIFY_BITS(c, 62);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    d += (uint64_t)(a[2]*2) * a[9]
-       + (uint64_t)(a[3]*2) * a[8]
-       + (uint64_t)(a[4]*2) * a[7]
-       + (uint64_t)(a[5]*2) * a[6];
+    d += ( (uint64_t)a[2]*2) * a[9]
+       + ( (uint64_t)a[3]*2) * a[8]
+       + ( (uint64_t)a[4]*2) * a[7]
+       + ( (uint64_t)a[5]*2) * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     u1 = d & M; d >>= 26; c += u1 * R0;
@@ -862,13 +862,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u1 0 t9 0 0 0 0 0 0 c-u1*R1 t1-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[2]
+    c += ( (uint64_t)a[0]*2) * a[2]
        + (uint64_t)a[1] * a[1];
     VERIFY_BITS(c, 62);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    d += (uint64_t)(a[3]*2) * a[9]
-       + (uint64_t)(a[4]*2) * a[8]
-       + (uint64_t)(a[5]*2) * a[7]
+    d += ( (uint64_t)a[3]*2) * a[9]
+       + ( (uint64_t)a[4]*2) * a[8]
+       + ( (uint64_t)a[5]*2) * a[7]
        + (uint64_t)a[6] * a[6];
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
@@ -883,13 +883,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u2 0 0 t9 0 0 0 0 0 c-u2*R1 t2-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[3]
-       + (uint64_t)(a[1]*2) * a[2];
+    c += ( (uint64_t)a[0]*2) * a[3]
+       + ( (uint64_t)a[1]*2) * a[2];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    d += (uint64_t)(a[4]*2) * a[9]
-       + (uint64_t)(a[5]*2) * a[8]
-       + (uint64_t)(a[6]*2) * a[7];
+    d += ( (uint64_t)a[4]*2) * a[9]
+       + ( (uint64_t)a[5]*2) * a[8]
+       + ( (uint64_t)a[6]*2) * a[7];
     VERIFY_BITS(d, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     u3 = d & M; d >>= 26; c += u3 * R0;
@@ -903,13 +903,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u3 0 0 0 t9 0 0 0 0 c-u3*R1 t3-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[4]
-       + (uint64_t)(a[1]*2) * a[3]
+    c += ( (uint64_t)a[0]*2) * a[4]
+       + ( (uint64_t)a[1]*2) * a[3]
        + (uint64_t)a[2] * a[2];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[5]*2) * a[9]
-       + (uint64_t)(a[6]*2) * a[8]
+    d += ( (uint64_t)a[5]*2) * a[9]
+       + ( (uint64_t)a[6]*2) * a[8]
        + (uint64_t)a[7] * a[7];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
@@ -924,13 +924,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u4 0 0 0 0 t9 0 0 0 c-u4*R1 t4-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[5]
-       + (uint64_t)(a[1]*2) * a[4]
-       + (uint64_t)(a[2]*2) * a[3];
+    c += ( (uint64_t)a[0]*2) * a[5]
+       + ( (uint64_t)a[1]*2) * a[4]
+       + ( (uint64_t)a[2]*2) * a[3];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[6]*2) * a[9]
-       + (uint64_t)(a[7]*2) * a[8];
+    d += ( (uint64_t)a[6]*2) * a[9]
+       + ( (uint64_t)a[7]*2) * a[8];
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     u5 = d & M; d >>= 26; c += u5 * R0;
@@ -944,13 +944,13 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u5 0 0 0 0 0 t9 0 0 c-u5*R1 t5-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[6]
-       + (uint64_t)(a[1]*2) * a[5]
-       + (uint64_t)(a[2]*2) * a[4]
+    c += ( (uint64_t)a[0]*2) * a[6]
+       + ( (uint64_t)a[1]*2) * a[5]
+       + ( (uint64_t)a[2]*2) * a[4]
        + (uint64_t)a[3] * a[3];
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[7]*2) * a[9]
+    d += ( (uint64_t)a[7]*2) * a[9]
        + (uint64_t)a[8] * a[8];
     VERIFY_BITS(d, 61);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
@@ -965,14 +965,14 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u6 0 0 0 0 0 0 t9 0 c-u6*R1 t6-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[7]
-       + (uint64_t)(a[1]*2) * a[6]
-       + (uint64_t)(a[2]*2) * a[5]
-       + (uint64_t)(a[3]*2) * a[4];
+    c += ( (uint64_t)a[0]*2) * a[7]
+       + ( (uint64_t)a[1]*2) * a[6]
+       + ( (uint64_t)a[2]*2) * a[5]
+       + ( (uint64_t)a[3]*2) * a[4];
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x8000007C00000007ULL);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[8]*2) * a[9];
+    d += ( (uint64_t)a[8]*2) * a[9];
     VERIFY_BITS(d, 58);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     u7 = d & M; d >>= 26; c += u7 * R0;
@@ -987,10 +987,10 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u7 0 0 0 0 0 0 0 t9 c-u7*R1 t7-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[8]
-       + (uint64_t)(a[1]*2) * a[7]
-       + (uint64_t)(a[2]*2) * a[6]
-       + (uint64_t)(a[3]*2) * a[5]
+    c += ( (uint64_t)a[0]*2) * a[8]
+       + ( (uint64_t)a[1]*2) * a[7]
+       + ( (uint64_t)a[2]*2) * a[6]
+       + ( (uint64_t)a[3]*2) * a[5]
        + (uint64_t)a[4] * a[4];
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x9000007B80000008ULL);


### PR DESCRIPTION
To fix all V1028 PVS warnings in src/secp256k1/src/field_10x26_impl.h

Result:
- Built successfully
- PVS report show no warnings for all the issues on column (Pastel (Fixed by this commit))
- Passed all circleci test cases
- Passed all below test suite on local machine:
cd qa/test-suite
./full_test_suite.py btest
./full_test_suite.py gtest
./full_test_suite.py sec-hard
./full_test_suite.py no-dot-so
./full_test_suite.py util-test
./full_test_suite.py secp256k1
./full_test_suite.py libsnark
./full_test_suite.py univalue
./full_test_suite.py rpc-common
./full_test_suite.py rpc-ext

Test case that took too long to complete, and failed some test cases while running:
./full_test_suite.py rpc-mn