### PR TITLE
[PSL-300] MingW pasteld crashes on startup

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -372,7 +372,7 @@ static bool HTTPBindAddresses(std::string &error, struct evhttp* http)
 /** Simple wrapper to set thread name and run work queue */
 static void HTTPWorkQueueRun(WorkQueue<HTTPClosure>* queue)
 {
-    RenameThread("pastel-httpworker");
+    RenameThread("psl-httpworker");
     queue->Run();
 }
 

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -12,7 +12,11 @@
 
 using namespace std;
 
+#ifdef __MINGW64__
+__thread CServiceThread *funcThreadObj;
+#else
 thread_local CServiceThread* funcThreadObj = nullptr;
+#endif
 
 CScheduler::CScheduler(const char *szThreadName) : 
     m_sThreadName(szThreadName ? szThreadName : "scheduler"),

--- a/src/script_check.cpp
+++ b/src/script_check.cpp
@@ -91,7 +91,7 @@ void CScriptCheckManager::create_workers(CServiceThreadGroup &threadGroup)
     string sThreadName;
     for (size_t i = 0; i < m_nScriptCheckThreads - 1; ++i)
     {
-        sThreadName = strprintf("script-ch%d", i + 1);
+        sThreadName = strprintf("scr-ch%d", i + 1);
         threadGroup.add_thread(make_shared<CScriptCheckWorker>(&m_ScriptCheckQueue, false, sThreadName.c_str()), true);
     }
 }
@@ -99,5 +99,5 @@ void CScriptCheckManager::create_workers(CServiceThreadGroup &threadGroup)
 unique_ptr<CScriptCheckWorker> CScriptCheckManager::create_master(const bool bEnabled)
 {
     return make_unique<CScriptCheckWorker>(bEnabled && m_nScriptCheckThreads ? &m_ScriptCheckQueue : nullptr, 
-        true, "script-chm");
+        true, "scr-chm");
 }

--- a/src/svc_thread.h
+++ b/src/svc_thread.h
@@ -21,7 +21,11 @@ class CServiceThread;
 class func_thread_interrupted : public std::exception
 {};
 
+#ifdef __MINGW64__
+extern __thread CServiceThread *funcThreadObj;
+#else
 extern thread_local CServiceThread *funcThreadObj;
+#endif
 
 /** 
  * Class to enhance std::thread.
@@ -36,7 +40,7 @@ public:
         m_bRunning(false),
         m_bStopRequested(false)
     {
-        m_sThreadName = strprintf("pastel-%s", SAFE_SZ(szThreadName));
+        m_sThreadName = strprintf("psl-%s", SAFE_SZ(szThreadName));
     }
 
     // disable copy
@@ -58,6 +62,7 @@ public:
             m_Thread = std::thread(&CServiceThread::run, this);
         }
         catch(...) {
+            LogPrintf("exception occured on thread [%s] creation\n", m_sThreadName);
             return false;
         }
         return true;


### PR DESCRIPTION
g++ 9.3 MingW cross-compiler creates incorrect code (with -O1 optimization option) for thread_local variable (c++11 feature).
The code crashes on the first access to thread_local var.
Replaced thread_local with __thread specifier (older gnu thread-local-storage) only for Mingw64 version.