### PR TITLE
univalue support for move semantics

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -18,11 +18,9 @@ class UniValue {
 public:
     enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };
 
-    UniValue() { typ = VNULL; }
-    UniValue(UniValue::VType initialType, const std::string& initialStr = "") {
-        typ = initialType;
-        val = initialStr;
-    }
+    UniValue() : typ(VNULL) {}
+    UniValue(UniValue::VType type, const std::string& value = std::string()) : typ(type), val(value) {}
+    UniValue(UniValue::VType type, std::string&& value) : typ(type), val(std::move(value)) {}
     UniValue(uint64_t val_) {
         setInt(val_);
     }
@@ -41,9 +39,11 @@ public:
     UniValue(const std::string& val_) {
         setStr(val_);
     }
+    UniValue(std::string&& val_) {
+        setStr(std::move(val_));
+    }
     UniValue(const char *val_) {
-        std::string s(val_);
-        setStr(s);
+        setStr(std::string(val_));
     }
 
     void clear();
@@ -60,11 +60,13 @@ public:
     bool setNull();
     bool setBool(bool val);
     bool setNumStr(const std::string& val);
+    bool setNumStr(std::string&& val);
     bool setInt(uint64_t val);
     bool setInt(int64_t val);
     bool setInt(int val_) { return setInt((int64_t)val_); }
     bool setFloat(double val);
     bool setStr(const std::string& val);
+    bool setStr(std::string&& val);
     bool setArray();
     bool setObject();
 
@@ -91,11 +93,22 @@ public:
     bool isObject() const { return (typ == VOBJ); }
 
     bool push_back(const UniValue& val);
+    bool push_back(UniValue&& val);
     bool push_backV(const std::vector<UniValue>& vec);
+    bool push_backV(std::vector<UniValue>&& vec);
 
     void __pushKV(const std::string& key, const UniValue& val);
+    void __pushKV(const std::string& key, UniValue&& val);
+    void __pushKV(std::string&& key, const UniValue& val);
+    void __pushKV(std::string&& key, UniValue&& val);
+
     bool pushKV(const std::string& key, const UniValue& val);
+    bool pushKV(const std::string& key, UniValue&& val);
+    bool pushKV(std::string&& key, const UniValue& val);
+    bool pushKV(std::string&& key, UniValue&& val);
+
     bool pushKVs(const UniValue& obj);
+    bool pushKVs(UniValue&& obj);
 
     std::string write(unsigned int prettyIndent = 0,
                       unsigned int indentLevel = 0) const;
@@ -113,6 +126,7 @@ private:
     std::vector<UniValue> values;
 
     bool findKey(const std::string& key, size_t& retIdx) const;
+    void write(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
     void writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const;
 

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -172,7 +172,7 @@ enum jtokentype getJsonToken(std::string& tokenVal, unsigned int& consumed,
             }
         }
 
-        tokenVal = numStr;
+        tokenVal = std::move(numStr);
         consumed = static_cast<unsigned int>(raw - rawStart);
         return JTOK_NUMBER;
         }
@@ -234,7 +234,7 @@ enum jtokentype getJsonToken(std::string& tokenVal, unsigned int& consumed,
 
         if (!writer.finalize())
             return JTOK_ERR;
-        tokenVal = valStr;
+        tokenVal = std::move(valStr);
         consumed = static_cast<unsigned int>(raw - rawStart);
         return JTOK_STRING;
         }
@@ -325,7 +325,7 @@ bool UniValue::read(const char *raw, size_t size)
             } else {
                 UniValue tmpVal(utyp);
                 UniValue *top = stack.back();
-                top->values.push_back(tmpVal);
+                top->values.push_back(std::move(tmpVal));
 
                 UniValue *newTop = &(top->values.back());
                 stack.push_back(newTop);
@@ -400,12 +400,12 @@ bool UniValue::read(const char *raw, size_t size)
             }
 
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -414,12 +414,12 @@ bool UniValue::read(const char *raw, size_t size)
         case JTOK_NUMBER: {
             UniValue tmpVal(VNUM, tokenVal);
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -434,11 +434,11 @@ bool UniValue::read(const char *raw, size_t size)
             } else {
                 UniValue tmpVal(VSTR, tokenVal);
                 if (!stack.size()) {
-                    *this = tmpVal;
+                    *this = std::move(tmpVal);
                     break;
                 }
                 UniValue *top = stack.back();
-                top->values.push_back(tmpVal);
+                top->values.push_back(std::move(tmpVal));
             }
 
             setExpect(NOT_VALUE);

--- a/src/univalue/lib/univalue_write.cpp
+++ b/src/univalue/lib/univalue_write.cpp
@@ -7,11 +7,8 @@
 #include "univalue.h"
 #include "univalue_escapes.h"
 
-static std::string json_escape(const std::string& inS)
+static void json_escape(const std::string& inS, std::string& outS)
 {
-    std::string outS;
-    outS.reserve(inS.size() * 2);
-
     for (unsigned int i = 0; i < inS.size(); i++) {
         unsigned char ch = inS[i];
         const char *escStr = escapes[ch];
@@ -21,16 +18,21 @@ static std::string json_escape(const std::string& inS)
         else
             outS += ch;
     }
-
-    return outS;
 }
 
 std::string UniValue::write(unsigned int prettyIndent,
                             unsigned int indentLevel) const
 {
     std::string s;
-    s.reserve(1024);
+    s.reserve(2048);
+    write(prettyIndent, indentLevel, s);
+    return s;
+}
 
+void UniValue::write(unsigned int prettyIndent,
+                     unsigned int indentLevel,
+                     std::string& s) const
+{
     unsigned int modIndent = indentLevel;
     if (modIndent == 0)
         modIndent = 1;
@@ -46,7 +48,9 @@ std::string UniValue::write(unsigned int prettyIndent,
         writeArray(prettyIndent, modIndent, s);
         break;
     case VSTR:
-        s += "\"" + json_escape(val) + "\"";
+        s += '"';
+        json_escape(val, s);
+        s += '"';
         break;
     case VNUM:
         s += val;
@@ -55,8 +59,6 @@ std::string UniValue::write(unsigned int prettyIndent,
         s += (val == "1" ? "true" : "false");
         break;
     }
-
-    return s;
 }
 
 static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, std::string& s)
@@ -66,47 +68,49 @@ static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, std::
 
 void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
-    s += "[";
+    s += '[';
     if (prettyIndent)
-        s += "\n";
+        s += '\n';
 
     for (unsigned int i = 0; i < values.size(); i++) {
         if (prettyIndent)
             indentStr(prettyIndent, indentLevel, s);
-        s += values[i].write(prettyIndent, indentLevel + 1);
+        values[i].write(prettyIndent, indentLevel + 1, s);
         if (i != (values.size() - 1)) {
-            s += ",";
+            s += ',';
         }
         if (prettyIndent)
-            s += "\n";
+            s += '\n';
     }
 
     if (prettyIndent)
         indentStr(prettyIndent, indentLevel - 1, s);
-    s += "]";
+    s += ']';
 }
 
 void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
-    s += "{";
+    s += '{';
     if (prettyIndent)
-        s += "\n";
+        s += '\n';
 
     for (unsigned int i = 0; i < keys.size(); i++) {
         if (prettyIndent)
             indentStr(prettyIndent, indentLevel, s);
-        s += "\"" + json_escape(keys[i]) + "\":";
+        s += '\"';
+        json_escape(keys[i], s);
+        s += "\":";
         if (prettyIndent)
-            s += " ";
-        s += values.at(i).write(prettyIndent, indentLevel + 1);
+            s += ' ';
+        values.at(i).write(prettyIndent, indentLevel + 1, s);
         if (i != (values.size() - 1))
-            s += ",";
+            s += ',';
         if (prettyIndent)
-            s += "\n";
+            s += '\n';
     }
 
     if (prettyIndent)
         indentStr(prettyIndent, indentLevel - 1, s);
-    s += "}";
+    s += '}';
 }
 


### PR DESCRIPTION
Integrate univalue PR to support move semathics: https://github.com/jgarzik/univalue/issues/52.

In a benchmark with Bitcoin's BlockToJsonVerbose, using these move
methods where possible speeds up JSON generation by about a factor of 2.

You can see some benchmarks here: bitcoin/bitcoin#20999