### PR TITLE
Revert "Fix issue that cause mn_governance.py failed randomly"

### DIFF
--- a/qa/rpc-tests/mn_governance.py
+++ b/qa/rpc-tests/mn_governance.py
@@ -110,8 +110,8 @@ class MasterNodeGovernanceTest (MasterNodeCommon):
 
         self.nodes[self.mining_node_num].generate(5)
 
-        print("Waiting 90 seconds")
-        time.sleep(90)
+        print("Waiting 60 seconds")
+        time.sleep(60)
 
         print("Test tickets votes")
         #3. Preliminary test, should be 2 tickets: 1st ticket - 3 votes, 2 yes; 2nd ticket - 1 vote, 1 yes


### PR DESCRIPTION
Reverts pastelnetwork/pastel#52

This PR is to revert the change from #52 , because that PR didn't get enough 2 approval before merging.