### PR TITLE
[PSL-3] LegRoast pubkey should be stored in PastelID reg ticket

### DIFF
--- a/build-aux/vs2019/libbitcoin_server/libbitcoin_server.vcxproj
+++ b/build-aux/vs2019/libbitcoin_server/libbitcoin_server.vcxproj
@@ -122,6 +122,7 @@
     <ClCompile Include="..\..\..\src\mnode\mnode-sync.cpp" />
     <ClCompile Include="..\..\..\src\mnode\mnode-validation.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\mnode-rpc-utils.cpp" />
+    <ClCompile Include="..\..\..\src\mnode\rpc\pastelid-rpc.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-fake.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-list.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-register.cpp" />
@@ -184,6 +185,7 @@
     <ClInclude Include="..\..\..\src\miner.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\masternode.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\mnode-rpc-utils.h" />
+    <ClInclude Include="..\..\..\src\mnode\rpc\pastelid-rpc.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-fake.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-list.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-register.h" />

--- a/build-aux/vs2019/libbitcoin_server/libbitcoin_server.vcxproj.filters
+++ b/build-aux/vs2019/libbitcoin_server/libbitcoin_server.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-list.cpp">
       <Filter>Source Files\mnode\rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\mnode\rpc\pastelid-rpc.cpp">
+      <Filter>Source Files\mnode\rpc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\addrman.h">
@@ -466,6 +469,9 @@
       <Filter>Source Files\mnode\rpc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-list.h">
+      <Filter>Source Files\mnode\rpc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\mnode\rpc\pastelid-rpc.h">
       <Filter>Source Files\mnode\rpc</Filter>
     </ClInclude>
   </ItemGroup>

--- a/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj
+++ b/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj
@@ -123,6 +123,7 @@
     <ClInclude Include="..\..\..\src\rpc\client.h" />
     <ClInclude Include="..\..\..\src\rpc\protocol.h" />
     <ClInclude Include="..\..\..\src\rpc\register.h" />
+    <ClInclude Include="..\..\..\src\scope_guard.hpp" />
     <ClInclude Include="..\..\..\src\str_utils.h" />
     <ClInclude Include="..\..\..\src\support\allocators\secure.h" />
     <ClInclude Include="..\..\..\src\support\allocators\zeroafterfree.h" />

--- a/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj.filters
+++ b/build-aux/vs2019/libbitcoin_util/libbitcoin_util.vcxproj.filters
@@ -141,5 +141,8 @@
     <ClInclude Include="..\..\..\src\numeric_range.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\scope_guard.hpp">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/qa/rpc-tests/mn_expiration.py
+++ b/qa/rpc-tests/mn_expiration.py
@@ -310,23 +310,23 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.nodes[self.mining_node_num].generate(10)
 
         # generate pastelIDs & send coins
-        self.creator_pastelid1 = self.create_pastelid(self.non_mn3)
-        self.nonmn3_pastelid1 = self.create_pastelid(self.non_mn3)
+        self.creator_pastelid1 = self.create_pastelid(self.non_mn3)[0]
+        self.nonmn3_pastelid1 = self.create_pastelid(self.non_mn3)[0]
         self.nonmn3_address1 = self.nodes[self.non_mn3].getnewaddress()
         self.nodes[self.mining_node_num].sendtoaddress(self.nonmn3_address1, 1000, "", "", False)
 
-        self.nonmn4_pastelid1 = self.create_pastelid(self.non_mn4)
+        self.nonmn4_pastelid1 = self.create_pastelid(self.non_mn4)[0]
         self.nonmn4_address1 = self.nodes[self.non_mn4].getnewaddress()
         self.nodes[self.mining_node_num].sendtoaddress(self.nonmn4_address1, 100, "", "", False)
 
-        self.nonmn5_pastelid1 = self.create_pastelid(self.non_mn5)
+        self.nonmn5_pastelid1 = self.create_pastelid(self.non_mn5)[0]
         self.nonmn5_address1 = self.nodes[self.non_mn5].getnewaddress()
         self.nodes[self.mining_node_num].sendtoaddress(self.nonmn5_address1, 100, "", "", False)
 
         for n in range(0, 12):
             self.mn_addresses[n] = self.nodes[n].getnewaddress()
             self.nodes[self.mining_node_num].sendtoaddress(self.mn_addresses[n], 100, "", "", False)
-            self.mn_pastelids[n] = self.create_pastelid(n)
+            self.mn_pastelids[n] = self.create_pastelid(n)[0]
             self.mn_outpoints[self.nodes[n].masternode("status")["outpoint"]] = n
 
         self.__wait_for_sync_all()

--- a/qa/rpc-tests/mn_tickets_username_change.py
+++ b/qa/rpc-tests/mn_tickets_username_change.py
@@ -72,10 +72,10 @@ class UserNameChangeTest(PastelTestFramework):
     def run_test(self):
         print("---- UserName-Change Ticket tests STARTED ----")
         print(" - Creating Pastel IDs")
-        self.n1_pastelid1 = self.create_pastelid(1)
-        self.n1_pastelid2 = self.create_pastelid(1)
-        self.n2_pastelid = self.create_pastelid(2)
-        self.n3_pastelid = self.create_pastelid(3)
+        self.n1_pastelid1 = self.create_pastelid(1)[0]
+        self.n1_pastelid2 = self.create_pastelid(1)[0]
+        self.n2_pastelid = self.create_pastelid(2)[0]
+        self.n3_pastelid = self.create_pastelid(3)[0]
         print(
             f"node1: pastelid1={self.n1_pastelid1}\n"
             f"node1: pastelid2={self.n1_pastelid2}\n"

--- a/qa/rpc-tests/mn_tickets_validation.py
+++ b/qa/rpc-tests/mn_tickets_validation.py
@@ -126,8 +126,8 @@ class MasterNodeTicketsTest(MasterNodeCommon):
     def fake_pastelid_tnx_tests(self):
         print("== Pastelid ticket transaction validation test ==")
 
-        mn0_pastelid1 = self.create_pastelid(0)
-        nonmn3_pastelid1 = self.create_pastelid(self.non_mn3)
+        mn0_pastelid1 = self.create_pastelid(0)[0]
+        nonmn3_pastelid1 = self.create_pastelid(self.non_mn3)[0]
 
         # makefaketicket mnid pastelID passphrase ticketPrice bChangeSignature
         # makefaketicket id pastelID passphrase address ticketPrice bChangeSignature
@@ -169,12 +169,12 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.mn_ticket_signatures = {}
 
         # generate pastelIDs
-        self.nonmn1_pastelid1 = self.create_pastelid(self.non_mn1)
-        self.creator_pastelid1 = self.create_pastelid(self.non_mn3)
+        self.nonmn1_pastelid1 = self.create_pastelid(self.non_mn1)[0]
+        self.creator_pastelid1 = self.create_pastelid(self.non_mn3)[0]
         for n in range(0, 13):
             self.mn_addresses[n] = self.nodes[n].getnewaddress()
             self.nodes[self.mining_node_num].sendtoaddress(self.mn_addresses[n], 100, "", "", False)
-            self.mn_pastelids[n] = self.create_pastelid(n)
+            self.mn_pastelids[n] = self.create_pastelid(n)[0]
             self.mn_outpoints[self.nodes[n].masternode("status")["outpoint"]] = n
 
         self.sync_all(10,30)

--- a/qa/rpc-tests/pastel_test_framework.py
+++ b/qa/rpc-tests/pastel_test_framework.py
@@ -20,14 +20,11 @@ class PastelTestFramework (BitcoinTestFramework):
 
     # create new PastelID and associated LegRoast keys on node node_no
     # returns PastelID
-    def create_pastelid(self, node_no = 0, LegRoastKeyVar = None):
+    def create_pastelid(self, node_no = 0):
         keys = self.nodes[node_no].pastelid("newkey", self.passphrase)
-        NewPastelID = keys["pastelid"]
-        assert_true(NewPastelID, f"No PastelID was created on node #{node_no}")
-        if LegRoastKeyVar:
-            LegRoastKeyVar = keys["legroast"]
-            assert_true(LegRoastKeyVar, f"No LegRoast public key was generated on node #{node_no}")
-        return NewPastelID
+        assert_true(keys["pastelid"], f"No PastelID was created on node #{node_no}")
+        assert_true(keys["legRoastKey"], f"No LegRoast public key was generated on node #{node_no}")
+        return keys["pastelid"], keys["legRoastKey"]
 
     def get_rand_testdata(self, scope, length):
         return ''.join(random.choice(scope) for i in range(length))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -116,6 +116,7 @@ MNODE_CPP =\
   mnode/rpc/masternode.cpp\
   mnode/rpc/mnode-rpc-utils.cpp\
   mnode/rpc/mnode-rpc.cpp\
+  mnode/rpc/pastelid-rpc.cpp\
   mnode/rpc/tickets-fake.cpp\
   mnode/rpc/tickets-list.cpp\
   mnode/rpc/tickets-register.cpp\
@@ -143,6 +144,7 @@ MNODE_H = \
   mnode/rpc/mnode-rpc-utils.h\
   mnode/rpc/mnode-register.h\
   mnode/rpc/mnode-rpc.h\
+  mnode/rpc/pastelid-rpc.h\
   mnode/rpc/tickets-fake.h\
   mnode/rpc/tickets-list.h\
   mnode/rpc/tickets-register.h\

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -1,4 +1,4 @@
-    #pragma once
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -577,13 +577,14 @@ bool CCoinsViewCache::HaveShieldedRequirements(const CTransaction& tx) const
 
 bool CCoinsViewCache::HaveInputs(const CTransaction& tx) const
 {
-    if (!tx.IsCoinBase()) {
-        for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            const COutPoint &prevout = tx.vin[i].prevout;
+    if (!tx.IsCoinBase())
+    {
+        for (const auto &txIn : tx.vin)
+        {
+            const COutPoint& prevout = txIn.prevout;
             const CCoins* coins = AccessCoins(prevout.hash);
-            if (!coins || !coins->IsAvailable(prevout.n)) {
+            if (!coins || !coins->IsAvailable(prevout.n))
                 return false;
-            }
         }
     }
     return true;

--- a/src/gtest/test_mnode/test_pastelid.cpp
+++ b/src/gtest/test_mnode/test_pastelid.cpp
@@ -1,4 +1,10 @@
 #include "pastelid/pastel_key.h"
+#include "fs.h"
+#include "util.h"
+#include "scope_guard.hpp"
+#include "chainparams.h"
+#include "test_utils.h"
+
 #include "gtest/gtest.h"
 #include <tuple>
 #include <string>
@@ -16,10 +22,62 @@ TEST_P(PTest_PastelID_Alg, GetAlgorithmByName)
     EXPECT_EQ(alg, get<1>(Param));
 }
 
-INSTANTIATE_TEST_SUITE_P(PastelID_Alg, PTest_PastelID_Alg,
+INSTANTIATE_TEST_SUITE_P(PastelID, PTest_PastelID_Alg,
     Values(
         make_tuple("", CPastelID::SIGN_ALGORITHM::ed448),
         make_tuple(SIGN_ALG_ED448, CPastelID::SIGN_ALGORITHM::ed448),
         make_tuple(SIGN_ALG_LEGROAST, CPastelID::SIGN_ALGORITHM::legroast),
         make_tuple("myalg", CPastelID::SIGN_ALGORITHM::not_defined)
     ));
+
+TEST(PastelID, GetStoredPastelIDs)
+{
+    SelectParams(CBaseChainParams::Network::REGTEST);
+    auto sTempPath = generateTempFileName(nullptr);
+    auto tempPath = fs::path(sTempPath);
+    if (!fs::exists(tempPath))
+        fs::create_directories(tempPath);
+    auto guard = sg::make_scope_guard([&]() noexcept 
+    {
+        fs::remove_all(tempPath);
+    });
+    mapArgs["-datadir"] = sTempPath;
+    auto mapIDs = CPastelID::GetStoredPastelIDs(true);
+    EXPECT_TRUE(mapIDs.empty());
+
+    const auto PASS1 = "passphrase1";
+    const auto PASS2 = "passphrase2";
+    const auto mapIDs_1 = CPastelID::CreateNewPastelKeys(PASS1);
+    EXPECT_TRUE(!mapIDs_1.empty());
+    const auto it = mapIDs_1.cbegin();
+    EXPECT_NE(it, mapIDs_1.cend());
+
+    if (it != mapIDs_1.cend())
+    {
+        mapIDs = CPastelID::GetStoredPastelIDs(false);
+        const auto it1 = mapIDs.find(it->first);
+        EXPECT_NE(it1, mapIDs.cend());
+        EXPECT_EQ(it1->second, it->second);
+    }
+    const auto mapIDs_2 = CPastelID::CreateNewPastelKeys(PASS2);
+    EXPECT_TRUE(!mapIDs_2.empty());
+    const auto it2 = mapIDs_2.cbegin();
+    EXPECT_NE(it2, mapIDs_2.cend());
+    if (it2 != mapIDs_2.cend())
+    {
+        string sPastelID = it2->first;
+        // get full list of pastelids - should be 2
+        mapIDs = CPastelID::GetStoredPastelIDs(false);
+        EXPECT_EQ(mapIDs.size(), 2u);
+
+        // get filtered pastelid
+        mapIDs = CPastelID::GetStoredPastelIDs(false, &sPastelID);
+        EXPECT_EQ(mapIDs.size(), 1u);
+        const auto it3 = mapIDs.find(sPastelID);
+        EXPECT_NE(it3, mapIDs.cend());
+
+        // legroast pubkeys match
+        if (it3 != mapIDs.cend())
+            EXPECT_EQ(it3->second, it2->second);
+    }
+}

--- a/src/mnode/rpc/pastelid-rpc.cpp
+++ b/src/mnode/rpc/pastelid-rpc.cpp
@@ -1,0 +1,246 @@
+// Copyright (c) 2018-2021 The Pastel Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "pastelid/pastel_key.h"
+#include "rpc/rpc_parser.h"
+#include "rpc/rpc_consts.h"
+#include "mnode/rpc/pastelid-rpc.h"
+
+using namespace std;
+
+UniValue pastelid_newkey(const UniValue& params)
+{
+    if (params.size() != 2)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(pastelid newkey "passphrase"
+Generate new PastelID, associated keys (EdDSA448) and LegRoast signing keys.
+Return PastelID base58-encoded.)");
+
+    SecureString strKeyPass(params[1].get_str());
+    if (strKeyPass.empty())
+        throw runtime_error(
+R"(pastelid newkey "passphrase"
+passphrase for new key cannot be empty!)");
+
+    UniValue resultObj(UniValue::VOBJ);
+    auto keyMap = CPastelID::CreateNewPastelKeys(move(strKeyPass));
+    if (keyMap.empty())
+        throw runtime_error("Failed to generate new PastelID and associated keys");
+    resultObj.pushKV(RPC_KEY_PASTELID, keyMap.begin()->first);
+    resultObj.pushKV(RPC_KEY_LEGROAST, move(keyMap.begin()->second));
+    return resultObj;
+}
+
+UniValue pastelid_importkey(const UniValue& params)
+{
+    if (params.size() < 2 || params.size() > 3)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(pastelid importkey "key" <"passphrase">
+Import PKCS8 encrypted private key (EdDSA448) in PEM format. Return PastelID base58-encoded if "passphrase" provided.)");
+
+    throw runtime_error("\"pastelid importkey\" NOT IMPLEMENTED!!!");
+
+    //import
+    //...
+
+    //validate and generate pastelid
+    if (params.size() == 3) //-V779 not implemented, but should keep here for future implementation's reference
+    {
+        SecureString strKeyPass(params[2].get_str());
+        if (strKeyPass.empty())
+            throw runtime_error(
+R"(pastelid importkey <"passphrase">
+passphrase for imported key cannot be empty!)");
+    }
+    return NullUniValue;
+}
+
+UniValue pastelid_list(const UniValue& params)
+{
+    UniValue resultArray(UniValue::VARR);
+
+    auto mapIDs = CPastelID::GetStoredPastelIDs(false);
+    for (auto& [sPastelID, sLegRoastPubKey] : mapIDs)
+    {
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("PastelID", sPastelID);
+        obj.pushKV(RPC_KEY_LEGROAST, move(sLegRoastPubKey));
+        resultArray.push_back(move(obj));
+    }
+
+    return resultArray;
+}
+
+UniValue pastelid_sign(const UniValue& params)
+{
+    if (params.size() < 4)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(pastelid sign "text" "PastelID" "passphrase" ("algorithm")
+Sign "text" with the internally stored private key associated with the PastelID (algorithm: ed448 [default] or legroast).)");
+
+    SecureString strKeyPass(params[3].get_str());
+    if (strKeyPass.empty())
+        throw runtime_error(
+R"(pastelid sign "text" "PastelID" <"passphrase"> ("algorithm")
+passphrase for the private key cannot be empty!)");
+
+    string sAlgorithm;
+    if (params.size() >= 5)
+        sAlgorithm = params[4].get_str();
+    const CPastelID::SIGN_ALGORITHM alg = CPastelID::GetAlgorithmByName(sAlgorithm);
+    if (alg == CPastelID::SIGN_ALGORITHM::not_defined)
+        throw runtime_error(strprintf("Signing algorithm '%s' is not supported", sAlgorithm));
+
+    UniValue resultObj(UniValue::VOBJ);
+
+    string sSignature = CPastelID::Sign(params[1].get_str(), params[2].get_str(), move(strKeyPass), alg, true);
+    resultObj.pushKV("signature", move(sSignature));
+
+    return resultObj;
+}
+
+UniValue pastelid_verify(const UniValue& params)
+{
+    if (params.size() < 4)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(pastelid verify "text" "signature" "PastelID" ("algorithm")
+Verify "text"'s "signature" with with the private key associated with the PastelID (algorithm: ed448 or legroast).)");
+
+    string sAlgorithm;
+    if (params.size() >= 5)
+        sAlgorithm = params[4].get_str();
+    const CPastelID::SIGN_ALGORITHM alg = CPastelID::GetAlgorithmByName(sAlgorithm);
+    if (alg == CPastelID::SIGN_ALGORITHM::not_defined)
+        throw runtime_error(strprintf("Signing algorithm '%s' is not supported", sAlgorithm));
+
+    UniValue resultObj(UniValue::VOBJ);
+
+    const bool bRes = CPastelID::Verify(params[1].get_str(), params[2].get_str(), params[3].get_str(), alg, true);
+    resultObj.pushKV("verification", bRes ? "OK" : "Failed");
+
+    return resultObj;
+}
+
+UniValue pastelid_signbykey(const UniValue& params)
+{
+    if (params.size() != 4)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(pastelid sign-by-key "text" "key" "passphrase"
+Sign "text" with the private "key" (EdDSA448) as PKCS8 encrypted string in PEM format.)");
+
+    SecureString strKeyPass(params[3].get_str());
+    if (strKeyPass.empty())
+        throw runtime_error(
+R"(pastelid sign-by-key "text" "key" <"passphrase">
+passphrase for the private key cannot be empty!)");
+
+    UniValue resultObj(UniValue::VOBJ);
+    return resultObj;
+}
+
+UniValue pastelid_passwd(const UniValue& params)
+{
+    if (params.size() < 4)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(pastelid passwd "PastelID" "old_passphrase" "new_passphrase"
+Change passphrase used to encrypt the secure container associated with the PastelID.)");
+
+    string sPastelID(params[1].get_str());
+    SecureString strOldPass(params[2].get_str());
+    SecureString strNewPass(params[3].get_str());
+
+    const char* szEmptyParam = nullptr;
+    if (sPastelID.empty())
+        szEmptyParam = "PastelID";
+    else if (strOldPass.empty())
+        szEmptyParam = "old_passphrase";
+    else if (strNewPass.empty())
+        szEmptyParam = "new_passphrase";
+    if (szEmptyParam)
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+strprintf(R"(pastelid passwd "PastelID" "old_passphrase" "new_passphrase"
+'%s' parameter cannot be empty!)",
+                                     szEmptyParam));
+    string error;
+    if (!CPastelID::ChangePassphrase(error, sPastelID, move(strOldPass), move(strNewPass)))
+        throw runtime_error(error);
+    UniValue resultObj(UniValue::VOBJ);
+    resultObj.pushKV(RPC_KEY_RESULT, RPC_RESULT_SUCCESS);
+    return resultObj;
+}
+
+/**
+ * pastelid RPC command.
+ * 
+ * \param params - RPC command parameters
+ * \param fHelp - true to show pastelid usage
+ * \return univalue result object
+ */
+UniValue pastelid(const UniValue& params, bool fHelp)
+{
+    RPC_CMD_PARSER(PASTELID, params, newkey, importkey, list, sign, sign__by__key, verify, passwd);
+
+    if (fHelp || !PASTELID.IsCmdSupported())
+        throw runtime_error(
+R"(pastelid "command"...
+Set of commands to deal with PastelID and related actions
+PastelID is the base58-encoded public key of the EdDSA448 key pair. EdDSA448 public key is 57 bytes
+
+Arguments:
+1. "command"        (string or set of strings, required) The command to execute
+
+Available commands:
+  newkey "passphrase"                                 - Generate new PastelID, associated keys (EdDSA448) and LegRoast signing keys.
+                                                        Return PastelID and LegRoast signing public key base58-encoded.
+                                                        "passphrase" will be used to encrypt the key file.
+  importkey "key" <"passphrase">                      - Import private "key" (EdDSA448) as PKCS8 encrypted string in PEM format. Return PastelID base58-encoded
+                                                        "passphrase" (optional) to decrypt the key for the purpose of validating and returning PastelID.
+                                                        NOTE: without "passphrase" key cannot be validated and if key is bad (not EdDSA448) call to "sign" will fail
+  list                                                - List all internally stored PastelIDs and associated keys. 
+  sign "text" "PastelID" "passphrase" ("algorithm")   - Sign "text" with the internally stored private key associated with the PastelID (algorithm: ed448 or legroast).
+  sign-by-key "text" "key" "passphrase"               - Sign "text" with the private "key" (EdDSA448) as PKCS8 encrypted string in PEM format.
+  verify "text" "signature" "PastelID" ("algorithm")  - Verify "text"'s "signature" with the private key associated with the PastelID (algorithm: ed448 or legroast).
+  passwd "PastelID" "old_passphrase" "new_passphrase" - Change passphrase used to encrypt the secure container associated with the PastelID.
+)");
+
+    UniValue result(UniValue::VOBJ);
+
+    switch (PASTELID.cmd()) {
+    case RPC_CMD_PASTELID::newkey:
+        result = pastelid_newkey(params);
+        break;
+
+    case RPC_CMD_PASTELID::importkey:
+        result = pastelid_importkey(params);
+        break;
+
+    // list all locally stored PastelIDs and associated public keys
+    case RPC_CMD_PASTELID::list:
+        result = pastelid_list(params);
+        break;
+
+    // sign text with the internally stored private key associated with the PastelID (ed448 or legroast).
+    case RPC_CMD_PASTELID::sign:
+        result = pastelid_sign(params);
+        break;
+
+    case RPC_CMD_PASTELID::sign__by__key: // sign-by-key
+        result = pastelid_signbykey(params);
+        break;
+
+    // verify "text"'s "signature" with the public key associated with the PastelID (algorithm: ed448 or legroast)
+    case RPC_CMD_PASTELID::verify:
+        result = pastelid_verify(params);
+        break;
+
+    case RPC_CMD_PASTELID::passwd:
+        result = pastelid_passwd(params);
+        break;
+
+    default:
+        break;
+    } // switch PASTELID.cmd()
+
+    return result;
+}

--- a/src/mnode/rpc/pastelid-rpc.h
+++ b/src/mnode/rpc/pastelid-rpc.h
@@ -1,0 +1,8 @@
+#pragma once
+// Copyright (c) 2018-2021 The Pastel Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <univalue.h>
+
+UniValue pastelid(const UniValue& params, bool fHelp);

--- a/src/mnode/ticket.h
+++ b/src/mnode/ticket.h
@@ -31,6 +31,7 @@ public:
     short GetStoredVersion() const noexcept { return m_nVersion; }
     const std::string GetTxId() const noexcept { return m_txid; }
     unsigned int GetBlock() const noexcept { return m_nBlock; }
+    std::int64_t GetTimestamp() const noexcept { return m_nTimestamp; }
     bool IsBlock(const unsigned int nBlock) const noexcept { return m_nBlock == nBlock; }
     auto GetTicketName() const noexcept
     {

--- a/src/pastelid/pastel_key.h
+++ b/src/pastelid/pastel_key.h
@@ -43,8 +43,7 @@ public:
     // Verify signature with the public key associated with PastelID.
     static bool Verify(const std::string& sText, const std::string& sSignature, const std::string& sPastelID, 
         const SIGN_ALGORITHM alg = SIGN_ALGORITHM::ed448, const bool fBase64 = false);
-    // Get PastelIDs stored locally in pastelkeys (pastelkeysdir option).
-    static pastelid_store_t GetStoredPastelIDs(const bool bPastelIdOnly = true);
+    static pastelid_store_t GetStoredPastelIDs(const bool bPastelIdOnly = true, std::string *psPastelID = nullptr);
     // Validate passphrase via secure container or pkcs8 format
     static bool isValidPassphrase(const std::string& sPastelId, const SecureString& strKeyPass) noexcept;
     // Change passphrase used to encrypt the secure container

--- a/src/rpc/rpc_consts.h
+++ b/src/rpc/rpc_consts.h
@@ -9,6 +9,7 @@ constexpr auto RPC_KEY_ERROR_MESSAGE			= "errorMessage";
 constexpr auto RPC_KEY_STATUS					= "status";
 constexpr auto RPC_KEY_ALIAS					= "alias";
 constexpr auto RPC_KEY_TXID					    = "txid";
+constexpr auto RPC_KEY_PASTELID					= "pastelid";
 constexpr auto RPC_KEY_LEGROAST					= "legRoastKey";
 
 // rpc response object key values

--- a/src/scope_guard.hpp
+++ b/src/scope_guard.hpp
@@ -1,0 +1,171 @@
+#pragma once
+/*
+ *  Created on: 13/02/2018
+ *      Author: ricab
+ *
+ * See README.md for documentation of this header's public interface.
+ */
+
+#include <type_traits>
+#include <utility>
+
+namespace sg
+{
+  namespace detail
+  {
+    /* --- Some custom type traits --- */
+
+    // Type trait determining whether a type is callable with no arguments
+    template<typename T, typename = void>
+    struct is_noarg_callable_t
+      : public std::false_type
+    {}; // in general, false
+
+    template<typename T>
+    struct is_noarg_callable_t<T, decltype(std::declval<T&&>()())>
+      : public std::true_type
+    {}; // only true when call expression valid
+
+    // Type trait determining whether a no-argument callable returns void
+    template<typename T>
+    struct returns_void_t
+      : public std::is_same<void, decltype(std::declval<T&&>()())>
+    {};
+
+    /* Type trait determining whether a no-arg callable is nothrow invocable if required. */
+    template<typename T>
+    struct is_nothrow_invocable_if_required_t
+      : public
+          std::is_nothrow_invocable<T> /* Note: _r variants not enough to
+                                          confirm void return: any return can be
+                                          discarded so all returns are
+                                          compatible with void */
+    {};
+
+    // logic AND of two or more type traits
+    template<typename A, typename B, typename... C>
+    struct and_t : public and_t<A, and_t<B, C...>>
+    {}; // for more than two arguments
+
+    template<typename A, typename B>
+    struct and_t<A, B> : public std::conditional<A::value, B, A>::type
+    {}; // for two arguments
+
+    // Type trait determining whether a type is a proper scope_guard callback.
+    template<typename T>
+    struct is_proper_sg_callback_t
+      : public and_t<is_noarg_callable_t<T>,
+                     returns_void_t<T>,
+                     is_nothrow_invocable_if_required_t<T>,
+                     std::is_nothrow_destructible<T>>
+    {};
+
+
+    /* --- The actual scope_guard template --- */
+
+    template<typename Callback,
+             typename = typename std::enable_if<
+               is_proper_sg_callback_t<Callback>::value>::type>
+    class scope_guard;
+
+
+    /* --- Now the friend maker --- */
+
+    template<typename Callback>
+    detail::scope_guard<Callback> make_scope_guard(Callback&& callback)
+    noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value); /*
+    we need this in the inner namespace due to MSVC bugs preventing
+    sg::detail::scope_guard from befriending a sg::make_scope_guard
+    template instance in the parent namespace (see https://is.gd/xFfFhE). */
+
+
+    /* --- The template specialization that actually defines the class --- */
+
+    template<typename Callback>
+    class scope_guard<Callback> final
+    {
+    public:
+      typedef Callback callback_type;
+
+      scope_guard(scope_guard&& other)
+      noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value);
+
+      ~scope_guard() noexcept; // highlight noexcept dtor
+
+      void dismiss() noexcept;
+
+    public:
+      scope_guard() = delete;
+      scope_guard(const scope_guard&) = delete;
+      scope_guard& operator=(const scope_guard&) = delete;
+      scope_guard& operator=(scope_guard&&) = delete;
+
+    private:
+      explicit scope_guard(Callback&& callback)
+      noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value); /*
+                                                      meant for friends only */
+
+      friend scope_guard<Callback> make_scope_guard<Callback>(Callback&&)
+      noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value); /*
+      only make_scope_guard can create scope_guards from scratch (i.e. non-move)
+      */
+
+    private:
+      Callback m_callback;
+      bool m_active;
+
+    };
+
+  } // namespace detail
+
+
+  /* --- Now the single public maker function --- */
+
+  using detail::make_scope_guard; // see comment on declaration above
+
+} // namespace sg
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard(Callback&& callback)
+noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
+  : m_callback(std::forward<Callback>(callback)) /* use () instead of {} because
+    of DR 1467 (https://is.gd/WHmWuo), which still impacts older compilers
+    (e.g. GCC 4.x and clang <=3.6, see https://godbolt.org/g/TE9tPJ and
+    https://is.gd/Tsmh8G) */
+  , m_active{true}
+{}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::~scope_guard<Callback>() noexcept
+{
+  if(m_active)
+    m_callback();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard(scope_guard&& other)
+noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
+  : m_callback(std::forward<Callback>(other.m_callback)) // idem
+  , m_active{std::move(other.m_active)}
+{
+  other.m_active = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+inline void sg::detail::scope_guard<Callback>::dismiss() noexcept
+{
+  m_active = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+inline auto sg::detail::make_scope_guard(Callback&& callback)
+noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
+-> detail::scope_guard<Callback>
+{
+  return detail::scope_guard<Callback>{std::forward<Callback>(callback)};
+}


### PR DESCRIPTION
"pastelid newkey" API generates:
  - Ed448 private/public key pair, encoded public key becomes PastelID
  - LegRoast private/public key pair
All keys are stored locally in the secure container, private keys are encrypted and stored as secure items,
LegRoast public key - not encrypted and stored as a public item.
PastelID can be registered in the blockchain using:
  1) tickets register id - to register personal PastelID
  2) tickets register mnid - to register MN PastelID
LegRoast public key is now stored in a pq_key fields of the Pastel ID registration ticket.
- added pq_key to the list of fields used to generate signature for Pastel IDreg ticket.
- removed duplicate code for IDReg ticket fields serialization (used for creating signature, verification)
- moved pastelid RPC API to the separate file mnode/rpc/pastelid-rcp.cpp
- changed CPastelID::GetStoredPastelIDs to accept optional PastelID parameter to return map of keys related to that ID only
- added google tests for CPastelID::CreateNewPastelKeys/CPastelID::GetStoredPastelIDs
- mn_tickets python tests: added tests for pq_key generation/storing in blockchain/verification (tickets find id)