### PR TITLE
[PSL-296] Fix `storagefee getactionfees`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ build-aux/m4/ltversion.m4
 build-aux/missing
 build-aux/compile
 build-aux/test-driver
+build-aux/vs2022/.vs/
+build-aux/vs2019/.vs/
 config.log
 config.status
 configure
@@ -69,6 +71,7 @@ src/univalue/gen
 *.pb.cc
 *.pb.h
 .vscode
+*.user
 
 *.log
 *.trs

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -1,9 +1,8 @@
+#pragma once
 // Copyright (c) 2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_CRYPTO_COMMON_H
-#define BITCOIN_CRYPTO_COMMON_H
 
 #if defined(HAVE_CONFIG_H)
 #include "bitcoin-config.h"
@@ -13,8 +12,8 @@
 #include <assert.h>
 #include <string.h>
 
-#include "sodium.h"
-#include "compat/endian.h"
+#include <sodium.h>
+#include <compat/endian.h>
 
 #if defined(NDEBUG)
 # error "Zcash cannot be compiled without assertions."
@@ -122,5 +121,3 @@ int inline init_and_check_sodium()
 
     return 0;
 }
-
-#endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/mnode/tickets/action-reg.cpp
+++ b/src/mnode/tickets/action-reg.cpp
@@ -273,10 +273,10 @@ ActionRegTickets_t CActionRegTicket::FindAllTicketByPastelID(const string& paste
 }
 
 /**
- * Get action fees based on data size.
+ * Get action fees based on data size in PSL.
  * 
  * \param nDataSizeInMB - data size in MB
- * \return map of <actionTicketType> -> <fee>
+ * \return map of <actionTicketType> -> <fee_in_psl>
  */
 action_fee_map_t CActionRegTicket::GetActionFees(const size_t nDataSizeInMB)
 {
@@ -284,7 +284,7 @@ action_fee_map_t CActionRegTicket::GetActionFees(const size_t nDataSizeInMB)
     const CAmount nStorageFeePerMB = masterNodeCtrl.GetNetworkFeePerMB();
     const CAmount nTicketFeePerKB = masterNodeCtrl.GetNFTTicketFeePerKB();
     
-    CAmount nActionFeePerMB = masterNodeCtrl.GetActionTicketFeePerMB(ACTION_TICKET_TYPE::SENSE);
+    const CAmount nActionFeePerMB = masterNodeCtrl.GetActionTicketFeePerMB(ACTION_TICKET_TYPE::SENSE);
 
     // calculate sense fee
     CAmount nFee = nDataSizeInMB * nActionFeePerMB + nStorageFeePerMB * ACTION_DUPE_DATA_SIZE_MB + nTicketFeePerKB * ACTION_SENSE_TICKET_SIZE_KB;

--- a/src/mnode/tickets/action-reg.h
+++ b/src/mnode/tickets/action-reg.h
@@ -148,7 +148,7 @@ public:
     static bool FindTicketInDb(const std::string& key, CActionRegTicket& _ticket);
     static bool CheckIfTicketInDb(const std::string& key);
     static ActionRegTickets_t FindAllTicketByPastelID(const std::string& pastelID);
-    // get action storage fees
+    // get action storage fees in PSL
     static action_fee_map_t GetActionFees(const size_t nDataSizeInMB);
 
 protected:

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,10 +1,12 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <univalue.h>
 
 #include <rpc/server.h>
-
 #include <init.h>
 #include <key_io.h>
 #include <random.h>
@@ -14,10 +16,6 @@
 #include <utilstrencodings.h>
 #include <asyncrpcqueue.h>
 #include <str_utils.h>
-
-#include <memory>
-
-#include <univalue.h>
 
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/stream.hpp>
@@ -135,10 +133,12 @@ uint256 ParseHashV(const UniValue& v, string strName)
     result.SetHex(strHex);
     return result;
 }
+
 uint256 ParseHashO(const UniValue& o, string strKey)
 {
     return ParseHashV(find_value(o, strKey), strKey);
 }
+
 v_uint8 ParseHexV(const UniValue& v, string strName)
 {
     string strHex;
@@ -148,6 +148,7 @@ v_uint8 ParseHexV(const UniValue& v, string strName)
         throw JSONRPCError(RPC_INVALID_PARAMETER, strName+" must be hexadecimal string (not '"+strHex+"')");
     return ParseHex(strHex);
 }
+
 v_uint8 ParseHexO(const UniValue& o, string strKey)
 {
     return ParseHexV(find_value(o, strKey), strKey);
@@ -274,12 +275,12 @@ CRPCTable::CRPCTable()
     }
 }
 
-const CRPCCommand *CRPCTable::operator[](const string &name) const
+const CRPCCommand *CRPCTable::operator[](const string &name) const noexcept
 {
-    map<string, const CRPCCommand*>::const_iterator it = mapCommands.find(name);
-    if (it == mapCommands.end())
+    auto it = mapCommands.find(name);
+    if (it == mapCommands.cend())
         return nullptr;
-    return (*it).second;
+    return it->second;
 }
 
 bool CRPCTable::appendCommand(const string& name, const CRPCCommand* pcmd)
@@ -288,8 +289,8 @@ bool CRPCTable::appendCommand(const string& name, const CRPCCommand* pcmd)
         return false;
 
     // don't allow overwriting for now
-    map<string, const CRPCCommand*>::const_iterator it = mapCommands.find(name);
-    if (it != mapCommands.end())
+    auto it = mapCommands.find(name);
+    if (it != mapCommands.cend())
         return false;
 
     mapCommands[name] = pcmd;

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -4,17 +4,17 @@
 // Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
-#include <amount.h>
-#include <rpc/protocol.h>
-#include <uint256.h>
-
 #include <list>
 #include <map>
 #include <stdint.h>
-#include <string>
 #include <memory>
 
 #include <univalue.h>
+
+#include <uint256.h>
+#include <amount.h>
+#include <rpc/protocol.h>
+#include <vector_types.h>
 
 class AsyncRPCQueue;
 class CRPCCommand;
@@ -133,7 +133,7 @@ private:
     std::map<std::string, const CRPCCommand*> mapCommands;
 public:
     CRPCTable();
-    const CRPCCommand* operator[](const std::string& name) const;
+    const CRPCCommand* operator[](const std::string& name) const noexcept;
     std::string help(const std::string& name) const;
 
     /**
@@ -162,14 +162,14 @@ extern CRPCTable tableRPC;
  */
 extern uint256 ParseHashV(const UniValue& v, std::string strName);
 extern uint256 ParseHashO(const UniValue& o, std::string strKey);
-extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
-extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
+extern v_uint8 ParseHexV(const UniValue& v, std::string strName);
+extern v_uint8 ParseHexO(const UniValue& o, std::string strKey);
 
 extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
-extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
-extern double GetNetworkDifficulty(const CBlockIndex* blockindex = NULL);
+extern double GetDifficulty(const CBlockIndex* blockindex = nullptr);
+extern double GetNetworkDifficulty(const CBlockIndex* blockindex = nullptr);
 extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);


### PR DESCRIPTION
- treat action fee units as PSL
pastel-cli storagefee getactionfees 0:
{
   "datasize": 0,
   "sensefee": 265,
   "sensefeePat": 26500000,
   "cascadefee": 15,
   "cascadefeePat": 1500000
}
- added units to all storage fee commands in a usage info
- added fees in patishis (with *Pat suffix) for consistency in other storagefee commands