### PR TITLE
Add implementation for z_sendmanywithchangetosender, which will send PSL to an address and return any change to the sending address

### DIFF
--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -248,7 +248,7 @@ class WalletSaplingTest(BitcoinTestFramework):
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
-        calculatedSenderBalance = calculatedSenderBalance - fee - receiverExpectedBalance * 2
+        calculatedSenderBalance = calculatedSenderBalance - fee - Decimal('5.0')*2
         assert_equal(self.nodes[0].z_getbalance(senderaddr), calculatedSenderBalance)
         assert_equal(self.nodes[2].z_getbalance(receiveraddr), receiverExpectedBalance)
         assert_equal(self.nodes[2].z_getbalance(receiveraddr2), receiver2ExpectedBalance)

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -205,11 +205,10 @@ class WalletSaplingTest(BitcoinTestFramework):
         # Check z_sendmanywithchangetosender
         # send from node 0 taddr to node 2 single taddr
         senderaddr = self.nodes[0].getnewaddress()
-        senderaddr_oldbalance = self.nodes[2].z_getbalance(senderaddr)
         self.nodes[0].generate(10)
 
-        senderExpectedBalance = senderaddr_oldbalance + Decimal('100.0')
-        mytxid = self.nodes[0].sendtoaddress(senderaddr, senderExpectedBalance)
+        mytxid = self.nodes[0].sendtoaddress(senderaddr, Decimal('100.0'))
+        senderExpectedBalance = Decimal('100.0')
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -235,7 +235,7 @@ class WalletSaplingTest(BitcoinTestFramework):
         receiveraddr = self.nodes[2].getnewaddress()
         receiveraddr_oldbalance = self.nodes[2].z_getbalance(receiveraddr)
         receiveraddr2 = self.nodes[2].getnewaddress()
-        receiveraddr2_oldbalance = self.nodes[2].z_getbalance(receiveraddr)
+        receiveraddr2_oldbalance = self.nodes[2].z_getbalance(receiveraddr2)
 
         receiverExpectedBalance = receiveraddr_oldbalance + Decimal('5.0')
         receiver2ExpectedBalance = receiveraddr2_oldbalance + Decimal('5.0')

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -201,5 +201,63 @@ class WalletSaplingTest(BitcoinTestFramework):
         except JSONRPCException as e:
             assert_equal("Cannot send to both Sprout and Sapling addresses using z_sendmany", e.error['message'])
 
+        # Check z_sendmanywithchangetosender
+        # send from node 0 taddr to node 2 single taddr
+        senderaddr = self.nodes[0].getnewaddress()
+        senderaddr = self.nodes[0].getnewaddress()
+        self.nodes[0].generate(10)
+        self.sync_all()
+
+        senderExpectedBalance = Decimal('100.0')
+        mytxid = self.nodes[0].sendtoaddress(senderaddr, senderExpectedBalance)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_equal(self.nodes[0].z_getbalance(senderaddr), senderExpectedBalance)
+
+        receiveraddr = self.nodes[2].getnewaddress()
+        receiveraddr = self.nodes[2].getnewaddress()
+        fee         = Decimal('0.01')
+        minconf     = 1
+        receiverExpectedBalance = Decimal('5.0')
+        recipients  = [ {"address": receiveraddr, "amount": receiverExpectedBalance} ]
+
+        myopid = self.nodes[0].z_sendmanywithchangetosender(senderaddr, recipients, minconf, fee)
+        assert(myopid)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_equal(self.nodes[2].z_getbalance(receiveraddr), receiverExpectedBalance)
+        calculatedSenderBalance = senderExpectedBalance - receiverExpectedBalance - fee
+        assert_equal(self.nodes[0].z_getbalance(senderaddr), calculatedSenderBalance)
+
+        # send from node 0 taddr to node 2 multiple taddr
+        receiveraddr = self.nodes[2].getnewaddress()
+        receiveraddr2 = self.nodes[2].getnewaddress()
+        recipients  = [ {"address": receiveraddr, "amount": receiverExpectedBalance},
+                        {"address": receiveraddr2, "amount": receiverExpectedBalance}  ]
+
+        myopid = self.nodes[0].z_sendmanywithchangetosender(senderaddr, recipients, minconf, fee)
+        mytxid = wait_and_assert_operationid_status(self.nodes[0], myopid)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        calculatedSenderBalance = calculatedSenderBalance - fee - receiverExpectedBalance * 2
+        assert_equal(self.nodes[0].z_getbalance(senderaddr), calculatedSenderBalance)
+        assert_equal(self.nodes[2].z_getbalance(receiveraddr), receiverExpectedBalance)
+        assert_equal(self.nodes[2].z_getbalance(receiveraddr2), receiverExpectedBalance)
+
+        # send from node 2 zaddr to node 3 zaddr
+        saplingreceiver = self.nodes[3].z_getnewaddress('sapling')
+        saplingAddrBalance = self.nodes[2].z_getbalance(saplingAddr0)
+        recipients  = [ {"address": saplingreceiver, "amount": receiverExpectedBalance}]
+        myopid = self.nodes[2].z_sendmanywithchangetosender(saplingAddr0, recipients, minconf, fee)
+        mytxid = wait_and_assert_operationid_status(self.nodes[2], myopid)
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+        calculatedSenderBalance = saplingAddrBalance - fee - receiverExpectedBalance
+        assert_equal(self.nodes[2].z_getbalance(saplingAddr0), calculatedSenderBalance)
+        assert_equal(self.nodes[3].z_getbalance(saplingreceiver), receiverExpectedBalance)
 if __name__ == '__main__':
     WalletSaplingTest().main()

--- a/qa/rpc-tests/wallet_sapling.py
+++ b/qa/rpc-tests/wallet_sapling.py
@@ -204,7 +204,6 @@ class WalletSaplingTest(BitcoinTestFramework):
         # Check z_sendmanywithchangetosender
         # send from node 0 taddr to node 2 single taddr
         senderaddr = self.nodes[0].getnewaddress()
-        senderaddr = self.nodes[0].getnewaddress()
         self.nodes[0].generate(10)
         self.sync_all()
 
@@ -215,7 +214,6 @@ class WalletSaplingTest(BitcoinTestFramework):
         self.sync_all()
         assert_equal(self.nodes[0].z_getbalance(senderaddr), senderExpectedBalance)
 
-        receiveraddr = self.nodes[2].getnewaddress()
         receiveraddr = self.nodes[2].getnewaddress()
         fee         = Decimal('0.01')
         minconf     = 1

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -66,7 +66,7 @@ AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(
         int minDepth,
         CAmount fee,
         UniValue contextInfo,
-        bool returnChangeToSenderAddr) :
+        const bool returnChangeToSenderAddr) :
         tx_(contextualTx), fromaddress_(fromAddress), t_outputs_(tOutputs), z_outputs_(zOutputs), mindepth_(minDepth), fee_(fee), contextinfo_(contextInfo), returnChangeToSenderAddr_(returnChangeToSenderAddr)
 {
     assert(fee_ >= 0);

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -65,8 +65,9 @@ AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(
         std::vector<SendManyRecipient> zOutputs,
         int minDepth,
         CAmount fee,
-        UniValue contextInfo) :
-        tx_(contextualTx), fromaddress_(fromAddress), t_outputs_(tOutputs), z_outputs_(zOutputs), mindepth_(minDepth), fee_(fee), contextinfo_(contextInfo)
+        UniValue contextInfo,
+        bool returnChangeToSenderAddr) :
+        tx_(contextualTx), fromaddress_(fromAddress), t_outputs_(tOutputs), z_outputs_(zOutputs), mindepth_(minDepth), fee_(fee), contextinfo_(contextInfo), returnChangeToSenderAddr_(returnChangeToSenderAddr)
 {
     assert(fee_ >= 0);
 
@@ -394,17 +395,27 @@ bool AsyncRPCOperation_sendmany::main_impl() {
             LOCK2(cs_main, pwalletMain->cs_wallet);
 
             EnsureWalletIsUnlocked();
-            CReserveKey keyChange(pwalletMain);
-            CPubKey vchPubKey;
-            bool ret = keyChange.GetReservedKey(vchPubKey);
-            if (!ret) {
-                // should never fail, as we just unlocked
-                throw JSONRPCError(
-                    RPC_WALLET_KEYPOOL_RAN_OUT,
-                    "Could not generate a taddr to use as a change address");
+
+            CTxDestination changeAddr;
+            if (!returnChangeToSenderAddr_) {
+                // We generate a new address to send to
+                CReserveKey keyChange(pwalletMain);
+                CPubKey vchPubKey;
+                bool ret = keyChange.GetReservedKey(vchPubKey);
+                if (!ret) {
+                    throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Could not generate a taddr to use as a change address"); // should never fail, as we just unlocked
+                }
+                changeAddr = vchPubKey.GetID();
+            } else {
+                // We send the change back to the sender
+                if (isfromtaddr_) {
+                    changeAddr = fromtaddr_;
+                } else {
+                    // This should never happen, because this API is called from t_addr case only
+                    throw JSONRPCError(RPC_WALLET_ERROR, "Could not detect type if type of address is t address or z address");
+                }
             }
 
-            CTxDestination changeAddr = vchPubKey.GetID();
             builder_.SendChangeTo(changeAddr);
         }
 
@@ -1291,13 +1302,27 @@ void AsyncRPCOperation_sendmany::add_taddr_change_output_to_tx(CAmount amount) {
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     EnsureWalletIsUnlocked();
-    CReserveKey keyChange(pwalletMain);
-    CPubKey vchPubKey;
-    bool ret = keyChange.GetReservedKey(vchPubKey);
-    if (!ret) {
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Could not generate a taddr to use as a change address"); // should never fail, as we just unlocked
+    CScript scriptPubKey;
+
+    if (!returnChangeToSenderAddr_) {
+        // We generate a new address to send to
+        CReserveKey keyChange(pwalletMain);
+        CPubKey vchPubKey;
+        bool ret = keyChange.GetReservedKey(vchPubKey);
+        if (!ret) {
+            throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Could not generate a taddr to use as a change address"); // should never fail, as we just unlocked
+        }
+        scriptPubKey = GetScriptForDestination(vchPubKey.GetID());
+    } else {
+        // We send the change back to the sender
+        if (isfromtaddr_) {
+            scriptPubKey = GetScriptForDestination(fromtaddr_);
+        } else {
+            // This should never happen, because this API is called from t_addr case only
+            throw JSONRPCError(RPC_WALLET_ERROR, "Could not detect type if type of address is t address or z address"); 
+        }
     }
-    CScript scriptPubKey = GetScriptForDestination(vchPubKey.GetID());
+
     CTxOut out(amount, scriptPubKey);
 
     CMutableTransaction rawTx(tx_);

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -60,7 +60,7 @@ public:
         int minDepth,
         CAmount fee = ASYNC_RPC_OPERATION_DEFAULT_MINERS_FEE,
         UniValue contextInfo = NullUniValue,
-        bool returnChangeToSenderAddr_ = false);
+        const bool returnChangeToSenderAddr_ = false);
     virtual ~AsyncRPCOperation_sendmany();
     
     // We don't want to be copied or moved around

--- a/src/wallet/asyncrpcoperation_sendmany.h
+++ b/src/wallet/asyncrpcoperation_sendmany.h
@@ -59,7 +59,8 @@ public:
         std::vector<SendManyRecipient> zOutputs,
         int minDepth,
         CAmount fee = ASYNC_RPC_OPERATION_DEFAULT_MINERS_FEE,
-        UniValue contextInfo = NullUniValue);
+        UniValue contextInfo = NullUniValue,
+        bool returnChangeToSenderAddr_ = false);
     virtual ~AsyncRPCOperation_sendmany();
     
     // We don't want to be copied or moved around
@@ -88,6 +89,7 @@ private:
     std::string fromaddress_;
     bool isfromtaddr_;
     bool isfromzaddr_;
+    bool returnChangeToSenderAddr_;
     CTxDestination fromtaddr_;
     PaymentAddress frompaymentaddress_;
     SpendingKey spendingkey_;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3981,14 +3981,16 @@ UniValue z_getoperationstatus_IMPL(const UniValue& params, bool fRemoveFinishedO
 #define CTXIN_SPEND_DUST_SIZE   148
 #define CTXOUT_REGULAR_SIZE     34
 
-UniValue z_sendmany(const UniValue& params, bool fHelp)
+UniValue z_sendmanyimpl(const UniValue& params, bool fHelp, bool returnChangeToSenderAddr)
 {
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
+    std::string functionName = returnChangeToSenderAddr ? "z_sendmanywithchangetosender": "z_sendmany";
+
     if (fHelp || params.size() < 2 || params.size() > 4)
         throw runtime_error(
-            "z_sendmany \"fromaddress\" [{\"address\":... ,\"amount\":...},...] ( minconf ) ( fee )\n"
+            functionName + " \"fromaddress\" [{\"address\":... ,\"amount\":...},...] ( minconf ) ( fee )\n"
             "\nSend multiple times. Amounts are decimal numbers with at most 8 digits of precision."
             "\nChange generated from a taddr flows to a new taddr address, while change generated from a zaddr returns to itself."
             "\nWhen sending coinbase UTXOs to a zaddr, change is not allowed. The entire value of the UTXO(s) must be consumed."
@@ -4008,8 +4010,8 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
             "\nResult:\n"
             "\"operationid\"          (string) An operationid to pass to z_getoperationstatus to get the result of the operation.\n"
             "\nExamples:\n"
-            + HelpExampleCli("z_sendmany", "\"PtczsZ91Bt3oDPDQotzUsrx1wjmsFVgf28n\" '[{\"address\": \"PzSSk8QJFqjo133DoFZvn9wwcCxt5RYeeLFJZRgws6xgJ3LroqRgXKNkhkG3ENmC8oe82UTr3PHcQB9mw7DSLXhyP6atQQ5\" ,\"amount\": 5.0}]'")
-            + HelpExampleRpc("z_sendmany", "\"PtczsZ91Bt3oDPDQotzUsrx1wjmsFVgf28n\", [{\"address\": \"PzSSk8QJFqjo133DoFZvn9wwcCxt5RYeeLFJZRgws6xgJ3LroqRgXKNkhkG3ENmC8oe82UTr3PHcQB9mw7DSLXhyP6atQQ5\" ,\"amount\": 5.0}]")
+            + HelpExampleCli(functionName, "\"PtczsZ91Bt3oDPDQotzUsrx1wjmsFVgf28n\" '[{\"address\": \"PzSSk8QJFqjo133DoFZvn9wwcCxt5RYeeLFJZRgws6xgJ3LroqRgXKNkhkG3ENmC8oe82UTr3PHcQB9mw7DSLXhyP6atQQ5\" ,\"amount\": 5.0}]'")
+            + HelpExampleRpc(functionName, "\"PtczsZ91Bt3oDPDQotzUsrx1wjmsFVgf28n\", [{\"address\": \"PzSSk8QJFqjo133DoFZvn9wwcCxt5RYeeLFJZRgws6xgJ3LroqRgXKNkhkG3ENmC8oe82UTr3PHcQB9mw7DSLXhyP6atQQ5\" ,\"amount\": 5.0}]")
         );
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
@@ -4251,12 +4253,21 @@ UniValue z_sendmany(const UniValue& params, bool fHelp)
 
     // Create operation and add to global queue
     std::shared_ptr<AsyncRPCQueue> q = getAsyncRPCQueue();
-    std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(builder, contextualTx, fromaddress, taddrRecipients, zaddrRecipients, nMinDepth, nFee, contextInfo) );
+    std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(builder, contextualTx, fromaddress, taddrRecipients, zaddrRecipients, nMinDepth, nFee, contextInfo, returnChangeToSenderAddr) );
     q->addOperation(operation);
     AsyncRPCOperationId operationId = operation->getId();
     return operationId;
 }
 
+UniValue z_sendmanywithchangetosender(const UniValue& params, bool fHelp)
+{
+    return z_sendmanyimpl(params, fHelp, true);
+}
+
+UniValue z_sendmany(const UniValue& params, bool fHelp)
+{
+    return z_sendmanyimpl(params, fHelp, false);
+}
 
 /**
 When estimating the number of coinbase utxos we can shield in a single transaction:
@@ -5058,6 +5069,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "z_gettotalbalance",        &z_gettotalbalance,        false },
     { "wallet",             "z_mergetoaddress",         &z_mergetoaddress,         false },
     { "wallet",             "z_sendmany",               &z_sendmany,               false },
+    { "wallet",             "z_sendmanywithchangetosender",  &z_sendmanywithchangetosender,   false },
     { "wallet",             "z_shieldcoinbase",         &z_shieldcoinbase,         false },
     { "wallet",             "z_getoperationstatus",     &z_getoperationstatus,     true  },
     { "wallet",             "z_getoperationresult",     &z_getoperationresult,     true  },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4253,7 +4253,7 @@ UniValue z_sendmanyimpl(const UniValue& params, bool fHelp, bool returnChangeToS
 
     // Create operation and add to global queue
     std::shared_ptr<AsyncRPCQueue> q = getAsyncRPCQueue();
-    std::shared_ptr<AsyncRPCOperation> operation( new AsyncRPCOperation_sendmany(builder, contextualTx, fromaddress, taddrRecipients, zaddrRecipients, nMinDepth, nFee, contextInfo, returnChangeToSenderAddr) );
+    auto operation = std::make_shared<AsyncRPCOperation_sendmany>(builder, contextualTx, fromaddress, taddrRecipients, zaddrRecipients, nMinDepth, nFee, contextInfo, returnChangeToSenderAddr);
     q->addOperation(operation);
     AsyncRPCOperationId operationId = operation->getId();
     return operationId;


### PR DESCRIPTION
## What is this about?
Add implementation for z_sendmanywithchangetosender, which will send PSL to an address and return any change to the sending address

## What is the test results?
Built successfully
Passed all below test suite on local machine (**_in old PR #51, rerunning to validate again_**):
  cd qa/test-suite
  ./mn_main.py
  ./mn_payment.py
  ./mn_tickets.py
  ./mn_tickets_validation.py
  ./mn_messaging.py
  ./full_test_suite.py btest
  ./full_test_suite.py gtest
  ./full_test_suite.py sec-hard
  ./full_test_suite.py no-dot-so
  ./full_test_suite.py util-test
  ./full_test_suite.py secp256k1
  ./full_test_suite.py libsnark
  ./full_test_suite.py univalue
  ./full_test_suite.py rpc-ext
  ./full_test_suite.py rpc-common
  Test case that is failing:
  ./mn_governance.py <-- Failed on master branch also.
  Test case that took too long to complete, and failed some test cases while running:
  ./full_test_suite.py rpc-mn