### PR TITLE
Re-based PR50 to up-to-date master (secure container support addition…

### DIFF
--- a/qa/rpc-tests/mn_tickets.py
+++ b/qa/rpc-tests/mn_tickets.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 import math
 
-from test_framework.util import assert_equal, assert_greater_than, \
+from test_framework.util import assert_equal, assert_equals, assert_greater_than, \
     assert_true, initialize_chain_clean, str_to_b64str
 from mn_common import MasterNodeCommon
 from test_framework.authproxy import JSONRPCException
@@ -114,6 +114,8 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.trade_ticket1_sell_ticket_txid = None
         self.trade_ticket1_buy_ticket_txid = None
         self.trade_ticket1_trade_ticket_txid = None
+        self.nested_ownership_trade_txid  = None
+        self.single_sell_trade_txids = []
 
         self.id_ticket_price = 10
         self.art_ticket_price = 10
@@ -176,6 +178,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.takedown_ticket_tests()
         self.storage_fee_tests()
         self.tickets_list_filter_tests(0)
+        self.list_and_validate_ticket_ownerships()
         self.username_ticket_tests()
 
         if self.test_high_heights:
@@ -206,6 +209,50 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             self.tickets_list_filter_tests(1)
             self.username_ticket_tests()
 
+# ===============================================================================================================
+    def list_and_validate_ticket_ownerships(self):
+        print("== Ownership validation tests ==")
+        tickets_list = self.nodes[self.non_mn4].tickets("list", "art", "all")
+
+        # Test not available pastelID
+        try:
+            self.nodes[self.non_mn4].tickets("tools", "validateownership", self.art_ticket1_txid, "NOT_A_VALID_PASTELID", "passphrase")
+        except JSONRPCException as e:
+            self.errorString = e.error['message']
+            print(self.errorString)
+        assert_equal("Error: Corresponding PastelID not found!"
+                     in self.errorString, True)
+
+        # Test incorrect passphrase
+        try:
+            self.nodes[self.non_mn3].tickets("tools", "validateownership", self.art_ticket1_txid, self.artist_pastelid1, "not_valid_passphrase")
+        except JSONRPCException as e:
+            self.errorString = e.error['message']
+            print(self.errorString)
+        assert_equal("Error: Failed to validate passphrase!"
+                     in self.errorString, True)
+
+        # Check if author
+        res1 = self.nodes[self.non_mn3].tickets("tools", "validateownership", self.art_ticket1_txid, self.artist_pastelid1, "passphrase")
+        assert_equal( self.art_ticket1_txid, res1['art'] )
+        assert_equal( "", res1['trade'] )
+
+        # Test 'single sale' (without re-selling)
+        res1 = self.nodes[self.non_mn4].tickets("tools", "validateownership", self.art_ticket1_txid, self.nonmn4_pastelid1, "passphrase")
+        assert_equal( self.art_ticket1_txid, res1['art'] )
+        assert_equals( self.single_sell_trade_txids, res1['trade'] )
+
+        # Test ownership with or re-sold art
+        res1 = self.nodes[self.non_mn3].tickets("tools", "validateownership", self.art_ticket1_txid, self.nonmn3_pastelid1, "passphrase")
+        assert_equal( self.art_ticket1_txid, res1['art'] )
+        assert_equal( self.nested_ownership_trade_txid, res1['trade'] )
+
+        # Test no ownership
+        res1 = self.nodes[self.non_mn1].tickets("tools", "validateownership", self.art_ticket1_txid, self.nonmn1_pastelid2, "passphrase")
+        assert_equal( "", res1['art'] )
+        assert_equal( "", res1['trade'] )
+
+        print("== Ownership validation tested ==")
     # ===============================================================================================================
     def pastelid_tests(self):
         print("== Pastelid tests ==")
@@ -2040,6 +2087,26 @@ class MasterNodeTicketsTest(MasterNodeCommon):
                                                            buyer_pastelid, self.passphrase)["txid"]
         assert_true(trade_ticket_txid, "No ticket was created")
         print(f"trade_ticket_txid: {trade_ticket_txid}")
+        # Choosen trade ticket for validating ownership 
+        # 1. We need a list ( at least with 1 element)
+        # of non-sold trade ticket
+        #
+        # 2. Filter that tickets by pastelID and get the
+        # underlying ArtReg ticket found by txid from the
+        # request
+        if (
+            test_num == 'A1' or test_num == 'A2' or
+        test_num == 'A3' or test_num == 'A4' or
+        test_num == 'A5' or test_num == 'A6' or
+        test_num == 'A7' or test_num == 'A8' or
+        test_num == 'A9'
+        ):
+            # This pastelID (and generated trades) holds the ownership of copies (2-10)
+            self.single_sell_trade_txids.append(trade_ticket_txid)
+
+        if test_num == 'T5':
+            # This pastelID (and generated trade) holds the ownership of copy 1 sold multiple times (nested)
+            self.nested_ownership_trade_txid = trade_ticket_txid
 
         self.__wait_for_ticket_tnx()
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -391,6 +391,16 @@ def assert_equal(expected, actual, message=""):
             message = "; %s" % message 
         raise AssertionError("(left == right)%s\n  left: <%s>\n right: <%s>" % (message, str(expected), str(actual)))
 
+def assert_equals(expected, actual, message=""):
+    find_item = False
+    for item in expected:
+        if item == actual:
+            find_item = True
+    if find_item != True:
+        if message:
+                message = "; %s" % message
+        raise AssertionError("Non of the (list) expected values are equal(left == right)%s\n  left: <%s>\n right: <%s>" % (message, str(expected), str(actual)))
+
 def assert_true(condition, message = ""):
     if not condition:
         raise AssertionError(message)

--- a/src/mnode/mnode-pastel.cpp
+++ b/src/mnode/mnode-pastel.cpp
@@ -1253,10 +1253,63 @@ CArtTradeTicket CArtTradeTicket::Create(std::string _sellTnxId, std::string _buy
 
     ticket.GenerateTimestamp();
     
+    // In case it is nested it means that we have the artTnxId of the sell ticket
+    // available within the trade tickets.
+    // [0]: original registration ticket's txid
+    // [1]: copy number for a given art
+    std::vector<std::string> artRegTicket_TxId_Serial = CArtTradeTicket::GetArtRegTxIDAndSerialIfResoldNft(sellTicket->artTnxId);
+    if(artRegTicket_TxId_Serial[0].compare("") == 0)
+    {  
+      auto artTicket = ticket.FindArtRegTicket();
+      if (!artTicket)
+      {
+        throw std::runtime_error("Art Reg ticket not found");
+      }
+
+      //Original TxId
+      ticket.SetArtRegTicketTxid(artTicket->GetTxId());
+      //Copy nr.
+      ticket.SetCopySerialNr(std::to_string(sellTicket->copyNumber));
+    }
+    else
+    {
+      //This is the re-sold case
+      ticket.SetArtRegTicketTxid(artRegTicket_TxId_Serial[0]);
+      ticket.SetCopySerialNr(artRegTicket_TxId_Serial[1]);
+    }
     std::string strTicket = ticket.ToStr();
     string_to_vector(CPastelID::Sign(strTicket, ticket.pastelID, strKeyPass), ticket.signature);
     
     return ticket;
+}
+
+std::vector<std::string> CArtTradeTicket::GetArtRegTxIDAndSerialIfResoldNft(const std::string& _txid)
+{
+
+    std::vector<std::string> vRetVal = {"",""};
+
+    try
+    {
+      //Possible conversion to trade ticket - if any
+      auto pNestedTicket = CPastelTicketProcessor::GetTicket(_txid, TicketID::Trade);
+      if(pNestedTicket != nullptr)
+      {
+        auto tradeTicket = dynamic_cast<const CArtTradeTicket*>(pNestedTicket.get());
+        if (tradeTicket)
+        {
+          vRetVal[0] = tradeTicket->GetArtRegTicketTxid();
+          vRetVal[1] = tradeTicket->GetCopySerialNr();
+        }
+      }
+    }
+    catch(const runtime_error& error)
+    {
+      //Intentionally not throw exception!
+      LogPrintf("DebugPrint: NFT with this txid is not resold: %s", _txid);
+    }
+    
+    return vRetVal;
+    
 }
 
 std::string CArtTradeTicket::ToStr() const noexcept
@@ -1267,6 +1320,8 @@ std::string CArtTradeTicket::ToStr() const noexcept
     ss << buyTnxId;
     ss << artTnxId;
     ss << m_nTimestamp;
+    ss << nftRegTnxId;
+    ss << nftCopySerialNr;
     return ss.str();
 }
 
@@ -1456,6 +1511,8 @@ std::string CArtTradeTicket::ToJSON() const noexcept
                 {"sell_txid", sellTnxId},
                 {"buy_txid", buyTnxId},
                 {"art_txid", artTnxId},
+                {"registration_txid",nftRegTnxId},
+                {"copy_serial_nr", nftCopySerialNr},
                 {"signature", ed_crypto::Hex_Encode(signature.data(), signature.size())}
             }}
     };
@@ -1478,6 +1535,51 @@ std::vector<CArtTradeTicket> CArtTradeTicket::FindAllTicketByPastelID(const std:
 std::vector<CArtTradeTicket> CArtTradeTicket::FindAllTicketByArtTnxID(const std::string& artTnxID)
 {
     return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CArtTradeTicket>(artTnxID);
+}
+
+std::vector<CArtTradeTicket> CArtTradeTicket::FindAllTicketByRegTnxID(const std::string& nftRegTnxId)
+{
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CArtTradeTicket>(nftRegTnxId);
+}
+
+std::map<std::string, std::string> CArtTradeTicket::GetPastelIdAndTxIdWithTopHeightPerCopy(const std::vector<CArtTradeTicket> & filteredTickets)
+{
+  //The list is already sorted by height (from beginning to end)
+
+  //This will hold all the owner / copies serial number where serial number is the key 
+  std::map<std::string, std::string> ownerPastelIDs_and_txids;
+
+  //Copy number and winning index (within the vector)
+  //std::map<std::string, int> copyOwner_Idxs;
+  std::map<std::string, std::pair<unsigned int, int>> copyOwner_Idxs;
+  int winning_idx = 0;
+
+  for (const auto & element : filteredTickets) {
+
+    const std::string& serial = element.GetCopySerialNr();
+    if(copyOwner_Idxs.find(serial) != copyOwner_Idxs.end())
+    {
+      //We do have it in our copyOwner_Idxs
+      if(element.GetBlock() >= copyOwner_Idxs[serial].first)
+      {
+        copyOwner_Idxs[serial] = std::make_pair(element.GetBlock(), winning_idx);
+      }
+    }
+    else
+    {
+      copyOwner_Idxs.insert({ serial, std::make_pair(element.GetBlock(), winning_idx) });
+    }
+    winning_idx++;
+  }
+
+  // Now we do have the winning IDXs
+  // we need to extract owners pastelId and TxnIds
+  for (const auto& winners: copyOwner_Idxs)
+  {
+    ownerPastelIDs_and_txids.insert({ filteredTickets[winners.second.second].pastelID, filteredTickets[winners.second.second].GetTxId() });
+  }
+
+  return ownerPastelIDs_and_txids;
 }
 
 bool CArtTradeTicket::CheckTradeTicketExistBySellTicket(const std::string& _sellTnxId)
@@ -1524,6 +1626,26 @@ std::unique_ptr<CPastelTicket> CArtTradeTicket::FindArtRegTicket() const
     }
     
     return std::move(chain.front());
+}
+
+void CArtTradeTicket::SetArtRegTicketTxid(const std::string& _NftRegTxid)
+{
+   nftRegTnxId =_NftRegTxid;
+}
+
+const std::string CArtTradeTicket::GetArtRegTicketTxid() const
+{
+  return nftRegTnxId;
+}
+
+void CArtTradeTicket::SetCopySerialNr(const std::string& _nftCopySerialNr)
+{
+  nftCopySerialNr = std::move(_nftCopySerialNr);
+}
+
+const std::string& CArtTradeTicket::GetCopySerialNr() const
+{
+  return nftCopySerialNr;
 }
 
 // CArtRoyaltyTicket ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/mnode/mnode-pastel.h
+++ b/src/mnode/mnode-pastel.h
@@ -469,6 +469,9 @@ public:
     std::string sellTnxId;
     std::string buyTnxId;
     std::string artTnxId;
+    std::string nftRegTnxId;
+    std::string nftCopySerialNr;
+
     unsigned int price{};
     std::string reserved;
     std::vector<unsigned char> signature;
@@ -487,10 +490,12 @@ public:
     std::string KeyTwo() const noexcept override { return buyTnxId; }
     std::string MVKeyOne() const noexcept override { return pastelID; }
     std::string MVKeyTwo() const noexcept override { return artTnxId; }
+    std::string MVKeyThree() const noexcept override { return nftRegTnxId; }
     
     bool HasKeyTwo() const noexcept override { return true; }
     bool HasMVKeyOne() const noexcept override { return true; }
     bool HasMVKeyTwo() const noexcept override { return true; }
+    bool HasMVKeyThree() const noexcept override { return true; }
     
     void SetKeyOne(std::string val) override { sellTnxId = std::move(val); }
     
@@ -517,6 +522,8 @@ public:
         READWRITE(m_nTimestamp);
         READWRITE(m_txid);
         READWRITE(m_nBlock);
+        READWRITE(nftRegTnxId);
+        READWRITE(nftCopySerialNr);
     }
 
     CAmount GetExtraOutputs(std::vector<CTxOut>& outputs) const override;
@@ -526,13 +533,22 @@ public:
     
     static std::vector<CArtTradeTicket> FindAllTicketByPastelID(const std::string& pastelID);
     static std::vector<CArtTradeTicket> FindAllTicketByArtTnxID(const std::string& artTnxID);
+    static std::vector<CArtTradeTicket> FindAllTicketByRegTnxID(const std::string& nftRegTnxId);
     
     static bool CheckTradeTicketExistBySellTicket(const std::string& _sellTnxId);
     static bool CheckTradeTicketExistByBuyTicket(const std::string& _buyTnxId);
     static bool GetTradeTicketBySellTicket(const std::string& _sellTnxId, CArtTradeTicket& ticket);
     static bool GetTradeTicketByBuyTicket(const std::string& _buyTnxId, CArtTradeTicket& ticket);
+    static std::map<std::string, std::string> GetPastelIdAndTxIdWithTopHeightPerCopy(const std::vector<CArtTradeTicket> & allTickets);
     
     std::unique_ptr<CPastelTicket> FindArtRegTicket() const;
+
+    void SetArtRegTicketTxid(const std::string& sNftRegTxid);
+    const std::string GetArtRegTicketTxid() const;
+    void SetCopySerialNr(const std::string& nftCopySerialNr);
+    const std::string& GetCopySerialNr() const;
+    
+    static std::vector<std::string> GetArtRegTxIDAndSerialIfResoldNft(const std::string& _txid);
 };
 
 /*

--- a/src/mnode/mnode-rpc.cpp
+++ b/src/mnode/mnode-rpc.cpp
@@ -2491,7 +2491,7 @@ As json rpc
     
     if (TICKETS.IsCmd(RPC_CMD_TICKETS::tools)) {
         
-        RPC_CMD_PARSER2(LIST, params, printtradingchain, getregbytrade, gettotalstoragefee, validateusername);
+        RPC_CMD_PARSER2(LIST, params, printtradingchain, getregbytrade, gettotalstoragefee, validateusername, validateownership);
         
         UniValue obj(UniValue::VARR);
         switch (LIST.cmd()) {
@@ -2622,6 +2622,74 @@ As json rpc
                     obj.pushKV("validationError", std::move(usernameValidationError));
 
                     return obj;
+                }
+            }
+			case RPC_CMD_LIST::validateownership: {
+
+                if (params.size() == 5)
+                {
+
+                    //result object
+                    UniValue retVal(UniValue::VOBJ);
+                    //txid
+                    std::string txid = params[2].get_str();
+                    //pastelid
+                    std::string pastelid = params[3].get_str();
+
+                    //Check if pastelid is found within the stored ones
+                    const auto pastelIDs = CPastelID::GetStoredPastelIDs();
+                    bool bIdFound = false;
+                    pastelid_store_t resultMap;
+
+                    for (const auto & p: pastelIDs)
+                    {
+                        if(p.first.compare(pastelid) == 0)
+                        {
+                            bIdFound = true;
+                            break;
+                        }
+                    }
+
+                    if(!bIdFound)
+                    {
+                        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
+                     "Error: Corresponding PastelID not found!");
+                    }
+                    //passphrase
+                    SecureString strKeyPass;
+                    strKeyPass.reserve(100);
+                    strKeyPass = params[4].get_str().c_str();
+                    if (strKeyPass.length() > 0)
+                    {
+                        //If passphrase is not valid exception is thrown
+                        if(!CPastelID::isValidPassphrase(pastelid,strKeyPass))
+                            throw JSONRPCError(RPC_WALLET_PASSPHRASE_INCORRECT, "Error: Failed to validate passphrase!");
+
+                        std::vector<std::string> result = masterNodeCtrl.masternodeTickets.ValidateOwnership(txid, pastelid);
+                        std::string art_txid = std::move(result[0]);
+                        std::string trade_txid = std::move(result[1]);
+
+                        retVal.pushKV("art", art_txid);
+                        retVal.pushKV("trade", trade_txid);
+                    }
+                    return retVal;
+                }
+                else
+                {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                       R"(tickets tools validateownership "txid" "pastelid" "passphrase"
+Get ownership validation by pastelid. If unsuccessful, method return art:"",trade:"". Every other case successful.
+
+Arguments:
+1. "txid"       (string, required) txid of the original nft registration 
+2. "pastelid"   (string, required) Registered pastelid which (according to the request) shall be the owner or the author of the registered NFT (of argument 1's txid)
+3. "passpharse" (string, required) The passphrase to the private key associated with PastelID and stored inside node. See "pastelid newkey".
+
+Validate ownership
+)" + HelpExampleCli("tickets tools validateownership", R"(""e4ee20e436d33f59cc313647bacff0c5b0df5b7b1c1fa13189ea7bc8b9df15a4" jXYqZNPj21RVnwxnEJ654wEdzi7GZTZ5LAdiotBmPrF7pDMkpX1JegDMQZX55WZLkvy9fxNpZcbBJuE8QYUqBF "passphrase")") +
+                                           R"(
+As json rpc
+)" + HelpExampleRpc("tickets", R"("tools", "validateownership", "e4ee20e436d33f59cc313647bacff0c5b0df5b7b1c1fa13189ea7bc8b9df15a4" "jXYqZNPj21RVnwxnEJ654wEdzi7GZTZ5LAdiotBmPrF7pDMkpX1JegDMQZX55WZLkvy9fxNpZcbBJuE8QYUqBF" "passphrase")"));
                 }
             }
         }

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -92,6 +92,8 @@ public:
                                                                     //      Trade, Buy, Sell, Act or Reg in long walk
             std::string& errRet) noexcept;
     
+    std::vector<std::string> ValidateOwnership(const std::string &_txid, const std::string &_pastelID);
+
 #ifdef FAKE_TICKET
     static std::string CreateFakeTransaction(CPastelTicket& ticket, CAmount ticketPrice, const std::vector<std::pair<std::string, CAmount>>& extraPayments, const std::string& strVerb, bool bSend);
 #endif

--- a/src/mnode/ticket.h
+++ b/src/mnode/ticket.h
@@ -88,11 +88,13 @@ public:
     virtual bool HasKeyTwo() const noexcept { return false; }
     virtual bool HasMVKeyOne() const noexcept { return false; }
     virtual bool HasMVKeyTwo() const noexcept { return false; }
+    virtual bool HasMVKeyThree() const noexcept { return false; }
 
     virtual std::string KeyOne() const noexcept = 0; //Key to the object itself
     virtual std::string KeyTwo() const noexcept { return ""; }
     virtual std::string MVKeyOne() const noexcept { return ""; }
     virtual std::string MVKeyTwo() const noexcept { return ""; }
+    virtual std::string MVKeyThree() const noexcept { return ""; }
 
     virtual void SetKeyOne(std::string val) = 0;
 

--- a/src/pastelid/pastel_key.h
+++ b/src/pastelid/pastel_key.h
@@ -43,6 +43,8 @@ public:
         const SIGN_ALGORITHM alg = SIGN_ALGORITHM::ed448, const bool fBase64 = false);
     // Get PastelIDs stored locally in pastelkeys (pastelkeysdir option).
     static pastelid_store_t GetStoredPastelIDs(const bool bPastelIdOnly = true);
+    // Validate passphrase via secure container or pkcs8 format
+    static bool isValidPassphrase(const std::string& pastelid,const SecureString& strKeyPass) noexcept;
 
 protected:
     // encode/decode PastelID

--- a/src/pastelid/secure_container.cpp
+++ b/src/pastelid/secure_container.cpp
@@ -378,6 +378,99 @@ bool CSecureContainer::read_from_file(const string& sFilePath, const SecureStrin
 }
 
 /**
+ * Validate passphrase via SECURE_ITEM_TYPE::pkey_ed448.
+ * Decrypt secure data. Throws std::runtime_error exception in case of failure.
+ * 
+ * \param sFilePath - container file path
+ * \param sPassphrase - passphrase in clear text to use for data decryption
+ * \return true if password was succesfully validated
+ *         false if file does not contain Pastel secure container
+ *         if container data cannot be read or decrypted - throws std::runtime_error
+ */
+bool CSecureContainer::is_valid_passphrase(const string& sFilePath, const SecureString& sPassphrase)
+{
+    using json = nlohmann::json;
+    bool bRet = false;
+    try
+    {
+        do
+        {
+            clear();
+
+            ifstream fs(sFilePath, ios::in | ios::ate | ios::binary);
+            fs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+            v_uint8 v;
+            uint64_t nDataSize = 0;
+            if (!read_public_items_ex(fs, nDataSize))
+                break;
+            // read secure container data as json msgpack
+            v.resize(nDataSize);
+            fs.read(reinterpret_cast<char*>(v.data()), v.size());
+            json j = json::from_msgpack(v);
+            v.clear();
+
+            // read header
+            j.at("version").get_to(m_nVersion);
+            j.at("timestamp").get_to(m_nTimestamp);
+            j.at("encryption").get_to(m_sEncryptionAlgorithm);
+            if (m_sEncryptionAlgorithm.compare(SECURE_CONTAINER_ENCRYPTION) != 0)
+                throw runtime_error(strprintf("Encryption algorithm '%s' is not supported", m_sEncryptionAlgorithm.c_str()));
+
+            CSodiumAutoBuf pw;
+            // allocate secure memory for the key, buffer is reused for all secure items
+            if (!pw.allocate(PWKEY_BUFSUZE))
+                throw runtime_error(strprintf("Failed to allocate memory (%zu bytes)", PWKEY_BUFSUZE));
+
+            // process encrypted items
+            // read nonce for each item and use it to derive password key from passphrase and 
+            // to decrypt data
+            string sType;
+            for (auto &jItem : j.at("secure_items"))
+            {
+                jItem["type"].get_to(sType);
+                secure_item_t item;
+                item.type = GetSecureItemTypeByName(sType);
+                if (item.type == SECURE_ITEM_TYPE::not_defined)
+                    throw runtime_error(strprintf("Secure item type '%s' is not supported", sType));
+                jItem["nonce"].get_to(item.nonce);
+                // encrypted data
+                auto& encrypted_data = jItem["data"].get_binary();
+
+                // derive key from the passphrase
+                if (crypto_pwhash(pw.p, crypto_box_SEEDBYTES,
+                                  sPassphrase.c_str(), sPassphrase.length(), item.nonce.data(),
+                                  crypto_pwhash_OPSLIMIT_INTERACTIVE, crypto_pwhash_MEMLIMIT_INTERACTIVE, crypto_pwhash_ALG_DEFAULT) != 0)
+                {
+                    throw runtime_error(strprintf("Failed to generate encryption key for the secure item '%s'", GetSecureItemTypeName(item.type)));
+                }
+                item.data.resize(encrypted_data.size());
+                unsigned long long nDecryptedLength = 0;
+                if (crypto_aead_xchacha20poly1305_ietf_decrypt(item.data.data(), &nDecryptedLength, nullptr,
+                        encrypted_data.data(), encrypted_data.size(), nullptr, 0, item.nonce.data(), pw.p) != 0)
+                {
+                    throw runtime_error(strprintf("Failed to decrypt secure item '%s' data", sType));
+                }
+                //Only need to read first secure item which has pkey_ed448 type
+                if (item.type == SECURE_ITEM_TYPE::pkey_ed448)
+                {
+                    break;
+                }
+            }
+            bRet = true;
+        } while (false);
+    }
+    catch (const std::out_of_range &ex)
+    {
+        throw runtime_error(strprintf("Pastel secure container file format error. %s", ex.what()));
+    }
+    catch (const std::exception &ex)
+    {
+        throw runtime_error(strprintf("Failed to read Pastel secure container file [%s]. %s", sFilePath.c_str(), ex.what()));
+    }
+    return bRet;
+}
+
+/**
  * Find secure item in the container by type.
  * 
  * \param type - secure item type to find

--- a/src/pastelid/secure_container.h
+++ b/src/pastelid/secure_container.h
@@ -173,6 +173,8 @@ public:
     bool write_to_file(const std::string& sFilePath, const SecureString& sPassphrase);
     // read from secure container file encrypted secure data as a msgpack and decrypt
     bool read_from_file(const std::string& sFilePath, const SecureString& sPassphrase);
+    // validate passphrase from secure container
+    bool is_valid_passphrase(const std::string& sFilePath, const SecureString& sPassphrase);
     // read from secure container file public data as a msgpack
     bool read_public_from_file(std::string &error, const std::string& sFilePath);
     // Get public data (byte vector) from the container by type


### PR DESCRIPTION
Same as PR #50 except:
- Implement new function into CSecureContainer is_valid_passphrase() to validate passphrase via secure container
- Move isValidPassphrase() into CPastel and extend to support secure containers

Rest is copied from PR#50:

PR for validate ownership of an NFT.

Implementation design details could be found in attached document.

    API usage is described in mnode-rpc
    -mn_tickets.py and mn_main.py succeeds

Key notes:

    Added 2 new fields to CArtTradeTicket + 1 MvKey in order to easily and quickly query a list of trade chain, by art registration txid.
    Cakk returns art= "", trade= "" -> This case ownership validation was not successful
    Code returns art= "example_pastelid", trade= "" -> This case example_pastelid is the author
    Code returns art= "example_pastelid", trade= "example_tradeidx" -> This case the queried art is owned by example_pastelid and was bought in example_tradeidx

![kép](https://user-images.githubusercontent.com/76977718/126782569-49115e92-9dfc-4994-9f1b-11c48fb2e4fd.png)
