### PR TITLE
[PSL-295] MasterNode payment voting fix

### DIFF
--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2016 Jack Grigg
 // Copyright (c) 2016 The Zcash developers
-// Copyright (c) 2021 The Pastel Core developers
+// Copyright (c) 2021-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -14,17 +14,16 @@
 // https://www.internetsociety.org/sites/default/files/blogs-media/equihash-asymmetric-proof-of-work-based-generalized-birthday-problem.pdf
 
 #if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
+#include <config/bitcoin-config.h>
 #endif
-
-#include "compat/endian.h"
-#include "crypto/equihash.h"
-#include "util.h"
 
 #include <algorithm>
 #include <iostream>
-#include <stdexcept>
 #include <optional>
+
+#include <compat/endian.h>
+#include <crypto/equihash.h>
+#include <util.h>
 
 static EhSolverCancelledException solver_cancelled;
 

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -1,21 +1,21 @@
 #pragma once
 // Copyright (c) 2016 Jack Grigg
 // Copyright (c) 2016 The Zcash developers
-// Copyright (c) 2021 The Pastel Core developers
+// Copyright (c) 2021-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
-
-#include "crypto/sha256.h"
-#include "utilstrencodings.h"
-
-#include "sodium.h"
 
 #include <exception>
 #include <stdexcept>
 #include <functional>
 #include <memory>
 #include <set>
-#include "vector_types.h"
+
+#include <sodium.h>
+
+#include <crypto/sha256.h>
+#include <utilstrencodings.h>
+#include <vector_types.h>
 
 typedef crypto_generichash_blake2b_state eh_HashState;
 typedef uint32_t eh_index;

--- a/src/main.h
+++ b/src/main.h
@@ -622,6 +622,7 @@ extern CBlockTreeDB *pblocktree;
  */
 int GetSpendHeight(const CCoinsViewCache& inputs);
 
+int GetChainHeight();
 /** Return a CMutableTransaction with contextual default values based on set of consensus rules at height */
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight);
 

--- a/src/mnode/mnode-manager.cpp
+++ b/src/mnode/mnode-manager.cpp
@@ -633,7 +633,7 @@ bool CMasternodeMan::GetMasternodeRank(const COutPoint& outpoint, int& nRankRet,
         return false;
 
     // make sure we know about this block
-    uint256 nBlockHash = uint256();
+    uint256 nBlockHash;
     if (!GetBlockHash(nBlockHash, nBlockHeight)) {
         LogPrintf("CMasternodeMan::%s -- ERROR: GetBlockHash() failed at nBlockHeight %d\n", __func__, nBlockHeight);
         return false;

--- a/src/mnode/mnode-payments.h
+++ b/src/mnode/mnode-payments.h
@@ -1,14 +1,13 @@
 #pragma once
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "vector"
-#include "map"
+#include <vector>
+#include <map>
 
-#include "main.h"
-
-#include "mnode/mnode-masternode.h"
+#include <main.h>
+#include <mnode/mnode-masternode.h>
 
 extern CCriticalSection cs_vecPayees;
 extern CCriticalSection cs_mapMasternodeBlockPayees;
@@ -16,8 +15,8 @@ extern CCriticalSection cs_mapMasternodePayeeVotes;
 
 class CMasternodePaymentVote;
 
-static constexpr size_t MNPAYMENTS_SIGNATURES_REQUIRED     = 6;
-static constexpr size_t MNPAYMENTS_SIGNATURES_TOTAL = 10;
+static constexpr size_t MNPAYMENTS_SIGNATURES_REQUIRED  = 6;
+static constexpr size_t MNPAYMENTS_SIGNATURES_TOTAL     = 20;
 
 typedef std::vector<COutPoint> outpoint_vector;
 
@@ -28,14 +27,12 @@ private:
     v_uint256 vecVoteHashes;
 
 public:
-    CMasternodePayee() :
-        scriptPubKey(),
-        vecVoteHashes()
-        {}
+    CMasternodePayee() noexcept :
+        scriptPubKey()
+    {}
 
-    CMasternodePayee(CScript payee, uint256 hashIn) :
-        scriptPubKey(payee),
-        vecVoteHashes()
+    CMasternodePayee(CScript payee, uint256 hashIn) noexcept :
+        scriptPubKey(payee)
     {
         vecVoteHashes.push_back(hashIn);
     }
@@ -49,10 +46,10 @@ public:
         READWRITE(vecVoteHashes);
     }
 
-    CScript GetPayee() { return scriptPubKey; }
+    CScript GetPayee() const noexcept { return scriptPubKey; }
 
     void AddVoteHash(const uint256 hashIn) { vecVoteHashes.push_back(hashIn); }
-    v_uint256 GetVoteHashes() { return vecVoteHashes; }
+    v_uint256 GetVoteHashes() const noexcept { return vecVoteHashes; }
     size_t GetVoteCount() const noexcept { return vecVoteHashes.size(); }
 };
 
@@ -63,14 +60,12 @@ public:
     int nBlockHeight;
     std::vector<CMasternodePayee> vecPayees;
 
-    CMasternodeBlockPayees() :
-        nBlockHeight(0),
-        vecPayees()
-        {}
-    CMasternodeBlockPayees(int nBlockHeightIn) :
-        nBlockHeight(nBlockHeightIn),
-        vecPayees()
-        {}
+    CMasternodeBlockPayees() noexcept:
+        nBlockHeight(0)
+    {}
+    CMasternodeBlockPayees(int nBlockHeightIn) noexcept:
+        nBlockHeight(nBlockHeightIn)
+    {}
 
     ADD_SERIALIZE_METHODS;
 
@@ -85,9 +80,9 @@ public:
     bool GetBestPayee(CScript& payeeRet);
     bool HasPayeeWithVotes(const CScript& payeeIn, int nVotesReq);
 
-    bool IsTransactionValid(const CTransaction& txNew);
+    bool IsTransactionValid(const CTransaction& txNew) const;
 
-    std::string GetRequiredPaymentsString();
+    std::string GetRequiredPaymentsString() const;
 };
 
 // vote for the winning payment
@@ -98,21 +93,17 @@ public:
 
     int nBlockHeight;
     CScript payee;
-    std::vector<unsigned char> vchSig;
+    v_uint8 vchSig;
 
-    CMasternodePaymentVote() :
-        vinMasternode(),
-        nBlockHeight(0),
-        payee(),
-        vchSig()
-        {}
+    CMasternodePaymentVote() noexcept :
+        nBlockHeight(0)
+     {}
 
     CMasternodePaymentVote(COutPoint outpointMasternode, int nBlockHeight, CScript payee) :
         vinMasternode(outpointMasternode),
         nBlockHeight(nBlockHeight),
-        payee(payee),
-        vchSig()
-        {}
+        payee(payee)
+     {}
 
     ADD_SERIALIZE_METHODS;
 
@@ -125,7 +116,8 @@ public:
         READWRITE(vchSig);
     }
 
-    uint256 GetHash() const {
+    uint256 GetHash() const
+    {
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << *(CScriptBase*)(&payee);
         ss << nBlockHeight;
@@ -139,7 +131,7 @@ public:
     bool IsValid(CNode* pnode, int nValidationHeight, std::string& strError);
     void Relay();
 
-    bool IsVerified() { return !vchSig.empty(); }
+    bool IsVerified() const noexcept { return !vchSig.empty(); }
     void MarkAsNotVerified() { vchSig.clear(); }
 
     std::string ToString() const;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -14,26 +14,7 @@
 
 using namespace std;
 
-namespace NetMsgType {
-const char *MNANNOUNCE="mnb";       //MasterNode Announce
-const char *MNPING="mnp";           //MasterNode Ping
-const char *MNVERIFY="mnv";         //
-const char *DSEG="dseg";            //MasterNode Sync request
-const char *SYNCSTATUSCOUNT="ssc";  //MasterNode Sync status
-
-// const char *TXLOCKREQUEST="ix";
-// const char *TXLOCKVOTE="txlvote";
-const char *MASTERNODEPAYMENTVOTE="mnw";
-const char *MASTERNODEPAYMENTBLOCK="mnwb";
-const char *MASTERNODEPAYMENTSYNC="mnget";
-const char *GOVERNANCESYNC="gvget";
-const char *GOVERNANCE="gov";
-const char *GOVERNANCEVOTE="gvt";
-const char *DSTX="dstx";
-const char *MASTERNODEMESSAGE="mnmsg";
-};
-
-static const char* ppszTypeName[] =
+static constexpr array<const char *, 13> NET_MSG_TYPE =
 {
     "ERROR",
     "tx",
@@ -50,7 +31,6 @@ static const char* ppszTypeName[] =
     NetMsgType::DSTX,
     NetMsgType::MNVERIFY,
     NetMsgType::MASTERNODEMESSAGE
-
 };
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
@@ -127,8 +107,6 @@ bool CMessageHeader::IsValid(string &error, const MessageStartChars& pchExpected
     return bRet;
 }
 
-
-
 CAddress::CAddress() : CService()
 {
     Init();
@@ -146,13 +124,13 @@ void CAddress::Init()
     nTime = 100000000;
 }
 
-CInv::CInv()
+CInv::CInv() noexcept
 {
     type = 0;
     hash.SetNull();
 }
 
-CInv::CInv(int typeIn, const uint256& hashIn)
+CInv::CInv(const int typeIn, const uint256& hashIn) noexcept
 {
     type = typeIn;
     hash = hashIn;
@@ -160,16 +138,16 @@ CInv::CInv(int typeIn, const uint256& hashIn)
 
 CInv::CInv(const string& strType, const uint256& hashIn)
 {
-    unsigned int i;
-    for (i = 1; i < ARRAYLEN(ppszTypeName); i++)
+    size_t i = 0;
+    for (i = 1; i < NET_MSG_TYPE.size(); ++i)
     {
-        if (strType == ppszTypeName[i])
+        if (strType == NET_MSG_TYPE[i])
         {
-            type = i;
+            type = static_cast<int>(i);
             break;
         }
     }
-    if (i == ARRAYLEN(ppszTypeName))
+    if (i == NET_MSG_TYPE.size())
         throw out_of_range(strprintf("CInv::CInv(string, uint256): unknown type '%s'", strType));
     hash = hashIn;
 }
@@ -179,16 +157,16 @@ bool operator<(const CInv& a, const CInv& b)
     return (a.type < b.type || (a.type == b.type && a.hash < b.hash));
 }
 
-bool CInv::IsKnownType() const
+bool CInv::IsKnownType() const noexcept
 {
-    return (type >= 1 && type < (int)ARRAYLEN(ppszTypeName));
+    return (type >= 1 && type < NET_MSG_TYPE.size());
 }
 
 const char* CInv::GetCommand() const
 {
     if (!IsKnownType())
         throw out_of_range(strprintf("CInv::GetCommand(): type=%d unknown type", type));
-    return ppszTypeName[type];
+    return NET_MSG_TYPE[type];
 }
 
 string CInv::ToString() const

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -122,8 +122,8 @@ public:
 class CInv
 {
 public:
-    CInv();
-    CInv(int typeIn, const uint256& hashIn);
+    CInv() noexcept;
+    CInv(const int typeIn, const uint256& hashIn) noexcept;
     CInv(const std::string& strType, const uint256& hashIn);
 
     ADD_SERIALIZE_METHODS;
@@ -137,7 +137,7 @@ public:
 
     friend bool operator<(const CInv& a, const CInv& b);
 
-    bool IsKnownType() const;
+    bool IsKnownType() const noexcept;
     const char* GetCommand() const;
     std::string ToString() const;
 
@@ -166,20 +166,22 @@ enum {
     MSG_MASTERNODE_MESSAGE
 };
 
-namespace NetMsgType {
-extern const char *MASTERNODEPAYMENTVOTE;
-extern const char *MASTERNODEPAYMENTBLOCK;
-extern const char *MASTERNODEPAYMENTSYNC;
-extern const char *GOVERNANCE;
-extern const char *GOVERNANCEVOTE;
-extern const char *GOVERNANCESYNC;
-extern const char *DSTX;
+namespace NetMsgType
+{
+    constexpr auto MNANNOUNCE               = "mnb";  //MasterNode Announce
+    constexpr auto MNPING                   = "mnp";  //MasterNode Ping
+    constexpr auto MNVERIFY                 = "mnv";  //
+    constexpr auto DSEG                     = "dseg"; //MasterNode Sync request
+    constexpr auto SYNCSTATUSCOUNT          = "ssc";  //MasterNode Sync status
 
-extern const char *MNANNOUNCE;
-extern const char *MNPING;
-extern const char *MNVERIFY;
-extern const char *DSEG;
-extern const char *SYNCSTATUSCOUNT;
-extern const char *MASTERNODEMESSAGE;
+    // const char *TXLOCKREQUEST="ix";
+    // const char *TXLOCKVOTE="txlvote";
+    constexpr auto MASTERNODEPAYMENTVOTE    = "mnw";
+    constexpr auto MASTERNODEPAYMENTBLOCK   = "mnwb";
+    constexpr auto MASTERNODEPAYMENTSYNC    = "mnget";
+    constexpr auto GOVERNANCESYNC           = "gvget";
+    constexpr auto GOVERNANCE               = "gov";
+    constexpr auto GOVERNANCEVOTE           = "gvt";
+    constexpr auto DSTX                     = "dstx";
+    constexpr auto MASTERNODEMESSAGE        = "mnmsg";
 };
-

--- a/src/vector_types.h
+++ b/src/vector_types.h
@@ -17,6 +17,7 @@ using v_bytes = std::vector<std::byte>;
 using v_ints = std::vector<int>;
 using v_doubles = std::vector<double>;
 using v_bools = std::vector<bool>;
+using v_sizet = std::vector<size_t>;
 
 /**
  * Converts string to byte vector.


### PR DESCRIPTION
- Added extra validation for SuperNode payment transaction.
- This check is activated in Mainnet at blockHeight 228700.
- Before the change, the transaction was considered valid if there were less than 6 votes. After the change, the transaction is checked for payment regardless of the payee vote count.
- Payees are also ordered by vote count in descending order and the payment check is performed first on the payee with max vote count.
- Regular transactions with no votes are considered valid.
- Increased number of MasterNodes participating in voting from 10 to 20