### PR TITLE
Update circle-ci configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   build_and_test_linux:
     executor: pastel-builder
     working_directory: /pastel
-    resource_class: xlarge
+    resource_class: medium+
     steps:
       - checkout
       - run:
@@ -80,14 +80,14 @@ jobs:
   build_windows:
     executor: pastel-builder
     working_directory: /pastel
-    resource_class: xlarge
+    resource_class: medium+
     steps:
       - checkout
       - run:
           name: Building Pastel Core (Windows version)
           no_output_timeout: 30m
           command: |
-            HOST=x86_64-w64-mingw32 ./build.sh -j16
+            HOST=x86_64-w64-mingw32 ./build.sh -j2
       - store_artifacts:
           path: /pastel/src/pasteld.exe
           destination: /windows/pasteld.exe
@@ -100,7 +100,7 @@ jobs:
   build_macOS:
     executor: pastel-builder
     working_directory: /pastel
-    resource_class: xlarge
+    resource_class: medium+
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Building Pastel Core (Linux version)
           no_output_timeout: 30m
           command: |
-            ./build.sh -j16
+            ./build.sh -j2
       - store_artifacts:
           path: /pastel/src/pasteld
           destination: /linux/pasteld
@@ -107,7 +107,7 @@ jobs:
           name: Building Pastel Core (macOS version)
           no_output_timeout: 30m
           command: |
-            HOST=x86_64-apple-darwin14 ./build.sh -j16
+            HOST=x86_64-apple-darwin14 ./build.sh -j2
       - store_artifacts:
           path: /pastel/src/pasteld
           destination: /macOS/pasteld


### PR DESCRIPTION
### What is this PR about?
Change circle-ci config:
    + `xlarge `-->` medium+`
    + -j16 to -j2

## How to test it manually?
Open all 3 build systems: MacOS, Windows, Linux and check if
    + The Executor changed to `Docker Medium+`:
![image](https://user-images.githubusercontent.com/42252263/123192158-8aade080-d4cc-11eb-8d7d-941afd875091.png)
    + At the start of "Building Pastel Core" log, check if `-j2` is used.
![image](https://user-images.githubusercontent.com/42252263/123192183-98636600-d4cc-11eb-87a3-1391c95dc813.png)

## What is the test result?
This change does not effect source code so no need to run test cases to validate.