### PR TITLE
Backward compatibility with old MNs

### DIFF
--- a/src/mnode/mnode-config.cpp
+++ b/src/mnode/mnode-config.cpp
@@ -108,9 +108,9 @@ bool CMasternodeConfig::read(std::string& strErr)
                 {"txid", ""},
                 {"outIndex", ""},
                 {"extAddress", ""},
-                {"extP2P", ""},
                 {"extKey", ""},
-                {"extCfg", {}}
+                {"extCfg", {}},
+                {"extP2P", ""}
             }}
         };
         pathMasternodeConfigFile += "-sample";

--- a/src/mnode/mnode-masternode.h
+++ b/src/mnode/mnode-masternode.h
@@ -186,10 +186,19 @@ public:
         READWRITE(fUnitTest);
         READWRITE(strExtraLayerKey);
         READWRITE(strExtraLayerAddress);
-        READWRITE(strExtraLayerP2P);
         READWRITE(strExtraLayerCfg);
         READWRITE(aMNFeePerMB);
         READWRITE(aArtTicketFeePerKB);
+        
+        //For backward compatibility
+        try
+        {
+            READWRITE(strExtraLayerP2P);
+        }
+        catch (const std::ios_base::failure& e)
+        {
+            LogPrintf("CMasternode: missing extP2P!");
+        }
     }
 
     // CALCULATE A RANK AGAINST OF GIVEN BLOCK
@@ -325,8 +334,17 @@ public:
         READWRITE(lastPing);
         READWRITE(strExtraLayerKey);
         READWRITE(strExtraLayerAddress);
-        READWRITE(strExtraLayerP2P);
         READWRITE(strExtraLayerCfg);
+
+        //For backward compatibility
+        try
+        {
+            READWRITE(strExtraLayerP2P);
+        }
+        catch (const std::ios_base::failure& e)
+        {
+            LogPrintf("CMasternodeBroadcast: missing extP2P!");
+        }
     }
 
     uint256 GetHash() const


### PR DESCRIPTION
Providing backward compatibility with `try{}catch()` block for reading / writing extP2P parameter only in case it is available. Tested on current mainnet.