### PR TITLE
Add APIs: storagefee getnetworkfee, tickets tools gettotalstoragefee

### DIFF
--- a/qa/rpc-tests/mn_tickets.py
+++ b/qa/rpc-tests/mn_tickets.py
@@ -1743,8 +1743,26 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         # 4. storagefee tests
         # a. Get Network median storage fee
         #   a.1 from non-MN without errors
+        non_mn1_total_storage_fee1 = self.nodes[self.non_mn4].tickets("tools", "gettotalstoragefee",
+                                                                   self.ticket, json.dumps(self.signatures_dict),
+                                                                   self.nonmn4_pastelid1, "passphrase",
+                                                                   "key5", "key6", str(self.storage_fee), 5)["totalstoragefee"]
         #   a.2 from MN without errors
+        mn0_total_storage_fee1 = self.nodes[self.top_mns_index0].tickets("tools", "gettotalstoragefee",
+                                                                   self.ticket, json.dumps(self.signatures_dict),
+                                                                   self.top_mn_pastelid0, "passphrase",
+                                                                   "key5", "key6", str(self.storage_fee), 5)["totalstoragefee"]
+        mn0_total_storage_fee2 = self.nodes[self.top_mns_index0].tickets("tools", "gettotalstoragefee",
+                                                                   self.ticket, json.dumps(self.signatures_dict),
+                                                                   self.top_mn_pastelid0, "passphrase",
+                                                                   "key5", "key6", str(self.storage_fee), 4)["totalstoragefee"]
+
         #   a.3 compare a.1 and a.2
+        print(non_mn1_total_storage_fee1)
+        print(mn0_total_storage_fee1)
+        print(mn0_total_storage_fee2)
+        assert_equal(int(non_mn1_total_storage_fee1), int(mn0_total_storage_fee1))
+        assert_greater_than(int(non_mn1_total_storage_fee1), int(mn0_total_storage_fee2))
 
         # b. Get local masternode storage fee
         #   b.1 fail from non-MN

--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -30,7 +30,8 @@ void CMasterNodeController::SetParameters()
     //this will allow to filter out old MN when ALL NETWORK is updated 
     MasternodeProtocolVersion           = 170008;
     
-    MasternodeFeePerMBDefault           = 100;
+    MasternodeFeePerMBDefault           = 50;
+    ArtTicketFeePerKBDefault           = 3;
 
     MasternodeCheckSeconds              =   5;
     MasternodeMinMNBSeconds             =   5 * 60;
@@ -431,6 +432,24 @@ CAmount CMasterNodeController::GetNetworkFeePerMB()
 
     return MasternodeFeePerMBDefault;
 }
+
+CAmount CMasterNodeController::GetArtTicketFeePerKB()
+{
+
+    if (fMasterNode) {
+        CAmount nFee = 0;
+        std::map<COutPoint, CMasternode> mapMasternodes = masternodeManager.GetFullMasternodeMap();
+        for (auto& mnpair : mapMasternodes) {
+            CMasternode mn = mnpair.second;
+            nFee += mn.aArtTicketFeePerKB > 0? mn.aArtTicketFeePerKB: masterNodeCtrl.ArtTicketFeePerKBDefault;
+        }
+        nFee /= mapMasternodes.size();
+        return nFee;
+    }
+
+    return ArtTicketFeePerKBDefault;
+}
+
 
 
 /*

--- a/src/mnode/mnode-controller.h
+++ b/src/mnode/mnode-controller.h
@@ -58,6 +58,7 @@ public:
     int MasternodeProtocolVersion;
     int MasternodeCollateral;
     CAmount MasternodeFeePerMBDefault;
+    CAmount ArtTicketFeePerKBDefault;
 
     int MasternodeCheckSeconds, MasternodeMinMNBSeconds, MasternodeMinMNPSeconds, MasternodeExpirationSeconds, MasternodeWatchdogMaxSeconds, MasternodeNewStartRequiredSeconds;
     int MasternodePOSEBanMaxScore;
@@ -102,6 +103,7 @@ public:
     bool ProcessGetData(CNode* pfrom, const CInv& inv);
 
     CAmount GetNetworkFeePerMB();
+    CAmount GetArtTicketFeePerKB();
 
     /***** MasterNode operations *****/
     CSemaphore *semMasternodeOutbound;

--- a/src/mnode/mnode-masternode.cpp
+++ b/src/mnode/mnode-masternode.cpp
@@ -48,7 +48,8 @@ CMasternode::CMasternode(const CMasternode& other) :
     nPoSeBanScore(other.nPoSeBanScore),
     nPoSeBanHeight(other.nPoSeBanHeight),
     fUnitTest(other.fUnitTest),
-    aMNFeePerMB(other.aMNFeePerMB)
+    aMNFeePerMB(other.aMNFeePerMB),
+    aArtTicketFeePerKB(other.aArtTicketFeePerKB)
 {}
 
 CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
@@ -76,6 +77,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
     strExtraLayerKey = mnb.strExtraLayerKey;
     strExtraLayerCfg = mnb.strExtraLayerCfg;
     aMNFeePerMB = 0;
+    aArtTicketFeePerKB = 0;
     nPoSeBanScore = 0;
     nPoSeBanHeight = 0;
     nTimeLastChecked = 0;

--- a/src/mnode/mnode-masternode.h
+++ b/src/mnode/mnode-masternode.h
@@ -150,6 +150,7 @@ public:
     bool fUnitTest = false;
 
     CAmount aMNFeePerMB = 0; // 0 means default (masterNodeCtrl.MasternodeFeePerMBDefault)
+    CAmount aArtTicketFeePerKB = 0; // 0 means default (masterNodeCtrl.ArtTicketFeePerKBDefault)
 
     CMasternode();
     CMasternode(const CMasternode& other);
@@ -185,6 +186,7 @@ public:
         READWRITE(strExtraLayerAddress);
         READWRITE(strExtraLayerCfg);
         READWRITE(aMNFeePerMB);
+        READWRITE(aArtTicketFeePerKB);
     }
 
     // CALCULATE A RANK AGAINST OF GIVEN BLOCK
@@ -271,6 +273,7 @@ public:
         nPoSeBanHeight = from.nPoSeBanHeight;
         fUnitTest = from.fUnitTest;
         aMNFeePerMB = from.aMNFeePerMB;
+        aArtTicketFeePerKB = from.aArtTicketFeePerKB;
         return *this;
     }
 };

--- a/src/mnode/mnode-rpc.cpp
+++ b/src/mnode/mnode-rpc.cpp
@@ -1365,7 +1365,7 @@ UniValue storagefee(const UniValue& params, bool fHelp) {
     if (!params.empty())
         strCommand = params[0].get_str();
 
-    if (fHelp || ( strCommand != "setfee" && strCommand != "getnetworkfee" && strCommand != "getlocalfee" ))
+    if (fHelp || ( strCommand != "setfee" && strCommand != "getnetworkfee" && strCommand != "getartticketfee" && strCommand != "getlocalfee"))
         throw runtime_error(
 			"storagefee \"command\"...\n"
 			"Set of commands to deal with Storage Fee and related actions\n"
@@ -1374,6 +1374,7 @@ UniValue storagefee(const UniValue& params, bool fHelp) {
 			"\nAvailable commands:\n"
 			"  setfee <n>		- Set storage fee for MN.\n"
 			"  getnetworkfee	- Get Network median storage fee.\n"
+			"  getartticketfee	- Get Network median art ticket fee.\n"
 			"  getlocalfee		- Get local masternode storage fee.\n"
         );
 
@@ -1395,6 +1396,14 @@ UniValue storagefee(const UniValue& params, bool fHelp) {
 
         UniValue mnObj(UniValue::VOBJ);
         mnObj.pushKV("networkfee", nFee);
+        return mnObj;
+    }
+    if (strCommand == "getartticketfee")
+    {
+        CAmount nFee = masterNodeCtrl.GetArtTicketFeePerKB();
+
+        UniValue mnObj(UniValue::VOBJ);
+        mnObj.pushKV("artticketfee", nFee);
         return mnObj;
     }
     if (strCommand == "getlocalfee")

--- a/src/mnode/mnode-rpc.cpp
+++ b/src/mnode/mnode-rpc.cpp
@@ -2278,7 +2278,7 @@ Arguments:
 5. "key1"       (string, required) The first key to search ticket.
 6. "key2"       (string, required) The second key to search ticket.
 7. "fee"        (int, required) The agreed upon storage fee.
-8. "imagesize"  (int) size of image in MB
+8. "imagesize"  (int, required) size of image in MB
 Masternode PastelID Ticket:
 {
 	"ticket": {
@@ -2303,10 +2303,6 @@ Register Art Ticket
                                            R"(
 As json rpc
 )" + HelpExampleRpc("tickets", R"("tools", "gettotalstoragefee", "ticket" "{signatures}" "jXYqZNPj21RVnwxnEJ654wEdzi7GZTZ5LAdiotBmPrF7pDMkpX1JegDMQZX55WZLkvy9fxNpZcbBJuE8QYUqBF" "passphrase", "key1", "key2", 100, 3)"));
-
-                if (!masterNodeCtrl.IsActiveMasterNode())
-                    throw JSONRPCError(RPC_INTERNAL_ERROR,
-                                       "This is not an active masternode. Only active MN can register its PastelID");
 
                 if (fImporting || fReindex)
                     throw JSONRPCError(RPC_INVALID_PARAMETER, "Initial blocks download. Re-try later");

--- a/src/mnode/mnode-rpc.cpp
+++ b/src/mnode/mnode-rpc.cpp
@@ -2279,26 +2279,8 @@ Arguments:
 6. "key2"       (string, required) The second key to search ticket.
 7. "fee"        (int, required) The agreed upon storage fee.
 8. "imagesize"  (int, required) size of image in MB
-Masternode PastelID Ticket:
-{
-	"ticket": {
-		"type": "art-reg",
-		"ticket": {...},
-		"signatures": {
- 			"authorsPastelID": "authorsSignature",
-			"mn1PastelID":"mn1Signature",
-			"mn2PastelID":"mn2Signature",
-			"mn3PastelID":"mn3Signature"
-		},
-		"key1": "<search key 1>",
-		"key2": "<search key 2>",
-		"storage_fee": "<agreed upon storage fee>",
-	},
-	"height": "",
-	"txid": ""
-}
 
-Register Art Ticket
+Get Total Storage Fee Ticket
 )" + HelpExampleCli("tickets tools gettotalstoragefee", R"(""ticket-blob" "{signatures}" jXYqZNPj21RVnwxnEJ654wEdzi7GZTZ5LAdiotBmPrF7pDMkpX1JegDMQZX55WZLkvy9fxNpZcbBJuE8QYUqBF "passphrase", "key1", "key2", 100, 3)") +
                                            R"(
 As json rpc
@@ -2331,7 +2313,7 @@ As json rpc
                 data_stream << (uint8_t)artRegTicket.ID();
                 data_stream << artRegTicket;
                 std::vector<unsigned char> input_bytes{data_stream.begin(), data_stream.end()};
-                CAmount totalFee = imageSize*masterNodeCtrl.GetNetworkFeePerMB() + input_bytes.size()*masterNodeCtrl.GetArtTicketFeePerKB()/1024;
+                CAmount totalFee = imageSize*masterNodeCtrl.GetNetworkFeePerMB() + ceil(input_bytes.size()*masterNodeCtrl.GetArtTicketFeePerKB()/1024);
 
                 UniValue mnObj(UniValue::VOBJ);
                 mnObj.pushKV("totalstoragefee", totalFee);


### PR DESCRIPTION
This commit is to implement: 
    + https://freedcamp.com/view/2956206/tasks/40506963
    + https://freedcamp.com/view/2956206/tasks/40507034
Follow the code of `storagefee getnetworkfee` and add similar logic for `storagefee getartticketfee`
  - Create method CAmount CMasterNodeController::GetArtTicketFeePerKB()
  - Use `ArtTicketFeePerKBDefault` for default value and set it to 3
Change MasternodeFeePerMBDefault to 50