### PR TITLE
[PSL-8] `pastelid verify` API for legroast

### DIFF
--- a/qa/rpc-tests/mn_tickets.py
+++ b/qa/rpc-tests/mn_tickets.py
@@ -41,9 +41,6 @@ private_keys_list = ["91sY9h4AQ62bAhNk1aJ7uJeSnQzSFtz7QmW5imrKmiACm7QJLXe",  # 0
                      ]
 
 
-# error strings
-ERR_READ_PASTELID_FILE = "Failed to read Pastel secure container file"
-
 class MasterNodeTicketsTest(MasterNodeCommon):
     number_of_master_nodes = len(private_keys_list)
     number_of_simple_nodes = 8
@@ -292,13 +289,13 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             self.nodes[self.non_active_mn].tickets, "register", "mnid", self.non_active_mn_pastelid1, self.passphrase)
 
         #       a.a.3 fail if active MN, but wrong PastelID
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE,
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE,
             self.nodes[0].tickets, "register", "mnid", self.nonmn1_pastelid2, self.passphrase)
 
         # TODO: provide better error for unknown PastelID
 
         #       a.a.4 fail if active MN, but wrong passphrase
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE,
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE,
             self.nodes[0].tickets, "register", "mnid", self.mn0_pastelid1, "wrong")
         # TODO: provide better error for wrong passphrase
 
@@ -377,12 +374,12 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
         #   b.a register personal PastelID
         #       b.a.1 fail if wrong PastelID
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE,
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE,
             self.nodes[self.non_mn3].tickets, "register", "id", self.nonmn1_pastelid2, self.passphrase, self.nonmn3_address1)
         # TODO Pastel: provide better error for unknown PastelID
 
         #       b.a.2 fail if wrong passphrase
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE,
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE,
             self.nodes[self.non_mn3].tickets, "register", "id", self.nonmn3_pastelid1, "wrong", self.nonmn3_address1)
         # TODO Pastel: provide better error for wrong passphrase
 
@@ -784,14 +781,14 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         assert_equal("This is not an active masternode" in self.errorString, True)
 
         #       c.a.3 fail if active MN, but wrong PastelID
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE,
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE,
             self.nodes[self.top_mns_index0].tickets, "register", "nft",
             self.ticket, json.dumps(self.signatures_dict), self.nonmn1_pastelid2, self.passphrase,
             key1, key2, str(self.storage_fee))
         # TODO: provide better error for unknown PastelID
 
         #       c.a.4 fail if active MN, but wrong passphrase
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE,
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE,
             self.nodes[self.top_mns_index0].tickets, "register", "nft",
                 self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, "wrong",
                 key1, key2, str(self.storage_fee))
@@ -1107,7 +1104,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         except JSONRPCException as e:
             self.errorString = e.error['message']
             print(self.errorString)
-        assert_equal(ERR_READ_PASTELID_FILE in self.errorString, True)
+        assert_equal(self.ERR_READ_PASTELID_FILE in self.errorString, True)
 
         # fail if wrong passphrase
         try:
@@ -1116,7 +1113,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         except JSONRPCException as e:
             self.errorString = e.error['message']
             print(self.errorString)
-        assert_equal(ERR_READ_PASTELID_FILE in self.errorString, True)
+        assert_equal(self.ERR_READ_PASTELID_FILE in self.errorString, True)
 
         # fail if there is not NFTTicket with this txid
         try:
@@ -1265,7 +1262,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         except JSONRPCException as e:
             self.errorString = e.error['message']
             print(self.errorString)
-        assert_equal(ERR_READ_PASTELID_FILE in self.errorString, True)
+        assert_equal(self.ERR_READ_PASTELID_FILE in self.errorString, True)
         # TODO Pastel: provide better error for unknown PastelID
 
         #       d.a.2 fail if wrong passphrase
@@ -1276,7 +1273,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         except JSONRPCException as e:
             self.errorString = e.error['message']
             print(self.errorString)
-        assert_equal(ERR_READ_PASTELID_FILE in self.errorString, True)
+        assert_equal(self.ERR_READ_PASTELID_FILE in self.errorString, True)
         # TODO Pastel: provide better error for wrong passphrase
 
         #       d.a.7 fail if not enough coins to pay 90% of registration price (from NFTReg ticket) (90) + tnx fee (act ticket price)

--- a/qa/rpc-tests/mn_tickets_username_change.py
+++ b/qa/rpc-tests/mn_tickets_username_change.py
@@ -15,9 +15,6 @@ import test_framework.rpc_consts as rpc
 from decimal import Decimal, getcontext
 getcontext().prec = 16
 
-# error strings
-ERR_READ_PASTELID_FILE = "Failed to read Pastel secure container file"
-
 class UserNameChangeTest(PastelTestFramework):
     """
     Test Pastel change-username tickets
@@ -160,10 +157,10 @@ class UserNameChangeTest(PastelTestFramework):
         assert_raises_rpc(rpc.RPC_MISC_ERROR, "is already registered in blockchain", 
             self.nodes[1].tickets, "register", "username", username1, self.n1_pastelid2, self.passphrase)
         # using invalid pastelid - node2 using n1_pastelid
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE, 
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE, 
             self.nodes[2].tickets, "register", "username", username2, self.n1_pastelid1, self.passphrase)
         # using invalid passphrase 
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, ERR_READ_PASTELID_FILE, 
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE, 
             self.nodes[1].tickets, "register", "username", username2, self.n1_pastelid1, self.new_passphrase)
 
         # second username change too early - less than 10 blocks for regtest

--- a/qa/rpc-tests/pastel_test_framework.py
+++ b/qa/rpc-tests/pastel_test_framework.py
@@ -18,6 +18,9 @@ class PastelTestFramework (BitcoinTestFramework):
     passphrase = "passphrase"
     new_passphrase = "new passphrase"
 
+    # error strings
+    ERR_READ_PASTELID_FILE = "Failed to read Pastel secure container file"
+
     # create new PastelID and associated LegRoast keys on node node_no
     # returns PastelID
     def create_pastelid(self, node_no = 0):

--- a/qa/rpc-tests/secure_container.py
+++ b/qa/rpc-tests/secure_container.py
@@ -12,7 +12,8 @@ from test_framework.util import (
     assert_raises, 
     assert_raises_message,
     assert_shows_help, 
-    start_nodes
+    start_nodes,
+    connect_nodes_bi
 )
 from pastel_test_framework import PastelTestFramework
 from test_framework.authproxy import JSONRPCException
@@ -25,25 +26,35 @@ class SecureContainerTest(PastelTestFramework):
     pastelid1 = None
     id1_lrkey = None
     pastelid2 = None
+    pastelid3 = None
+    id3_lrkey = None
 
     def __init__(self):
         super().__init__()
-        self.num_nodes = 1
+        self.num_nodes = 2
 
     def setup_network(self):
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[[ '-debug' ]])
+                                 extra_args=[[ '-debug' ]] * self.num_nodes)
         self.is_network_split = False
+        connect_nodes_bi(self.nodes,0,1)
 
     def run_test(self):
         print("---- Pastel ID tests STARTED ----")
         print(" -pastelid help")
         assert_shows_help(self.nodes[0].pastelid)
 
+        coinbase_addr1 = self.nodes[1].getnewaddress()
+        taddr1 = self.nodes[1].getnewaddress()
+
         print(" -pastelid newkey")
         assert_shows_help(self.nodes[0].pastelid, "newkey")
         self.pastelid1, self.id1_lrkey = self.create_pastelid(0)
         self.pastelid2 = self.create_pastelid()[0]
+        self.pastelid3, self.id3_lrkey = self.create_pastelid(1)
+        print(f"pastelid1: {self.pastelid1}")
+        print(f"pastelid2: {self.pastelid2}")
+        print(f"pastelid3: {self.pastelid3}")
 
         # fail if empty passphrase
         assert_raises_rpc(rpc.RPC_MISC_ERROR, "passphrase for new key cannot be empty", 
@@ -51,11 +62,17 @@ class SecureContainerTest(PastelTestFramework):
 
         # List all internally stored PastelID and keys
         print(" -pastelid list")
-        id_list = self.nodes[0].pastelid("list")
-        id_list = dict((key+str(i), val) for i, k in enumerate(id_list) for key, val in k.items())
-        assert_true(self.pastelid1 in id_list.values(), f"PastelID {self.pastelid1} not in the list")
-        assert_true(self.pastelid2 in id_list.values(), f"PastelID {self.pastelid2} not in the list")
+        # check Pastel IDs on node0
+        id_list0 = self.nodes[0].pastelid("list")
+        id_list0 = dict((key+str(i), val) for i, k in enumerate(id_list0) for key, val in k.items())
+        assert_true(self.pastelid1 in id_list0.values(), f"PastelID {self.pastelid1} not in the list")
+        assert_true(self.pastelid2 in id_list0.values(), f"PastelID {self.pastelid2} not in the list")
+        # check Pastel IDs on node1
+        id_list1 = self.nodes[1].pastelid("list")
+        id_list1 = dict((key+str(i), val) for i, k in enumerate(id_list1) for key, val in k.items())
+        assert_true(self.pastelid3 in id_list1.values(), f"PastelID {self.pastelid3} not in the list")
 
+        print(" -pastelid sign & verify ed448")
         text_to_sign = "my text to sign"
         # Sign "text" with the internally stored private key associated with the PastelID
         # check that signing with existing passphrase works, default algorithm - EdDSA448
@@ -65,8 +82,18 @@ class SecureContainerTest(PastelTestFramework):
         # Verify text"'s "signature" (EdDSA448) with the PastelID
         result = self.nodes[0].pastelid("verify", text_to_sign, signature, self.pastelid1)["verification"]
         assert_equal(result, "OK")
+        # Fail to verify EdDSA448 signature with the different key (PastelID2)
+        result = self.nodes[0].pastelid("verify", text_to_sign, signature, self.pastelid2)["verification"]
+        assert_equal(result, "Failed")
+        # Fail to verify modified text (ed448 signature)
+        text_to_sign_modified = 'X' + text_to_sign[1:]
+        result = self.nodes[0].pastelid("verify", text_to_sign_modified, signature, self.pastelid1)["verification"]
+        assert_equal(result, "Failed")
+        # try to sign using PastelID with invalid passphrase
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, self.ERR_READ_PASTELID_FILE,
+            self.nodes[1].pastelid, "sign", text_to_sign, self.pastelid1, self.new_passphrase)
 
-        print(" -pastelid sign & verify")
+        print(" -pastelid sign & verify legroast")
         # Sign with no errors using encoded LegRoast public key
         # returns base64 encoded signature
         lr_signature = self.nodes[0].pastelid("sign", text_to_sign, self.pastelid1, self.passphrase, "legroast")["signature"]
@@ -75,22 +102,41 @@ class SecureContainerTest(PastelTestFramework):
         # Verify text"'s "signature" (LegRoast) with the PastelID
         result = self.nodes[0].pastelid("verify", text_to_sign, lr_signature, self.pastelid1, "legroast")["verification"]
         assert_equal(result, "OK")
-
-        # Fail to verify EdDSA448 signature with the different key (PastelID2)
-        result = self.nodes[0].pastelid("verify", text_to_sign, signature, self.pastelid2)["verification"]
-        assert_equal(result, "Failed")
         # Fail to verify LegRoast signature with the different key (PastelID2)
         result = self.nodes[0].pastelid("verify", text_to_sign, lr_signature, self.pastelid2, "legroast")["verification"]
         assert_equal(result, "Failed")
-
-        # Fail to verify modified text (ed448 signature)
-        text_to_sign_modified = 'X' + text_to_sign[1:]
-        result = self.nodes[0].pastelid("verify", text_to_sign_modified, signature, self.pastelid1)["verification"]
-        assert_equal(result, "Failed")
-
         # Fail to verify modified text (LegRoast signature)
         result = self.nodes[0].pastelid("verify", text_to_sign_modified, lr_signature, self.pastelid1, "legroast")["verification"]
         assert_equal(result, "Failed")
+        
+        # Sign message on node1 with the LegRoast key associated with pastelid3 
+        lr_signature = self.nodes[1].pastelid("sign", text_to_sign, self.pastelid3, self.passphrase, "legroast")["signature"]
+        assert_true(lr_signature, "Cannot sign text on node1 with LegRoast key associated with pastelid3. No LegRoast signature was created")
+        # ... but verify it on node0 that does not have pastelid3 and we don't have any PastelID reg tickets
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, "is not stored locally and PastelID registration ticket was not found in the blockchain",
+            self.nodes[0].pastelid, "verify", text_to_sign, lr_signature, self.pastelid3, "legroast")
+        # now let's register pastelid3
+        self.generate_and_sync_inc(10)
+        # send all utxos from node #3 to addr[0] to make empty balance
+        self.nodes[0].sendtoaddress(taddr1, self.nodes[0].getbalance(), "empty node0", "test", True)
+        self.generate_and_sync_inc(1)
+        # register pastelid3
+        txid = self.nodes[1].tickets("register", "id", self.pastelid3, self.passphrase, taddr1)
+        assert_true(txid, "pastelid3 registration failed")
+        self.generate_and_sync_inc(2)
+        # now we should be able to retrieve lr pubkey for pastelid3 on node0
+        # but first make sure pastelid3 is not stored locally on node0
+        assert_true(self.pastelid3 not in id_list0.values(), f"PastelID3 {self.pastelid3} should not be stored on node0")
+           # Verify text"'s "signature" (LegRoast) with the PastelID3
+        result = self.nodes[0].pastelid("verify", text_to_sign, lr_signature, self.pastelid3, "legroast")["verification"]
+        assert_equal(result, "OK")
+         # Fail to verify LegRoast signature with the different key (PastelID1)
+        result = self.nodes[0].pastelid("verify", text_to_sign, lr_signature, self.pastelid1, "legroast")["verification"]
+        assert_equal(result, "Failed")
+        # Fail to verify modified text (LegRoast signature)
+        result = self.nodes[0].pastelid("verify", text_to_sign_modified, lr_signature, self.pastelid3, "legroast")["verification"]
+        assert_equal(result, "Failed")
+       
 
         print(" -pastelid passwd")
         assert_shows_help(self.nodes[0].pastelid, "passwd")

--- a/qa/rpc-tests/secure_container.py
+++ b/qa/rpc-tests/secure_container.py
@@ -35,7 +35,7 @@ class SecureContainerTest(PastelTestFramework):
 
     def setup_network(self):
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
-                                 extra_args=[[ '-debug' ]] * self.num_nodes)
+                                 extra_args=[[]] * self.num_nodes)
         self.is_network_split = False
         connect_nodes_bi(self.nodes,0,1)
 
@@ -123,7 +123,8 @@ class SecureContainerTest(PastelTestFramework):
         # register pastelid3
         txid = self.nodes[1].tickets("register", "id", self.pastelid3, self.passphrase, taddr1)
         assert_true(txid, "pastelid3 registration failed")
-        self.generate_and_sync_inc(2)
+        self.generate_and_sync_inc(1)
+
         # now we should be able to retrieve lr pubkey for pastelid3 on node0
         # but first make sure pastelid3 is not stored locally on node0
         assert_true(self.pastelid3 not in id_list0.values(), f"PastelID3 {self.pastelid3} should not be stored on node0")

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -129,6 +129,7 @@ class BitcoinTestFramework(object):
     # generate nblocks on node0, sync all nodes
     def generate_and_sync_inc(self, nblocks = 1, nodeNo = 0):
         current_height = self.nodes[nodeNo].getblockcount()
+        self.sync_all()
         self.nodes[nodeNo].generate(nblocks)
         self.sync_all()
         assert_equal(current_height + nblocks, self.nodes[nodeNo].getblockcount())

--- a/src/mnode/mnode-pastel.h
+++ b/src/mnode/mnode-pastel.h
@@ -37,6 +37,11 @@ using ChangeUsernameTickets_t = std::vector<CChangeUsernameTicket>;
 using ChangeEthereumAddressTickets_t = std::vector<CChangeEthereumAddressTicket>;
 
 // PastelID Ticket //////////////////////////////////////////////////////////////////////////////////////////////////////
+// 
+// keys:
+//   #1: PastelID
+//   #2: for personal ids: secondKey or funding address
+//       for mastenode ids: outpoint
 class CPastelIDRegTicket : public CPastelTicket
 {
 public:


### PR DESCRIPTION
Enhanced "pastelid verify" RPC API with 'legroast' algorithm parameter.
New verify command logic:
 - if the specified PastelID is stored locally - load legroast public key from the secure container associated with that PastelID
 - try to find PastelID registration ticket in the blockchain using PastelID as a key.
If IDreg ticket was found - get legroast public key from that ticket.

Added python tests to secure_container.py to:
 - pastelid1 is generated on node0, pastelid3 on node1
 - sign text on node1 with the legroast key associated with pastelid3
 - check that signature verification fails on node0 (because pastelid3 is not stored locally and not registered in the blockchain)
 - register pastelid3 (PastelID registration ticket)
 - check that signature verification succeeds on node0. LegRoast public key is retrieved from the PastelID
   registration ticket from the blockchain