### PR TITLE
Fix HIGH PVS 1028 warnings for secp256 arithmetic

### DIFF
--- a/src/secp256k1/src/field_10x26_impl.h
+++ b/src/secp256k1/src/field_10x26_impl.h
@@ -11,6 +11,8 @@
 #include "num.h"
 #include "field.h"
 
+#define SECP256_PVS_FIX
+
 #ifdef VERIFY
 static void secp256k1_fe_verify(const secp256k1_fe *a) {
     const uint32_t *d = a->n;
@@ -809,11 +811,20 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
      *  Note that [x 0 0 0 0 0 0 0 0 0 0] = [x*R1 x*R0].
      */
 
-    d  = (uint64_t)(a[0]*2) * a[9]
-       + (uint64_t)(a[1]*2) * a[8]
-       + (uint64_t)(a[2]*2) * a[7]
-       + (uint64_t)(a[3]*2) * a[6]
-       + (uint64_t)(a[4]*2) * a[5];
+#ifdef SECP256_PVS_FIX
+    d  = ( static_cast<uint64_t>(a[0])*2 ) * a[9]
+       + ( static_cast<uint64_t>(a[1])*2 ) * a[8]
+       + ( static_cast<uint64_t>(a[2])*2 ) * a[7]
+       + ( static_cast<uint64_t>(a[3])*2 ) * a[6]
+       + ( static_cast<uint64_t>(a[4])*2 ) * a[5];
+#else // !SECP256_PVS_FIX
+    d  = (uint64_t)(a[0]*2) * a[9]  // -V1028
+       + (uint64_t)(a[1]*2) * a[8]  // -V1028
+       + (uint64_t)(a[2]*2) * a[7]  // -V1028
+       + (uint64_t)(a[3]*2) * a[6]  // -V1028
+       + (uint64_t)(a[4]*2) * a[5]; // -V1028
+#endif // SECP256_PVS_FIX
+
     /* VERIFY_BITS(d, 64); */
     /* [d 0 0 0 0 0 0 0 0 0] = [p9 0 0 0 0 0 0 0 0 0] */
     t9 = d & M; d >>= 26;
@@ -824,11 +835,20 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     c  = (uint64_t)a[0] * a[0];
     VERIFY_BITS(c, 60);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p9 0 0 0 0 0 0 0 0 p0] */
-    d += (uint64_t)(a[1]*2) * a[9]
-       + (uint64_t)(a[2]*2) * a[8]
-       + (uint64_t)(a[3]*2) * a[7]
-       + (uint64_t)(a[4]*2) * a[6]
+
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[1])*2) * a[9]
+       + ( static_cast<uint64_t>(a[2])*2) * a[8]
+       + ( static_cast<uint64_t>(a[3])*2) * a[7]
+       + ( static_cast<uint64_t>(a[4])*2) * a[6]
+       + static_cast<uint64_t>(a[5]) * a[5];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[1]*2) * a[9]  // -V1028
+       + (uint64_t)(a[2]*2) * a[8]  // -V1028
+       + (uint64_t)(a[3]*2) * a[7]  // -V1028
+       + (uint64_t)(a[4]*2) * a[6]  // -V1028
        + (uint64_t)a[5] * a[5];
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 63);
     /* [d t9 0 0 0 0 0 0 0 0 c] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
     u0 = d & M; d >>= 26; c += u0 * R0;
@@ -842,13 +862,26 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u0 t9 0 0 0 0 0 0 0 c-u0*R1 t0-u0*R0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 0 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[1];
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[1];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[1];  // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 62);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p10 p9 0 0 0 0 0 0 0 p1 p0] */
-    d += (uint64_t)(a[2]*2) * a[9]
-       + (uint64_t)(a[3]*2) * a[8]
-       + (uint64_t)(a[4]*2) * a[7]
-       + (uint64_t)(a[5]*2) * a[6];
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[2])*2) * a[9]
+       + ( static_cast<uint64_t>(a[3])*2) * a[8]
+       + ( static_cast<uint64_t>(a[4])*2) * a[7]
+       + ( static_cast<uint64_t>(a[5])*2) * a[6];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[2]*2) * a[9]  // -V1028
+       + (uint64_t)(a[3]*2) * a[8]  // -V1028
+       + (uint64_t)(a[4]*2) * a[7]  // -V1028
+       + (uint64_t)(a[5]*2) * a[6]; // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 63);
     /* [d 0 t9 0 0 0 0 0 0 0 c t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     u1 = d & M; d >>= 26; c += u1 * R0;
@@ -862,14 +895,28 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u1 0 t9 0 0 0 0 0 0 c-u1*R1 t1-u1*R0 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 0 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[2]
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[2]
+       + static_cast<uint64_t>(a[1]) * a[1];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[2]  // -V1028
        + (uint64_t)a[1] * a[1];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 62);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
-    d += (uint64_t)(a[3]*2) * a[9]
-       + (uint64_t)(a[4]*2) * a[8]
-       + (uint64_t)(a[5]*2) * a[7]
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[3])*2) * a[9]
+       + ( static_cast<uint64_t>(a[4])*2) * a[8]
+       + ( static_cast<uint64_t>(a[5])*2) * a[7]
+       + static_cast<uint64_t>(a[6]) * a[6];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[3]*2) * a[9]  // -V1028
+       + (uint64_t)(a[4]*2) * a[8]  // -V1028
+       + (uint64_t)(a[5]*2) * a[7]  // -V1028
        + (uint64_t)a[6] * a[6];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 63);
     /* [d 0 0 t9 0 0 0 0 0 0 c t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     u2 = d & M; d >>= 26; c += u2 * R0;
@@ -883,13 +930,25 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u2 0 0 t9 0 0 0 0 0 c-u2*R1 t2-u2*R0 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 0 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[3]
-       + (uint64_t)(a[1]*2) * a[2];
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[3]
+       + ( static_cast<uint64_t>(a[1])*2) * a[2];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[3]  // -V1028
+       + (uint64_t)(a[1]*2) * a[2]; // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
-    d += (uint64_t)(a[4]*2) * a[9]
-       + (uint64_t)(a[5]*2) * a[8]
-       + (uint64_t)(a[6]*2) * a[7];
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[4])*2) * a[9]
+       + ( static_cast<uint64_t>(a[5])*2) * a[8]
+       + ( static_cast<uint64_t>(a[6])*2) * a[7];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[4]*2) * a[9]  // -V1028
+       + (uint64_t)(a[5]*2) * a[8]  // -V1028
+       + (uint64_t)(a[6]*2) * a[7]; // -V1028
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 63);
     /* [d 0 0 0 t9 0 0 0 0 0 c t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     u3 = d & M; d >>= 26; c += u3 * R0;
@@ -903,14 +962,28 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u3 0 0 0 t9 0 0 0 0 c-u3*R1 t3-u3*R0 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 0 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[4]
-       + (uint64_t)(a[1]*2) * a[3]
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[4]
+       + ( static_cast<uint64_t>(a[1])*2) * a[3]
+       + static_cast<uint64_t>(a[2]) * a[2];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[4]  // -V1028
+       + (uint64_t)(a[1]*2) * a[3]  // -V1028
        + (uint64_t)a[2] * a[2];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[5]*2) * a[9]
-       + (uint64_t)(a[6]*2) * a[8]
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[5])*2) * a[9]
+       + ( static_cast<uint64_t>(a[6])*2) * a[8]
+       + static_cast<uint64_t>(a[7]) * a[7];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[5]*2) * a[9]  // -V1028
+       + (uint64_t)(a[6]*2) * a[8]  // -V1028
        + (uint64_t)a[7] * a[7];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 t9 0 0 0 0 c t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     u4 = d & M; d >>= 26; c += u4 * R0;
@@ -924,13 +997,25 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u4 0 0 0 0 t9 0 0 0 c-u4*R1 t4-u4*R0 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 0 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[5]
-       + (uint64_t)(a[1]*2) * a[4]
-       + (uint64_t)(a[2]*2) * a[3];
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[5]
+       + ( static_cast<uint64_t>(a[1])*2) * a[4]
+       + ( static_cast<uint64_t>(a[2])*2) * a[3];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[5]  // -V1028
+       + (uint64_t)(a[1]*2) * a[4]  // -V1028
+       + (uint64_t)(a[2]*2) * a[3]; // -V1028
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(c, 63);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[6]*2) * a[9]
-       + (uint64_t)(a[7]*2) * a[8];
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[6])*2) * a[9]
+       + ( static_cast<uint64_t>(a[7])*2) * a[8];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[6]*2) * a[9]  // -V1028
+       + (uint64_t)(a[7]*2) * a[8]; // -V1028
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 62);
     /* [d 0 0 0 0 0 t9 0 0 0 c t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     u5 = d & M; d >>= 26; c += u5 * R0;
@@ -944,14 +1029,28 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u5 0 0 0 0 0 t9 0 0 c-u5*R1 t5-u5*R0 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 0 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[6]
-       + (uint64_t)(a[1]*2) * a[5]
-       + (uint64_t)(a[2]*2) * a[4]
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[6]
+       + ( static_cast<uint64_t>(a[1])*2) * a[5]
+       + ( static_cast<uint64_t>(a[2])*2) * a[4]
+       + static_cast<uint64_t>(a[3]) * a[3];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[6]  // -V1028
+       + (uint64_t)(a[1]*2) * a[5]  // -V1028
+       + (uint64_t)(a[2]*2) * a[4]  // -V1028
        + (uint64_t)a[3] * a[3];
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(c, 63);
+
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[7]*2) * a[9]
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[7])*2) * a[9]
+       + static_cast<uint64_t>(a[8]) * a[8];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[7]*2) * a[9]  // -V1028
        + (uint64_t)a[8] * a[8];
+#endif // SECP256_PVS_FIX
+
     VERIFY_BITS(d, 61);
     /* [d 0 0 0 0 0 0 t9 0 0 c t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
     u6 = d & M; d >>= 26; c += u6 * R0;
@@ -965,14 +1064,26 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u6 0 0 0 0 0 0 t9 0 c-u6*R1 t6-u6*R0 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 0 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[7]
-       + (uint64_t)(a[1]*2) * a[6]
-       + (uint64_t)(a[2]*2) * a[5]
-       + (uint64_t)(a[3]*2) * a[4];
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[7]
+       + ( static_cast<uint64_t>(a[1])*2) * a[6]
+       + ( static_cast<uint64_t>(a[2])*2) * a[5]
+       + ( static_cast<uint64_t>(a[3])*2) * a[4];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[7]  // -V1028
+       + (uint64_t)(a[1]*2) * a[6]  // -V1028
+       + (uint64_t)(a[2]*2) * a[5]  // -V1028
+       + (uint64_t)(a[3]*2) * a[4]; // -V1028
+#endif // SECP256_PVS_FIX
+
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x8000007C00000007ULL);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
-    d += (uint64_t)(a[8]*2) * a[9];
+#ifdef SECP256_PVS_FIX
+    d += ( static_cast<uint64_t>(a[8])*2) * a[9];
+#else // !SECP256_PVS_FIX
+    d += (uint64_t)(a[8]*2) * a[9]; // -V1028
+#endif // SECP256_PVS_FIX
     VERIFY_BITS(d, 58);
     /* [d 0 0 0 0 0 0 0 t9 0 c t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     u7 = d & M; d >>= 26; c += u7 * R0;
@@ -987,11 +1098,20 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
     /* [d u7 0 0 0 0 0 0 0 t9 c-u7*R1 t7-u7*R0 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 0 p7 p6 p5 p4 p3 p2 p1 p0] */
 
-    c += (uint64_t)(a[0]*2) * a[8]
-       + (uint64_t)(a[1]*2) * a[7]
-       + (uint64_t)(a[2]*2) * a[6]
-       + (uint64_t)(a[3]*2) * a[5]
+#ifdef SECP256_PVS_FIX
+    c += ( static_cast<uint64_t>(a[0])*2) * a[8]
+       + ( static_cast<uint64_t>(a[1])*2) * a[7]
+       + ( static_cast<uint64_t>(a[2])*2) * a[6]
+       + ( static_cast<uint64_t>(a[3]*)2) * a[5]
+       + static_cast<uint64_t>(a[4]) * a[4];
+#else // !SECP256_PVS_FIX
+    c += (uint64_t)(a[0]*2) * a[8]  // -V1028
+       + (uint64_t)(a[1]*2) * a[7]  // -V1028
+       + (uint64_t)(a[2]*2) * a[6]  // -V1028
+       + (uint64_t)(a[3]*2) * a[5]  // -V1028
        + (uint64_t)a[4] * a[4];
+#endif // SECP256_PVS_FIX
+
     /* VERIFY_BITS(c, 64); */
     VERIFY_CHECK(c <= 0x9000007B80000008ULL);
     /* [d 0 0 0 0 0 0 0 0 t9 c t7 t6 t5 t4 t3 t2 t1 t0] = [p17 p16 p15 p14 p13 p12 p11 p10 p9 p8 p7 p6 p5 p4 p3 p2 p1 p0] */


### PR DESCRIPTION
To fix all V1028 PVS warnings in src/secp256k1/src/field_10x26_impl.h

Result:

Built successfully
PVS report show no warnings for all the issues on column (Pastel (Fixed by this commit))
Passed all circleci test cases
Passed all below test suite on local machine:
cd qa/test-suite
./full_test_suite.py btest
./full_test_suite.py gtest
./full_test_suite.py sec-hard
./full_test_suite.py no-dot-so
./full_test_suite.py util-test
./full_test_suite.py secp256k1
./full_test_suite.py libsnark
./full_test_suite.py univalue
./full_test_suite.py rpc-common
./full_test_suite.py rpc-ext
Test case that took too long to complete, and failed some test cases while running:
./full_test_suite.py rpc-mn