### PR TITLE
[PSL-153] 'pastelid passwd' API does not work for old pkcs8 pastelkey file

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -18,6 +18,7 @@
 #include "support/events.h"
 
 #include <univalue.h>
+#include <port_config.h>
 
 static const int DEFAULT_HTTP_CLIENT_TIMEOUT=900;
 static const int CONTINUE_EXECUTION=-1;
@@ -33,7 +34,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageOpt("-regtest", _("Enter regression test mode, which uses a special chain in which blocks can be "
                                              "solved instantly. This is intended for regression testing tools and app development."));
     strUsage += HelpMessageOpt("-rpcconnect=<ip>", strprintf(_("Send commands to node running on <ip> (default: %s)"), "127.0.0.1"));
-    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u or testnet: %u)"), 9932, 19932));
+    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u or testnet: %u)"), MAINNET_DEFAULT_RPC_PORT, TESTNET_DEFAULT_RPC_PORT));
     strUsage += HelpMessageOpt("-rpcwait", _("Wait for RPC server to start"));
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));

--- a/src/mnode/tickets/ticket-mn-fees.h
+++ b/src/mnode/tickets/ticket-mn-fees.h
@@ -29,16 +29,16 @@ public:
     // get all MN fees in PSL
     CAmount getAllMNFees() const noexcept
     {
-        return GetStorageFee() * (static_cast<double>(getMNFees().all) / 100);
+        return static_cast<CAmount>(GetStorageFee() * (static_cast<double>(getMNFees().all) / 100));
     }
     // get principal MN fee in PSL
     CAmount getPrincipalMNFee() const noexcept
     {
-        return getAllMNFees() * (static_cast<double>(getMNFees().principalShare) / 100);
+        return static_cast<CAmount>(getAllMNFees() * (static_cast<double>(getMNFees().principalShare) / 100));
     }
     // get othe MNs fee in PSL
     CAmount getOtherMNFee() const noexcept
     {
-        return getAllMNFees() * (static_cast<double>(getMNFees().otherShare) / 100);
+        return static_cast<CAmount>(getAllMNFees() * (static_cast<double>(getMNFees().otherShare) / 100));
     }
 };

--- a/src/pastelid/pastel_key.h
+++ b/src/pastelid/pastel_key.h
@@ -48,6 +48,8 @@ public:
     static bool isValidPassphrase(const std::string& sPastelId, const SecureString& strKeyPass) noexcept;
     // Change passphrase used to encrypt the secure container
     static bool ChangePassphrase(std::string &error, const std::string& sPastelId, SecureString&& sOldPassphrase, SecureString&& sNewPassphrase);
+    // read ed448 private key from PKCS8 file (olf format)
+    static bool ProcessEd448_PastelKeyFile(std::string& error, const std::string& sFilePath, const SecureString& sOldPassPhrase, SecureString &&sNewPassPhrase);
 
 protected:
     // encode/decode PastelID


### PR DESCRIPTION
PastelID was stored previously in pkcs8 encrypted file using ed448 key and a passphrase.
Later on, storage for PastelID was converted to the secure container file encrypted with xchacha20-poly1305 with the same passphrase.
"pastelid passwd" rpc API is used to change passphrase on the secure container.
Fixed an issue when "pastelid passwd" command is called on the pastel key file in old format.
Change Password algorithm has been changed:
 - try to read Pastel Key file as a secure container
 - if secure container prefix does not match - try to read ed448 private key from a file in PKCS8 format.
 - if ed448 private key successfully read using old passphrase - new secure container is created (created missing legroast private/public key pair).
 - write secure container file with the new passphrase and override existing PKCS8 file