### PR TITLE
[43158891] Update ZeroMQ library to v4.3.4

### DIFF
--- a/build-aux/vs2019/bitcoin_test/bitcoin_test.props
+++ b/build-aux/vs2019/bitcoin_test/bitcoin_test.props
@@ -7,11 +7,11 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SRC)univalue\include;$(SRC)leveldb\include;$(SRC)snark;$(SRC)snark\libsnark;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>BOOST_SPIRIT_THREADSAFE;__GMP_LIBGMP_DLL;ENABLE_WALLET;ENABLE_ZMQ;ZMQ_STATIC;BINARY_OUTPUT;MONTGOMERY_OUTPUT;CURVE_ALT_BN128;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>BOOST_SPIRIT_THREADSAFE;__GMP_LIBGMP_DLL;ENABLE_WALLET;BINARY_OUTPUT;MONTGOMERY_OUTPUT;CURVE_ALT_BN128;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>event${LIBDBGSFX}.lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;shlwapi.lib;ws2_32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;shlwapi.lib;ws2_32.lib;userenv.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <ResourceCompile>

--- a/build-aux/vs2019/pastel_gtest/pastel_gtest.props
+++ b/build-aux/vs2019/pastel_gtest/pastel_gtest.props
@@ -3,15 +3,16 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="../settings/googletest.props" />
     <Import Project="../settings/boost.props" />
+    <Import Project="../settings/libzmq.props" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SRC)gtest;$(SRC)univalue\include;$(SRC)leveldb\include;$(SRC)snark;$(SRC)snark\libsnark;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__GMP_LIBGMP_DLL;ENABLE_WALLET;ENABLE_ZMQ;ZMQ_STATIC;BINARY_OUTPUT;BOOST_SPIRIT_THREADSAFE;MONTGOMERY_OUTPUT;CURVE_ALT_BN128;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__GMP_LIBGMP_DLL;ENABLE_WALLET;BINARY_OUTPUT;BOOST_SPIRIT_THREADSAFE;MONTGOMERY_OUTPUT;CURVE_ALT_BN128;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libzmq-v142-mt-sgd-4_3_1.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>libcmt$(LIBDBGSFX).lib</IgnoreSpecificDefaultLibraries>
     </Link>

--- a/build-aux/vs2019/pasteld/pasteld.props
+++ b/build-aux/vs2019/pasteld/pasteld.props
@@ -4,15 +4,16 @@
     <Import Project="../settings/common.props" />
     <Import Project="../settings/boost.props" />
     <Import Project="../settings/pastel_common.props" />
+    <Import Project="../settings/libzmq.props" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(SRC)univalue\include;$(SRC)leveldb\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__GMP_LIBGMP_DLL;ENABLE_ZMQ;ZMQ_STATIC;BINARY_OUTPUT;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__GMP_LIBGMP_DLL;BINARY_OUTPUT;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libzmq-v142-mt-sgd-4_3_1.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb62$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>libcmt$(LIBDBGSFX).lib</IgnoreSpecificDefaultLibraries>
     </Link>

--- a/build-aux/vs2019/settings/common.props
+++ b/build-aux/vs2019/settings/common.props
@@ -10,6 +10,8 @@
     <DEPENDS>$(PSL_ROOT)depends\x86_64-pc-windows-msvc\</DEPENDS>
     <LIBDBGSFX Condition="'$(Configuration)'=='Debug'">d</LIBDBGSFX>
     <LIBDBGSFX Condition="'$(Configuration)'=='Release'"></LIBDBGSFX>
+    <LIBDBGSFX_GD Condition="'$(Configuration)'=='Debug'">gd</LIBDBGSFX_GD>
+    <LIBDBGSFX_GD Condition="'$(Configuration)'=='Release'"></LIBDBGSFX_GD>
   </PropertyGroup>
   <PropertyGroup>
     <OutDir>$(RELEASE_OUTDIR)\</OutDir>
@@ -73,6 +75,9 @@
     </BuildMacro>
     <BuildMacro Include="LIBDBGSFX">
       <Value>$(LIBDBGSFX)</Value>
+    </BuildMacro>
+    <BuildMacro Include="LIBDBGSFX_GD">
+      <Value>$(LIBDBGSFX_GD)</Value>
     </BuildMacro>
   </ItemGroup>
 </Project>

--- a/build-aux/vs2019/settings/libzmq.props
+++ b/build-aux/vs2019/settings/libzmq.props
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>ENABLE_ZMQ;ZMQ_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>libzmq-v142-mt-s$(LIBDBGSFX_GD)-4_3_4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -15,6 +15,7 @@ $(1)_objcxx=$($($(1)_type)_OBJCXX)
 $(1)_ar=$($($(1)_type)_AR)
 $(1)_ranlib=$($($(1)_type)_RANLIB)
 $(1)_libtool=$($($(1)_type)_LIBTOOL)
+$(1)_rc_compiler=$($($(1)_type)_RC_COMPILER)
 $(1)_nm=$($($(1)_type)_NM)
 $(1)_cflags=$($($(1)_type)_CFLAGS) $($($(1)_type)_$(release_type)_CFLAGS)
 $(1)_cxxflags=$($($(1)_type)_CXXFLAGS) $($($(1)_type)_$(release_type)_CXXFLAGS)
@@ -191,12 +192,20 @@ $(1)_cmake=env CC="$$($(1)_cc)" \
                CFLAGS="$$($(1)_cppflags) $$($(1)_cflags)" \
                CXX="$$($(1)_cxx)" \
                CXXFLAGS="$$($(1)_cppflags) $$($(1)_cxxflags)" \
-             cmake -DCMAKE_AR="$$($(1)_ar)" -DCMAKE_RANLIB="$$($(1)_ranlib)" -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" $$($(1)_cmake_opts)
+               cmake \
+		  -DCMAKE_AR="$$($(1)_ar)" \
+		  -DCMAKE_RANLIB="$$($(1)_ranlib)" \
+		  -DCMAKE_RC_COMPILER="$$($(1)_rc_compiler)" \
+		  -DCMAKE_INSTALL_PREFIX:PATH="$$($($(1)_type)_prefix)" \
+		  $$($(1)_cmake_opts)
 ifeq ($($(1)_type),build)
 $(1)_cmake += -DCMAKE_INSTALL_RPATH:PATH="$$($($(1)_type)_prefix)/lib"
 else
 ifneq ($(host),$(build))
 $(1)_cmake += -DCMAKE_SYSTEM_NAME=$($(host_os)_cmake_system)
+ifneq ($($(host_os)_cmake_system_version),)
+$(1)_cmake += -DCMAKE_SYSTEM_VERSION=$($(host_os)_cmake_system_version)
+endif
 $(1)_cmake += -DCMAKE_C_COMPILER_TARGET=$(host)
 $(1)_cmake += -DCMAKE_CXX_COMPILER_TARGET=$(host)
 ifneq ($($(host_os)_cmake_root_path),)
@@ -232,7 +241,7 @@ $($(1)_configured): | $($(1)_preprocessed)
 	$(AT)rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar --no-same-owner -xf $($(package)_cached); )
 	$(AT)mkdir -p $$(@D)
 	$(AT)$(info ----- PACKAGE [$(1)] ----- $(1)_type=$($(1)_type))
-	$(AT)$(foreach tool,cc cxx ar ranlib libtool nm cflags cxxflags ldflags cppflags, $(info $(1)_$(tool)=$($(1)_$(tool))))
+	$(AT)$(foreach tool,cc cxx ar ranlib rc_compiler libtool nm cflags cxxflags ldflags cppflags, $(info $(1)_$(tool)=$($(1)_$(tool))))
 	$(AT)+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
 	$(AT)touch $$@
 $($(1)_built): | $($(1)_configured)

--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -4,13 +4,14 @@ default_tool_CC=gcc
 default_tool_CXX=g++
 default_tool_AR=ar
 default_tool_RANLIB=ranlib
+default_tool_RC_COMPILER=
 default_tool_STRIP=strip
 default_tool_LIBTOOL=libtool
 default_tool_INSTALL_NAME_TOOL=install_name_tool
 default_tool_OTOOL=otool
 default_tool_NM=nm
 
-ALL_HOST_TOOLS=CC CXX AR RANLIB STRIP LIBTOOL INSTALL_NAME_TOOL OTOOL NM
+ALL_HOST_TOOLS=CC CXX AR RANLIB RC_COMPILER STRIP LIBTOOL INSTALL_NAME_TOOL OTOOL NM
 define add_default_host_tool_func
 default_host_$1=$(host_toolchain_path)$(if $($(host_os)_host_$1),$($(host_os)_host_$1),$(host_toolchain)$(default_tool_$1))
 endef

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -1,5 +1,6 @@
 mingw32_install_path=$(dir $(which $(host_toolchain)gcc))
 mingw32_toolchain_path=$(if $(mingw32_install_path), $(mingw32_install_path),/usr/bin/)
+mingw32_host_RC_COMPILER=$(host_toolchain)windres
 
 mingw32_CFLAGS=-pipe
 mingw32_CXXFLAGS=$(mingw32_CFLAGS)
@@ -14,4 +15,5 @@ mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
 
 mingw32_cmake_system=Windows
+mingw32_cmake_system_version=10.0
 

--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -6,9 +6,13 @@ $(package)_download_file=release-$($(package)_version).tar.gz
 $(package)_sha256_hash=b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
 
 define $(package)_set_vars
-$(package)_cxxflags+=-std=c++17
-$(package)_cxxflags_linux=-fPIC
-$(package)_cmake_opts_darwin=-DCMAKE_POLICY_DEFAULT_CMP0025=NEW
+$(package)_cxxflags+= -std=c++17
+$(package)_cxxflags_linux= -fPIC
+$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD=17
+$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD_REQUIRED=ON
+$(package)_cmake_opts+= -DCMAKE_CXX_EXTENSIONS=OFF
+$(package)_cmake_opts+= -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+$(package)_cmake_opts_darwin= -DCMAKE_POLICY_DEFAULT_CMP0025=NEW
 endef
 
 define $(package)_preprocess_cmds
@@ -17,12 +21,12 @@ endef
 
 define $(package)_config_cmds
   cd build && \
-  $($(package)_cmake) -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON ..
+  $($(package)_cmake) ..
 endef
 
 define $(package)_build_cmds
   cd build && \
-  $(MAKE) VERBOSE=1
+  $(MAKE) -j$(JOBCOUNT) VERBOSE=1
 endef
 
 define $(package)_stage_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -7,6 +7,7 @@ $(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336
 define $(package)_set_vars
 $(package)_cxxflags+=-std=c++17
 $(package)_cxxflags_linux=-fPIC
+$(package)_cmake_opts_mingw32= -D_WIN32_WINNT=0x0603
 $(package)_cmake_opts+= -DCMAKE_CXX_STANDARD=17
 $(package)_cmake_opts+= -DCMAKE_CXX_STANDARD_REQUIRED=ON
 $(package)_cmake_opts+= -DCMAKE_CXX_EXTENSIONS=OFF
@@ -14,6 +15,7 @@ $(package)_cmake_opts+= -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 $(package)_cmake_opts+= -DENABLE_CURVE=OFF
 $(package)_cmake_opts+= -DWITH_DOC=OFF
 $(package)_cmake_opts+= -DBUILD_SHARED=OFF
+$(package)_cmake_opts+= -DBUILD_TESTS=OFF
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,27 +1,39 @@
 package=zeromq
-$(package)_version=4.3.1
+$(package)_version=4.3.4
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
+$(package)_sha256_hash=c593001a89f5a85dd2ddf564805deb860e02471171b3f204944857336295c3e5
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-documentation --disable-shared --disable-curve
-  $(package)_config_opts_linux=--with-pic
-  $(package)_cxxflags+=-std=c++17
+$(package)_cxxflags+=-std=c++17
+$(package)_cxxflags_linux=-fPIC
+$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD=17
+$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD_REQUIRED=ON
+$(package)_cmake_opts+= -DCMAKE_CXX_EXTENSIONS=OFF
+$(package)_cmake_opts+= -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+$(package)_cmake_opts+= -DENABLE_CURVE=OFF
+$(package)_cmake_opts+= -DWITH_DOC=OFF
+$(package)_cmake_opts+= -DBUILD_SHARED=OFF
+endef
+
+define $(package)_preprocess_cmds
+  mkdir build
 endef
 
 define $(package)_config_cmds
-  $($(package)_autoconf)
+  cd build && \
+  $($(package)_cmake) ..
 endef
 
 define $(package)_build_cmds
-  $(MAKE) -j$(JOBCOUNT) src/libzmq.la
+  cd build && \
+  $(MAKE) -j$(JOBCOUNT) VERBOSE=1
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install-libLTLIBRARIES install-includeHEADERS install-pkgconfigDATA
+  mkdir -p $($(package)_staging_dir)$(host_prefix)/lib && \
+  $(MAKE) -C ./build/ VERBOSE=1 DESTDIR=$($(package)_staging_prefix_dir) install && \
+  install ./build/lib/libzmq.a $($(package)_staging_dir)$(host_prefix)/lib/libzmq.a && \
+  cp -a ./include $($(package)_staging_dir)$(host_prefix)/
 endef
 
-define $(package)_postprocess_cmds
-  rm -rf bin share
-endef

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2015 The Bitcoin Core developers
+// Copyright (c) 2021 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
@@ -9,11 +10,11 @@
 
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
-static const char *MSG_HASHBLOCK = "hashblock";
-static const char *MSG_HASHTX    = "hashtx";
-static const char *MSG_RAWBLOCK  = "rawblock";
-static const char *MSG_RAWTX     = "rawtx";
-static const char *MSG_CHECKEDBLOCK = "checkedblock";
+constexpr auto MSG_HASHBLOCK    = "hashblock";
+constexpr auto MSG_HASHTX       = "hashtx";
+constexpr auto MSG_RAWBLOCK     = "rawblock";
+constexpr auto MSG_RAWTX        = "rawtx";
+constexpr auto MSG_CHECKEDBLOCK = "checkedblock";
 
 // Internal function to send multipart message
 static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
@@ -98,13 +99,12 @@ void CZMQAbstractPublishNotifier::Shutdown()
 {
     assert(psocket);
 
-    int count = mapPublishNotifiers.count(address);
+    const size_t count = mapPublishNotifiers.count(address);
 
     // remove this notifier from the list of publishers using this address
-    typedef std::multimap<std::string, CZMQAbstractPublishNotifier*>::iterator iterator;
-    std::pair<iterator, iterator> iterpair = mapPublishNotifiers.equal_range(address);
+    auto iterpair = mapPublishNotifiers.equal_range(address);
 
-    for (iterator it = iterpair.first; it != iterpair.second; ++it)
+    for (auto it = iterpair.first; it != iterpair.second; ++it)
     {
         if (it->second==this)
         {

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -1,9 +1,8 @@
+#pragma once
 // Copyright (c) 2015 The Bitcoin Core developers
+// Copyright (c) 2021 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H
-#define BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H
 
 #include "zmqabstractnotifier.h"
 
@@ -57,5 +56,3 @@ class CZMQPublishCheckedBlockNotifier : public CZMQAbstractPublishNotifier
 public:
     bool NotifyBlock(const CBlock &block);
 };
-
-#endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
- updated libzmq library from v4.3.1 (01/12/2019) to v4.3.4 (01/17/2021)
- changed depends package zeromq.mk to support new version,
- converted ZeroMQ build from autotools to cmake
- fixed some warnings in src/zmq related to ZeroMQ usage
- Visual Studio 2019 build:
   - added new libzmq.props with ZeroMQ lib configuration
   - added libzmq.props to pasteld.props, pastel_gtest.props