### PR TITLE
tickets updates; royalty and Green NFT; ticket prices back to 10

### DIFF
--- a/src/mnode/mnode-pastel.cpp
+++ b/src/mnode/mnode-pastel.cpp
@@ -176,7 +176,9 @@ std::string CPastelIDRegTicket::ToJSON() const noexcept
         {"height", m_nBlock},
         {"ticket", {
 			{"type", GetTicketName()},
+			{"version", GetStoredVersion()},
 			{"pastelID", pastelID},
+			{"pq_key", pq_key},
 			{"address", address},
 			{"timeStamp", std::to_string(m_nTimestamp)},
 			{"signature", ed_crypto::Hex_Encode(pslid_signature.data(), pslid_signature.size())},
@@ -215,6 +217,19 @@ std::vector<CPastelIDRegTicket> CPastelIDRegTicket::FindAllTicketByPastelAddress
 }
 
 // CArtRegTicket ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/* Current art_ticket - 8 Items!!!!
+ {
+  "version": integer          // 1
+  "author": bytes,            // PastelID of the author (artist)
+  "blocknum": integer,        // block number when the ticket was created - this is to map the ticket to the MNs that should process it
+  "block_hash": bytes         // hash of the top block when the ticket was created - this is to map the ticket to the MNs that should process it
+  "copies": integer,          // number of copies
+  "royalty": float,           // (not yet supported by cNode) how much artist should get on all future resales
+  "green": string,            // address for Green NFT payment (not yet supported by cNode)
+
+  "app_ticket": ...
+  }
+ */
 CArtRegTicket CArtRegTicket::Create(
         std::string _ticket, const std::string& signatures,
         std::string _pastelID, const SecureString& strKeyPass,
@@ -225,7 +240,7 @@ CArtRegTicket CArtRegTicket::Create(
     
     //Art Ticket
     auto jsonTicketObj = json::parse(ed_crypto::Base64_Decode(ticket.artTicket));
-    if (jsonTicketObj.size() != 7){
+    if (jsonTicketObj.size() != 8){
         throw std::runtime_error("Art ticket json is incorrect");
     }
     if (jsonTicketObj["version"] != 1) {
@@ -233,6 +248,8 @@ CArtRegTicket CArtRegTicket::Create(
     }
     ticket.artistHeight = jsonTicketObj["blocknum"];
     ticket.totalCopies = jsonTicketObj["copies"];
+    ticket.nRoyalty = jsonTicketObj["royalty"];
+    ticket.strGreenAddress = jsonTicketObj["green"];
     
     //Artist's and MN2/3's signatures
     auto jsonSignaturesObj = json::parse(signatures);
@@ -413,6 +430,21 @@ bool CArtRegTicket::IsValid(std::string& errRet, bool preReg, int depth) const
             return false;
         }
     }
+    
+    if (nRoyalty > 20)
+    {
+        errRet = strprintf("Royalty can't be %d per cent, Max is 20 per cent", nRoyalty);
+        return false;
+    }
+    if (!strGreenAddress.empty()) {
+        KeyIO keyIO(Params());
+        const auto dest = keyIO.DecodeDestination(strGreenAddress);
+        if (!IsValidDestination(dest)) {
+            errRet = strprintf("The Green NFT address [%s] is invalid",
+                               strGreenAddress);
+            return false;
+        }
+    }
     return true;
 }
 
@@ -425,6 +457,7 @@ std::string CArtRegTicket::ToJSON() const noexcept
         {"ticket", {
             {"type", GetTicketName()},
             {"art_ticket", artTicket},
+            {"version", GetStoredVersion()},
             {"signatures",{
                 {"artist", {
                     {pastelIDs[artistsign], ed_crypto::Base64_Encode(ticketSignatures[artistsign].data(), ticketSignatures[artistsign].size())}
@@ -444,6 +477,8 @@ std::string CArtRegTicket::ToJSON() const noexcept
             {"artist_height", artistHeight},
             {"total_copies", totalCopies},
             {"storage_fee", storageFee},
+            {"royalty", nRoyalty},
+            {"is_green", strGreenAddress},
         }}
 	};
     
@@ -709,6 +744,7 @@ std::string CArtActivateTicket::ToJSON() const noexcept
 			{"height", m_nBlock},
 			{"ticket", {
 				{"type", GetTicketName()},
+				{"version", GetStoredVersion()},
 				{"pastelID", pastelID},
 				{"reg_txid", regTicketTnxId},
 				{"artist_height", artistHeight},
@@ -940,15 +976,16 @@ std::string CArtSellTicket::ToJSON() const noexcept
             {"txid", m_txid},
             {"height", m_nBlock},
             {"ticket", {
-                             {"type", GetTicketName()},
-                             {"pastelID", pastelID},
-                             {"art_txid", artTnxId},
-                             {"copy_number", copyNumber},
-                             {"asked_price", askedPrice},
-                             {"valid_after", activeAfter},
-                             {"valid_before", activeBefore},
-                             {"signature", ed_crypto::Hex_Encode(signature.data(), signature.size())}
-                     }}
+                {"type", GetTicketName()},
+                {"version", GetStoredVersion()},
+                {"pastelID", pastelID},
+                {"art_txid", artTnxId},
+                {"copy_number", copyNumber},
+                {"asked_price", askedPrice},
+                {"valid_after", activeAfter},
+                {"valid_before", activeBefore},
+                {"signature", ed_crypto::Hex_Encode(signature.data(), signature.size())}
+            }}
     };
     return jsonObj.dump(4);
 }
@@ -1091,12 +1128,13 @@ std::string CArtBuyTicket::ToJSON() const noexcept
             {"txid", m_txid},
             {"height", m_nBlock},
             {"ticket", {
-                             {"type", GetTicketName()},
-                             {"pastelID", pastelID},
-                             {"sell_txid", sellTnxId},
-                             {"price", price},
-                             {"signature", ed_crypto::Hex_Encode(signature.data(), signature.size())}
-                     }}
+                {"type", GetTicketName()},
+                {"version", GetStoredVersion()},
+                {"pastelID", pastelID},
+                {"sell_txid", sellTnxId},
+                {"price", price},
+                {"signature", ed_crypto::Hex_Encode(signature.data(), signature.size())}
+            }}
     };
     return jsonObj.dump(4);
 }
@@ -1231,6 +1269,19 @@ bool CArtTradeTicket::IsValid(std::string& errRet, bool preReg, int depth) const
     return true;
 }
 
+bool addOutput(const std::string& strAddress, CAmount nAmount, std::vector<CTxOut>& outputs)
+{
+    KeyIO keyIO(Params());
+    const auto dest = keyIO.DecodeDestination(strAddress);
+    if (!IsValidDestination(dest))
+        return false;
+    
+    CScript scriptPubKey = GetScriptForDestination(dest);
+    CTxOut out(nAmount, scriptPubKey);
+    outputs.push_back(out);
+    return true;
+}
+
 CAmount CArtTradeTicket::GetExtraOutputs(std::vector<CTxOut>& outputs) const
 {
     auto pArtSellTicket = CPastelTicketProcessor::GetTicket(sellTnxId, TicketID::Sell);
@@ -1238,8 +1289,6 @@ CAmount CArtTradeTicket::GetExtraOutputs(std::vector<CTxOut>& outputs) const
     if (!artSellTicket)
         throw std::runtime_error(strprintf("The Art Sell ticket with this txid [%s] is not in the blockchain", sellTnxId));
 
-    CAmount nPriceAmount = artSellTicket->askedPrice * COIN;
-    
     auto sellerPastelID = artSellTicket->pastelID;
     CPastelIDRegTicket sellerPastelIDticket;
     if (!CPastelIDRegTicket::FindTicketInDb(sellerPastelID, sellerPastelIDticket))
@@ -1247,17 +1296,59 @@ CAmount CArtTradeTicket::GetExtraOutputs(std::vector<CTxOut>& outputs) const
                 "The PastelID [%s] from sell ticket with this txid [%s] is not in the blockchain or is invalid",
                 sellerPastelID, sellTnxId));
     
-    KeyIO keyIO(Params());
-    const auto dest = keyIO.DecodeDestination(sellerPastelIDticket.address);
-    if (!IsValidDestination(dest))
+    CAmount nPriceAmount = artSellTicket->askedPrice * COIN;
+    CAmount nRoyaltyAmount = 0;
+    CAmount nGreenNFTAmount = 0;
+    
+    auto artTicket = FindArtRegTicket();
+    auto artRegTicket = dynamic_cast<CArtRegTicket*>(artTicket.get());
+    if (!artRegTicket)
+    {
+        throw std::runtime_error(strprintf(
+                "Can't find Art Registration ticket for this Trade ticket [txid=%s]",
+                GetTxId()));
+    }
+    
+    std::string strRoyaltyAddress;
+    if (artRegTicket->nRoyalty > 0)
+    {
+        nRoyaltyAmount = nPriceAmount*artRegTicket->nRoyalty/100;
+        nPriceAmount -= nRoyaltyAmount;
+        
+        //HERE -> Search if there is RoyaltyChange ticket
+    
+        CPastelIDRegTicket artistPastelIDticket;
+        if (!CPastelIDRegTicket::FindTicketInDb(artRegTicket->pastelIDs[CArtRegTicket::artistsign], artistPastelIDticket))
+            throw std::runtime_error(strprintf(
+                    "The Artist PastelID [%s] from Art Registration ticket with this txid [%s] is not in the blockchain or is invalid",
+                    artRegTicket->pastelIDs[CArtRegTicket::artistsign], artRegTicket->GetTxId()));
+        
+        strRoyaltyAddress = artistPastelIDticket.address;
+    }
+    
+    if (!artRegTicket->strGreenAddress.empty())
+    {
+        nGreenNFTAmount = nPriceAmount*2/100;
+        nPriceAmount -= nGreenNFTAmount;
+    }
+    
+    if (!addOutput(sellerPastelIDticket.address, nPriceAmount, outputs)) {
         throw std::runtime_error(
                 strprintf("The PastelID [%s] from sell ticket with this txid [%s] has invalid address",
                           sellerPastelID, sellTnxId));
+    }
     
-    CScript scriptPubKey = GetScriptForDestination(dest);
+    if (!strRoyaltyAddress.empty() && !addOutput(sellerPastelIDticket.address, nRoyaltyAmount, outputs)) {
+        throw std::runtime_error(
+                strprintf("The PastelID [%s] from sell ticket with this txid [%s] has invalid address",
+                          sellerPastelID, sellTnxId));
+    }
     
-    CTxOut out(nPriceAmount, scriptPubKey);
-    outputs.push_back(out);
+    if (!artRegTicket->strGreenAddress.empty() && !addOutput(artRegTicket->strGreenAddress, nGreenNFTAmount, outputs)) {
+        throw std::runtime_error(
+                strprintf("The PastelID [%s] from sell ticket with this txid [%s] has invalid address",
+                          sellerPastelID, sellTnxId));
+    }
     
     return nPriceAmount;
 }
@@ -1269,13 +1360,14 @@ std::string CArtTradeTicket::ToJSON() const noexcept
             {"txid", m_txid},
             {"height", m_nBlock},
             {"ticket", {
-                             {"type", GetTicketName()},
-                             {"pastelID", pastelID},
-                             {"sell_txid", sellTnxId},
-                             {"buy_txid", buyTnxId},
-                             {"art_txid", artTnxId},
-                             {"signature", ed_crypto::Hex_Encode(signature.data(), signature.size())}
-                     }}
+                {"type", GetTicketName()},
+                {"version", GetStoredVersion()},
+                {"pastelID", pastelID},
+                {"sell_txid", sellTnxId},
+                {"buy_txid", buyTnxId},
+                {"art_txid", artTnxId},
+                {"signature", ed_crypto::Hex_Encode(signature.data(), signature.size())}
+            }}
     };
     return jsonObj.dump(4);
 }
@@ -1322,6 +1414,26 @@ bool CArtTradeTicket::GetTradeTicketByBuyTicket(const std::string& _buyTnxId, CA
 {
     ticket.buyTnxId = _buyTnxId;
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
+}
+
+std::unique_ptr<CPastelTicket> CArtTradeTicket::FindArtRegTicket() const
+{
+    std::vector< std::unique_ptr<CPastelTicket> > chain;
+    std::string errRet;
+    if (!CPastelTicketProcessor::WalkBackTradingChain(artTnxId, chain, true, errRet))
+    {
+        throw std::runtime_error(errRet);
+    }
+    
+    auto artRegTicket = dynamic_cast<CArtRegTicket*>(chain.front().get());
+    if (!artRegTicket)
+    {
+        throw std::runtime_error(
+                strprintf("This is not an Art Registration ticket [txid=%s]",
+                          chain.front()->GetTxId()));
+    }
+    
+    return std::move(chain.front());
 }
 
 // CTakeDownTicket ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/mnode/mnode-pastel.h
+++ b/src/mnode/mnode-pastel.h
@@ -159,7 +159,7 @@ public:
     int artistHeight{}; //blocknum when the ticket was created by the wallet
     int totalCopies{}; //blocknum when the ticket was created by the wallet
     
-    ushort nRoyalty{};
+    uint16_t nRoyalty{};
     std::string strGreenAddress;
     
 public:

--- a/src/mnode/mnode-rpc.cpp
+++ b/src/mnode/mnode-rpc.cpp
@@ -1506,7 +1506,7 @@ static UniValue getTickets(const std::string& key, T2 key2 = "", Lambda otherFun
 #define FAKE_TICKET
 UniValue tickets(const UniValue& params, bool fHelp) {
 #ifdef FAKE_TICKET
-    RPC_CMD_PARSER(TICKETS, params, Register, find, list, get, makefaketicket, sendfaketicket);
+    RPC_CMD_PARSER(TICKETS, params, Register, find, list, get, makefaketicket, sendfaketicket, tools);
 #else
     RPC_CMD_PARSER(TICKETS, params, Register, find, list, get);
 #endif	
@@ -2195,7 +2195,39 @@ As json rpc
         obj.read(CPastelTicketProcessor::GetTicketJSON(txid));
         return obj;
 	}
-	
+    
+    if (TICKETS.IsCmd(RPC_CMD_TICKETS::tools)) {
+        
+        RPC_CMD_PARSER2(LIST, params, printtradingchain);
+        
+        UniValue obj(UniValue::VARR);
+        switch (LIST.cmd()) {
+            
+            case RPC_CMD_LIST::printtradingchain:
+    
+                std::string txid;
+                if (params.size() > 2) {
+                    txid = params[2].get_str();
+    
+                    UniValue resultArray(UniValue::VARR);
+                    
+                    std::vector< std::unique_ptr<CPastelTicket> > chain;
+                    std::string errRet;
+                    if (CPastelTicketProcessor::WalkBackTradingChain(txid, chain, false, errRet))
+                    {
+                        for (auto& t : chain){
+                            if (t) {
+                                UniValue obj(UniValue::VOBJ);
+                                obj.read(t->ToJSON());
+                                resultArray.push_back(obj);
+                            }
+                        }
+                    }
+                    return resultArray;
+                }
+        }
+    }
+    
 #ifdef FAKE_TICKET
     if (TICKETS.IsCmd(RPC_CMD_TICKETS::makefaketicket) || TICKETS.IsCmd(RPC_CMD_TICKETS::sendfaketicket)) {
             const bool bSend = TICKETS.IsCmd(RPC_CMD_TICKETS::sendfaketicket);

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -720,9 +720,10 @@ std::string CPastelTicketProcessor::ListFilterTradeTickets(const short filter) c
                                pastelTicket->GetTxId(), sTxId);
             return false;
         }
-        return WalkBackTradingChain(shortPath? tradeTicket->artTnxId: tradeTicket->buyTnxId, chain, shortPath, errRet);
+        if (!WalkBackTradingChain(shortPath? tradeTicket->artTnxId: tradeTicket->buyTnxId, chain, shortPath, errRet))
+            return false;
     }
-    if (pastelTicket->ID() == TicketID::Buy)
+    else if (pastelTicket->ID() == TicketID::Buy)
     {
         auto tradeTicket = dynamic_cast<CArtBuyTicket*>(pastelTicket.get());
         if (!tradeTicket)
@@ -731,9 +732,10 @@ std::string CPastelTicketProcessor::ListFilterTradeTickets(const short filter) c
                                pastelTicket->GetTxId(), sTxId);
             return false;
         }
-        return WalkBackTradingChain(tradeTicket->sellTnxId, chain, shortPath, errRet);
+        if (!WalkBackTradingChain(tradeTicket->sellTnxId, chain, shortPath, errRet))
+            return false;
     }
-    if (pastelTicket->ID() == TicketID::Sell)
+    else if (pastelTicket->ID() == TicketID::Sell)
     {
         auto tradeTicket = dynamic_cast<CArtSellTicket*>(pastelTicket.get());
         if (!tradeTicket)
@@ -742,7 +744,8 @@ std::string CPastelTicketProcessor::ListFilterTradeTickets(const short filter) c
                                pastelTicket->GetTxId(), sTxId);
             return false;
         }
-        return WalkBackTradingChain(tradeTicket->artTnxId, chain, shortPath, errRet);
+        if (!WalkBackTradingChain(tradeTicket->artTnxId, chain, shortPath, errRet))
+            return false;
     }
     else if (pastelTicket->ID() == TicketID::Activate)
     {
@@ -753,7 +756,8 @@ std::string CPastelTicketProcessor::ListFilterTradeTickets(const short filter) c
                                pastelTicket->GetTxId(), sTxId);
             return false;
         }
-        return WalkBackTradingChain(actTicket->regTicketTnxId, chain, shortPath, errRet);
+        if (!WalkBackTradingChain(actTicket->regTicketTnxId, chain, shortPath, errRet))
+            return false;
     }
     else if (pastelTicket->ID() == TicketID::Art)
     {

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -182,8 +182,24 @@ bool CPastelTicketProcessor::ValidateIfTicketTransaction(const int nHeight, cons
             bOk = ticket->IsValid(error_ret, false, 0);
             expectedTicketFee = ticket->TicketPrice(nHeight) * COIN;
             storageFee = ticket->GetStorageFee();
-            if (ticket_id == TicketID::Trade)
-                tradePrice = dynamic_cast<CArtTradeTicket*>(ticket.get())->price * COIN;
+            if (ticket_id == TicketID::Trade) {
+                auto trade_ticket = dynamic_cast<CArtTradeTicket *>(ticket.get());
+                tradePrice = trade_ticket->price * COIN;
+
+                auto artTicket = trade_ticket->FindArtRegTicket();
+                auto artRegTicket = dynamic_cast<CArtRegTicket*>(artTicket.get());
+                if (artRegTicket)
+                {
+                    if (artRegTicket->nRoyalty > 0)
+                    {
+                        tradePrice += tradePrice*artRegTicket->nRoyalty/100;
+                    }
+                    if (!artRegTicket->strGreenAddress.empty())
+                    {
+                        tradePrice += tradePrice*2/100;
+                    }
+                }
+            }
         }
     }
     catch (const std::exception& ex)
@@ -673,6 +689,90 @@ std::string CPastelTicketProcessor::ListFilterTradeTickets(const short filter) c
                 return false; //don't skip sold
             return true;
         });
+}
+
+/*static*/ bool CPastelTicketProcessor::WalkBackTradingChain(
+        const std::string& sTxId,
+        std::vector< std::unique_ptr<CPastelTicket> >& chain,
+        bool shortPath,
+        std::string& errRet) noexcept
+{
+    std::unique_ptr<CPastelTicket> pastelTicket;
+    
+    uint256 txid;
+    txid.SetHex(sTxId);
+    //  Get ticket pointed by artTnxId. This is either Activation or Trade tickets (Sell, Buy, Trade)
+    try
+    {
+        pastelTicket = CPastelTicketProcessor::GetTicket(txid);
+    }
+    catch ([[maybe_unused]] std::runtime_error& ex)
+    {
+        errRet = strprintf("Ticket [txid=%s] is not in the blockchain.", sTxId);
+        return false;
+    }
+    if (pastelTicket->ID() == TicketID::Trade)
+    {
+        auto tradeTicket = dynamic_cast<CArtTradeTicket*>(pastelTicket.get());
+        if (!tradeTicket)
+        {
+            errRet = strprintf("The Trade ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
+                               pastelTicket->GetTxId(), sTxId);
+            return false;
+        }
+        return WalkBackTradingChain(shortPath? tradeTicket->artTnxId: tradeTicket->buyTnxId, chain, shortPath, errRet);
+    }
+    if (pastelTicket->ID() == TicketID::Buy)
+    {
+        auto tradeTicket = dynamic_cast<CArtBuyTicket*>(pastelTicket.get());
+        if (!tradeTicket)
+        {
+            errRet = strprintf("The Buy ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
+                               pastelTicket->GetTxId(), sTxId);
+            return false;
+        }
+        return WalkBackTradingChain(tradeTicket->sellTnxId, chain, shortPath, errRet);
+    }
+    if (pastelTicket->ID() == TicketID::Sell)
+    {
+        auto tradeTicket = dynamic_cast<CArtSellTicket*>(pastelTicket.get());
+        if (!tradeTicket)
+        {
+            errRet = strprintf("The Sell ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
+                               pastelTicket->GetTxId(), sTxId);
+            return false;
+        }
+        return WalkBackTradingChain(tradeTicket->artTnxId, chain, shortPath, errRet);
+    }
+    else if (pastelTicket->ID() == TicketID::Activate)
+    {
+        auto actTicket = dynamic_cast<CArtActivateTicket*>(pastelTicket.get());
+        if (!actTicket)
+        {
+            errRet = strprintf("The Activation ticket [txid=%s] referred by ticket [txid=%s] ticket is invalid",
+                               pastelTicket->GetTxId(), sTxId);
+            return false;
+        }
+        return WalkBackTradingChain(actTicket->regTicketTnxId, chain, shortPath, errRet);
+    }
+    else if (pastelTicket->ID() == TicketID::Art)
+    {
+        auto tradeTicket = dynamic_cast<CArtRegTicket*>(pastelTicket.get());
+        if (!tradeTicket)
+        {
+            errRet = strprintf("The Art Registration ticket [txid=%s] referred by ticket [txid=%s] is invalid",
+                               pastelTicket->GetTxId(), sTxId);
+            return false;
+        }
+    }
+    else
+    {
+        errRet = strprintf("The Art ticket [txid=%s] referred by ticket [txid=%s] has wrong type - %s]",
+                           pastelTicket->GetTxId(), sTxId, pastelTicket->GetTicketName());
+        return false;
+    }
+    chain.emplace_back(std::move(pastelTicket));
+    return true;
 }
 
 std::string CPastelTicketProcessor::SendTicket(const CPastelTicket& ticket)

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -184,6 +184,8 @@ bool CPastelTicketProcessor::ValidateIfTicketTransaction(const int nHeight, cons
             storageFee = ticket->GetStorageFee();
             if (ticket_id == TicketID::Trade) {
                 auto trade_ticket = dynamic_cast<CArtTradeTicket *>(ticket.get());
+                if (!trade_ticket)
+                    throw std::runtime_error("Invalid Art Trade ticket");
                 tradePrice = trade_ticket->price * COIN;
 
                 auto artTicket = trade_ticket->FindArtRegTicket();
@@ -258,7 +260,7 @@ bool CPastelTicketProcessor::ValidateIfTicketTransaction(const int nHeight, cons
             }
             //in this tickets last 2 outputs is: change, and payment to the seller
             if (ticket_id == TicketID::Trade)
-            { 
+            {
                 if (i == num - 2)
                     continue;
                 if (i == num - 1)
@@ -711,72 +713,64 @@ std::string CPastelTicketProcessor::ListFilterTradeTickets(const short filter) c
         errRet = strprintf("Ticket [txid=%s] is not in the blockchain.", sTxId);
         return false;
     }
-    if (pastelTicket->ID() == TicketID::Trade)
-    {
-        auto tradeTicket = dynamic_cast<CArtTradeTicket*>(pastelTicket.get());
-        if (!tradeTicket)
-        {
-            errRet = strprintf("The Trade ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
-                               pastelTicket->GetTxId(), sTxId);
-            return false;
+    
+    bool bOk = false;
+    do {
+        if (pastelTicket->ID() == TicketID::Trade) {
+            auto tradeTicket = dynamic_cast<CArtTradeTicket *>(pastelTicket.get());
+            if (!tradeTicket) {
+                errRet = strprintf("The Trade ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
+                                   pastelTicket->GetTxId(), sTxId);
+                break;
+            }
+            if (!WalkBackTradingChain(shortPath ? tradeTicket->artTnxId : tradeTicket->buyTnxId, chain, shortPath,
+                                      errRet))
+                break;
+        } else if (pastelTicket->ID() == TicketID::Buy) {
+            auto tradeTicket = dynamic_cast<CArtBuyTicket *>(pastelTicket.get());
+            if (!tradeTicket) {
+                errRet = strprintf("The Buy ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
+                                   pastelTicket->GetTxId(), sTxId);
+                break;
+            }
+            if (!WalkBackTradingChain(tradeTicket->sellTnxId, chain, shortPath, errRet))
+                break;
+        } else if (pastelTicket->ID() == TicketID::Sell) {
+            auto tradeTicket = dynamic_cast<CArtSellTicket *>(pastelTicket.get());
+            if (!tradeTicket) {
+                errRet = strprintf("The Sell ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
+                                   pastelTicket->GetTxId(), sTxId);
+                break;
+            }
+            if (!WalkBackTradingChain(tradeTicket->artTnxId, chain, shortPath, errRet))
+                break;
+        } else if (pastelTicket->ID() == TicketID::Activate) {
+            auto actTicket = dynamic_cast<CArtActivateTicket *>(pastelTicket.get());
+            if (!actTicket) {
+                errRet = strprintf("The Activation ticket [txid=%s] referred by ticket [txid=%s] ticket is invalid",
+                                   pastelTicket->GetTxId(), sTxId);
+                break;
+            }
+            if (!WalkBackTradingChain(actTicket->regTicketTnxId, chain, shortPath, errRet))
+                break;
+        } else if (pastelTicket->ID() == TicketID::Art) {
+            auto tradeTicket = dynamic_cast<CArtRegTicket *>(pastelTicket.get());
+            if (!tradeTicket) {
+                errRet = strprintf("The Art Registration ticket [txid=%s] referred by ticket [txid=%s] is invalid",
+                                   pastelTicket->GetTxId(), sTxId);
+                break;
+            }
+        } else {
+            errRet = strprintf("The Art ticket [txid=%s] referred by ticket [txid=%s] has wrong type - %s]",
+                               pastelTicket->GetTxId(), sTxId, pastelTicket->GetTicketName());
+            break;
         }
-        if (!WalkBackTradingChain(shortPath? tradeTicket->artTnxId: tradeTicket->buyTnxId, chain, shortPath, errRet))
-            return false;
+        chain.emplace_back(std::move(pastelTicket));
+        bOk = true;
     }
-    else if (pastelTicket->ID() == TicketID::Buy)
-    {
-        auto tradeTicket = dynamic_cast<CArtBuyTicket*>(pastelTicket.get());
-        if (!tradeTicket)
-        {
-            errRet = strprintf("The Buy ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
-                               pastelTicket->GetTxId(), sTxId);
-            return false;
-        }
-        if (!WalkBackTradingChain(tradeTicket->sellTnxId, chain, shortPath, errRet))
-            return false;
-    }
-    else if (pastelTicket->ID() == TicketID::Sell)
-    {
-        auto tradeTicket = dynamic_cast<CArtSellTicket*>(pastelTicket.get());
-        if (!tradeTicket)
-        {
-            errRet = strprintf("The Sell ticket [txid=%s] referred by this ticket [txid=%s] is invalid",
-                               pastelTicket->GetTxId(), sTxId);
-            return false;
-        }
-        if (!WalkBackTradingChain(tradeTicket->artTnxId, chain, shortPath, errRet))
-            return false;
-    }
-    else if (pastelTicket->ID() == TicketID::Activate)
-    {
-        auto actTicket = dynamic_cast<CArtActivateTicket*>(pastelTicket.get());
-        if (!actTicket)
-        {
-            errRet = strprintf("The Activation ticket [txid=%s] referred by ticket [txid=%s] ticket is invalid",
-                               pastelTicket->GetTxId(), sTxId);
-            return false;
-        }
-        if (!WalkBackTradingChain(actTicket->regTicketTnxId, chain, shortPath, errRet))
-            return false;
-    }
-    else if (pastelTicket->ID() == TicketID::Art)
-    {
-        auto tradeTicket = dynamic_cast<CArtRegTicket*>(pastelTicket.get());
-        if (!tradeTicket)
-        {
-            errRet = strprintf("The Art Registration ticket [txid=%s] referred by ticket [txid=%s] is invalid",
-                               pastelTicket->GetTxId(), sTxId);
-            return false;
-        }
-    }
-    else
-    {
-        errRet = strprintf("The Art ticket [txid=%s] referred by ticket [txid=%s] has wrong type - %s]",
-                           pastelTicket->GetTxId(), sTxId, pastelTicket->GetTicketName());
-        return false;
-    }
-    chain.emplace_back(std::move(pastelTicket));
-    return true;
+    while(false);
+    
+    return bOk;
 }
 
 std::string CPastelTicketProcessor::SendTicket(const CPastelTicket& ticket)

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -80,7 +80,15 @@ public:
     static std::string GetTicketJSON(const uint256 &txid);
 
     static bool ValidateIfTicketTransaction(const int nHeight, const CTransaction& tx);
-
+    
+    static bool WalkBackTradingChain(
+            const std::string& sTxId,                               // txid of the starting ticket
+            std::vector< std::unique_ptr<CPastelTicket> >& chain,   // vector with the tickets in chain
+            bool shortPath,                                         // follow short or long path
+                                                                    //      Trade, Act, Reg in short walk
+                                                                    //      Trade, Buy, Sell, Act or Reg in long walk
+            std::string& errRet) noexcept;
+    
 #ifdef FAKE_TICKET
     static std::string CreateFakeTransaction(CPastelTicket& ticket, CAmount ticketPrice, const std::vector<std::pair<std::string, CAmount>>& extraPayments, const std::string& strVerb, bool bSend);
 #endif

--- a/src/mnode/ticket.h
+++ b/src/mnode/ticket.h
@@ -55,9 +55,7 @@ public:
             m_nVersion = nTicketVersion; // make sure we have up-to-date current ticket version
         else
         { // serialization mode
-            if (m_nVersion < nTicketVersion)
-                m_nVersion = nTicketVersion;      // we're writing always current version
-            else if (m_nVersion > nTicketVersion) // we don't support this ticket version yet
+            if (m_nVersion > nTicketVersion) // we don't support this ticket version yet
             {
                 error = tfm::format("Can't serialize '%s' ticket, newer ticket version v%hi found, supported ticket v%hi. Please update pasteld version",
                                     GetTicketName(), m_nVersion, GetVersion());


### PR DESCRIPTION
1) Add additional fields to tickets (freedcamp - 39157067)
  a) ID ticket: legroast public key
  b) Art Registration ticket: royalty and Green NFT address
2) Removed "silent upgrade" of ticket versions
3) Added methods to "walk back to art registration ticket" from future trade tickets
4) mn_tickets test:
  a) "high heights" tests disabled by default and fixed counters;
  b) ticket prices changed
5) Draft of logic to support royalty and Green NFT payments

Tests:
<<< TEST SUCCEDED >>>
--- Success: mn_tickets --- | exectime: 01:09:47.762