### PR TITLE
Fix issue that cause mn_governance.py failed randomly

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -115,7 +115,7 @@ declare -a testScriptsMN=(
     'mn_main.py'
     'mn_bugs.py'
     'mn_payment.py'
-#    'mn_governance.py'
+    'mn_governance.py'
     'mn_tickets.py'
     'mn_tickets_validation.py'
     'mn_messaging.py'

--- a/qa/rpc-tests/mn_governance.py
+++ b/qa/rpc-tests/mn_governance.py
@@ -110,8 +110,8 @@ class MasterNodeGovernanceTest (MasterNodeCommon):
 
         self.nodes[self.mining_node_num].generate(5)
 
-        print("Waiting 60 seconds")
-        time.sleep(60)
+        print("Waiting 90 seconds")
+        time.sleep(90)
 
         print("Test tickets votes")
         #3. Preliminary test, should be 2 tickets: 1st ticket - 3 votes, 2 yes; 2nd ticket - 1 vote, 1 yes


### PR DESCRIPTION
Fix issue that cause mn_governance.py failed randomly.
Root cause: The current test didn't wait long enough for nodes to sync, so sometimes the test cases failed, sometimes the test cases passed.
Solution: Increase waiting time to make sure all nodes synced.

##What is the test result?

Built successfully
Passed all below test suite on local machine(**_in old PR #52, rerunning to validate again_**):
cd qa/test-suite
./mn_governance.py
./mn_main.py
./mn_payment.py
./mn_tickets.py
./mn_tickets_validation.py
./mn_messaging.py
./full_test_suite.py btest
./full_test_suite.py gtest
./full_test_suite.py sec-hard
./full_test_suite.py no-dot-so
./full_test_suite.py util-test
./full_test_suite.py secp256k1
./full_test_suite.py libsnark
./full_test_suite.py univalue
./full_test_suite.py rpc-common
./full_test_suite.py rpc-ext
Test case that took too long to complete, and failed some test cases while running:
./full_test_suite.py rpc-mn