### PR TITLE
[PSL-347] Generate primary key internally for NFT,NFT Collection & Action Reg tickets

### DIFF
--- a/qa/rpc-tests/mn_tickets_validation.py
+++ b/qa/rpc-tests/mn_tickets_validation.py
@@ -266,42 +266,42 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
         self.nodes[self.non_mn1].generate(10)
 
-        # makefaketicket nft ticket signatures pastelID passphrase key1 key2 creatorheight nStorageFee ticketPrice bChangeSignature
+        # makefaketicket nft ticket signatures pastelID passphrase label creatorheight nStorageFee ticketPrice bChangeSignature
 
         tickets = {
             #  non MN with real signatures of non top 10 MNs
             "nft1-non-mn123": self.nodes[self.non_mn1].tickets("makefaketicket", "nft",
-                                                              self.ticket, json.dumps(self.not_top_mns_signatures_dict), self.nonmn1_pastelid1, "passphrase", "key1", "key2",
+                                                              self.ticket, json.dumps(self.not_top_mns_signatures_dict), self.nonmn1_pastelid1, "passphrase", "nft-label",
                                                               str(self.creator_ticket_height), str(self.storage_fee), "10", "0"),
 
             #  non MN with fake signatures of top 10 MNs
             "nft2-nonmn1-fake23": self.nodes[self.non_mn1].tickets("makefaketicket", "nft",
-                                                                  self.ticket, json.dumps(self.signatures_dict), self.nonmn1_pastelid1, "passphrase", "key1", "key2",
+                                                                  self.ticket, json.dumps(self.signatures_dict), self.nonmn1_pastelid1, "passphrase", "nft-label",
                                                                   str(self.creator_ticket_height), str(self.storage_fee), "10", "1"),  # Verb = 1 - will modify pastlelid signature to make it invalid
 
             #  non top 10 MN with real signatures of non top 10 MNs
             "nft3-non-top-mn1-nonmn23": self.nodes[self.not_top_mns_index0].tickets("makefaketicket", "nft",
-                                                                               self.ticket, json.dumps(self.not_top_mns_signatures_dict), self.not_top_mn_pastelid0, "passphrase", "key1", "key2",
+                                                                               self.ticket, json.dumps(self.not_top_mns_signatures_dict), self.not_top_mn_pastelid0, "passphrase", "nft-label",
                                                                                str(self.creator_ticket_height), str(self.storage_fee), "10", "0"),
 
             #  non top 10 MN with fake signatures of top 10 MNs
             "nft4-non-top-mn1-fake23": self.nodes[self.not_top_mns_index0].tickets("makefaketicket", "nft",
-                                                                          self.ticket, json.dumps(self.signatures_dict), self.not_top_mn_pastelid0, "passphrase", "key1", "key2",
+                                                                          self.ticket, json.dumps(self.signatures_dict), self.not_top_mn_pastelid0, "passphrase", "nft-label",
                                                                           str(self.creator_ticket_height), str(self.storage_fee), "10", "1"),  # Verb = 1 - will modify pastlelid signature to make it invalid
 
             #  top 10 MN with real signatures of non top 10 MNs
             "nft5-top-mn1-non-top-mn23": self.nodes[self.top_mns_index0].tickets("makefaketicket", "nft",
-                                                                                self.ticket, json.dumps(self.not_top_mns_signatures_dict), self.top_mn_pastelid0, "passphrase", "key1", "key2",
+                                                                                self.ticket, json.dumps(self.not_top_mns_signatures_dict), self.top_mn_pastelid0, "passphrase", "nft-label",
                                                                                 str(self.creator_ticket_height), str(self.storage_fee), "10", "0"),
 
             #  top 10 MN with fake signatures of top 10 MNs
             "nft6-top-mn1-fake23": self.nodes[self.top_mns_index0].tickets("makefaketicket", "nft",
-                                                                          self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, "passphrase", "key1", "key2",
+                                                                          self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, "passphrase", "nft-label",
                                                                           str(self.creator_ticket_height), str(self.storage_fee), "10", "1"),  # Verb = 1 - will modify pastlelid signature to make it invalid
 
             #  good signatures of top 10 MNs, bad ticket fee
             "nft-top-mn1-bad-fee": self.nodes[self.top_mns_index0].tickets("makefaketicket", "nft",
-                                                            self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, "passphrase", "key1", "key2",
+                                                            self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, "passphrase", "nft-label",
                                                             str(self.creator_ticket_height), str(self.storage_fee), "1", "0")
         }
 
@@ -321,7 +321,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         # valid ticket
         self.nft_ticket1_txid = self.nodes[self.top_mns_index0].tickets("register", "nft", self.ticket, json.dumps(self.signatures_dict),
                                                                         self.top_mn_pastelid0, "passphrase",
-                                                                        "key1", "key2",
+                                                                        "nft-label",
                                                                         str(self.storage_fee))["txid"]
         assert_true(self.nft_ticket1_txid, "No ticket was created")
 

--- a/src/gtest/test_mnode/test_ticket_processor.cpp
+++ b/src/gtest/test_mnode/test_ticket_processor.cpp
@@ -84,8 +84,9 @@ TEST_F(TestTicketProcessor, ticket_compression)
         { ticket->CChangeUsernameTicket::SerializationOp(s, ser_action); });
 
     // serialize ticket, convert to tx, add to mempool, validate tx
-    string txid = SendTicket(*ticket);
-    EXPECT_TRUE(!txid.empty());
+    const auto result = SendTicket(*ticket);
+    EXPECT_TRUE(!get<0>(result).empty());
+    EXPECT_TRUE(!get<1>(result).empty());
 }
 #endif // ENABLE_WALLET
 #endif // ENABLE_MINING

--- a/src/gtest/test_random.cpp
+++ b/src/gtest/test_random.cpp
@@ -1,33 +1,66 @@
+// Copyright (c) 2021-2022 The Pastel developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <gtest/gtest.h>
 
-#include "random.h"
-#include "pastel_gtest_utils.h"
+#include <random.h>
+#include <pastel_gtest_utils.h>
+#include <vector_types.h>
+
+using namespace std;
 
 TEST(Random, MappedShuffle) {
-    std::vector<int> a {8, 4, 6, 3, 5};
-    std::vector<int> m {0, 1, 2, 3, 4};
+    v_ints a {8, 4, 6, 3, 5};
+    v_ints m {0, 1, 2, 3, 4};
 
     auto a1 = a;
     auto m1 = m;
     MappedShuffle(a1.begin(), m1.begin(), a1.size(), GenZero);
-    std::vector<int> ea1 {4, 6, 3, 5, 8};
-    std::vector<int> em1 {1, 2, 3, 4, 0};
+    v_ints ea1 {4, 6, 3, 5, 8};
+    v_ints em1 {1, 2, 3, 4, 0};
     EXPECT_EQ(ea1, a1);
     EXPECT_EQ(em1, m1);
 
     auto a2 = a;
     auto m2 = m;
     MappedShuffle(a2.begin(), m2.begin(), a2.size(), GenMax);
-    std::vector<int> ea2 {8, 4, 6, 3, 5};
-    std::vector<int> em2 {0, 1, 2, 3, 4};
+    v_ints ea2 {8, 4, 6, 3, 5};
+    v_ints em2 {0, 1, 2, 3, 4};
     EXPECT_EQ(ea2, a2);
     EXPECT_EQ(em2, m2);
 
     auto a3 = a;
     auto m3 = m;
     MappedShuffle(a3.begin(), m3.begin(), a3.size(), GenIdentity);
-    std::vector<int> ea3 {8, 4, 6, 3, 5};
-    std::vector<int> em3 {0, 1, 2, 3, 4};
+    v_ints ea3 {8, 4, 6, 3, 5};
+    v_ints em3 {0, 1, 2, 3, 4};
     EXPECT_EQ(ea3, a3);
     EXPECT_EQ(em3, m3);
+}
+
+TEST(Random, generateRandomBase85Str)
+{
+    string s = generateRandomBase85Str(0);
+    EXPECT_TRUE(s.empty());
+
+    s = generateRandomBase85Str(64);
+    EXPECT_GE(s.size(), 64);
+}
+
+TEST(Random, generateRandomBase64Str)
+{
+    string s = generateRandomBase64Str(0);
+    EXPECT_TRUE(s.empty());
+
+    s = generateRandomBase64Str(32);
+    EXPECT_GE(s.size(), 32);
+}
+
+TEST(Random, generateRandomBase32Str)
+{
+    string s = generateRandomBase32Str(0);
+    EXPECT_TRUE(s.empty());
+
+    s = generateRandomBase32Str(32);
+    EXPECT_GE(s.size(), 32);
 }

--- a/src/mnode/rpc/mnode-rpc-utils.cpp
+++ b/src/mnode/rpc/mnode-rpc-utils.cpp
@@ -1,8 +1,10 @@
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <mnode/rpc/mnode-rpc-utils.h>
+#include <rpc/rpc_consts.h>
 
-#include "mnode/rpc/mnode-rpc-utils.h"
+using namespace std;
 
 int get_number(const UniValue& v)
 {
@@ -12,4 +14,20 @@ int get_number(const UniValue& v)
 long long get_long_number(const UniValue& v)
 {
     return v.isStr() ? std::stoll(v.get_str()) : (long long)v.get_int();
+}
+
+/**
+ * Generate UniValue result after SendTicket.
+ * 
+ * \param resultIDs - tuple of (txid),(ticket primary key)
+ * \return result univalue object
+ */
+UniValue GenerateSendTicketResult(tuple<string, string> &&resultIDs)
+{
+    UniValue result(UniValue::VOBJ);
+
+    result.pushKV(RPC_KEY_TXID, move(get<0>(resultIDs)));
+    result.pushKV(RPC_KEY_KEY, move(get<1>(resultIDs)));
+
+    return result;
 }

--- a/src/mnode/rpc/mnode-rpc-utils.h
+++ b/src/mnode/rpc/mnode-rpc-utils.h
@@ -1,6 +1,13 @@
 #pragma once
+// Copyright (c) 2018-2022 The Pastel Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <tuple>
+#include <string>
 
 #include <univalue.h>
 
 int get_number(const UniValue& v);
 long long get_long_number(const UniValue& v);
+
+UniValue GenerateSendTicketResult(std::tuple<std::string, std::string>&& resultIDs);

--- a/src/mnode/rpc/tickets-activate.cpp
+++ b/src/mnode/rpc/tickets-activate.cpp
@@ -83,11 +83,7 @@ As json rpc:
         sFundingAddress = params[7].get_str();
 
     const auto NFTActTicket = CNFTActivateTicket::Create(move(regTicketTxID), height, fee, move(pastelID), move(strKeyPass));
-    string txid = CPastelTicketProcessor::SendTicket(NFTActTicket, sFundingAddress);
-
-    UniValue result(UniValue::VOBJ);
-    result.pushKV(RPC_KEY_TXID, move(txid));
-    return result;
+    return GenerateSendTicketResult(CPastelTicketProcessor::SendTicket(NFTActTicket, sFundingAddress));
 }
 
 UniValue tickets_activate_action(const UniValue& params, const bool bRegisterAPI)
@@ -146,11 +142,7 @@ As json rpc:
         sFundingAddress = params[7].get_str();
 
     const auto ActionActivateTicket = CActionActivateTicket::Create(move(regTicketTxID), height, fee, move(pastelID), move(strKeyPass));
-    string txid = CPastelTicketProcessor::SendTicket(ActionActivateTicket, sFundingAddress);
-
-    UniValue result(UniValue::VOBJ);
-    result.pushKV(RPC_KEY_TXID, move(txid));
-    return result;
+    return GenerateSendTicketResult(CPastelTicketProcessor::SendTicket(ActionActivateTicket, sFundingAddress));
 }
 
 UniValue tickets_activate_nft_collection(const UniValue& params, const bool bRegisterAPI)
@@ -209,11 +201,7 @@ As json rpc:
         sFundingAddress = params[7].get_str();
 
     const auto NFTCollectionActTicket = CNFTCollectionActivateTicket::Create(move(regTicketTxID), height, fee, move(pastelID), move(strKeyPass));
-    string txid = CPastelTicketProcessor::SendTicket(NFTCollectionActTicket, sFundingAddress);
-
-    UniValue result(UniValue::VOBJ);
-    result.pushKV(RPC_KEY_TXID, move(txid));
-    return result;
+    return GenerateSendTicketResult(CPastelTicketProcessor::SendTicket(NFTCollectionActTicket, sFundingAddress));
 }
 
 UniValue tickets_activate(const UniValue& params)

--- a/src/mnode/rpc/tickets-fake.cpp
+++ b/src/mnode/rpc/tickets-fake.cpp
@@ -46,13 +46,12 @@ UniValue tickets_fake(const UniValue& params, const bool bSend)
         string signatures = params[3].get_str();
         string sPastelID = params[4].get_str();
         SecureString strKeyPass(params[5].get_str());
-        string key1 = params[6].get_str();
-        string key2 = params[7].get_str();
-        CAmount nStorageFee = get_long_number(params[8]);
+        string label = params[6].get_str();
+        CAmount nStorageFee = get_long_number(params[7]);
         auto NFTRegTicket = CNFTRegTicket::Create(move(nft_ticket), signatures,
-                                                  move(sPastelID), move(strKeyPass), move(key1), move(key2), nStorageFee);
-        const CAmount ticketPricePSL = get_long_number(params[10].get_str());
-        string strVerb = params[11].get_str();
+                                                  move(sPastelID), move(strKeyPass),move(label), nStorageFee);
+        const CAmount ticketPricePSL = get_long_number(params[9].get_str());
+        string strVerb = params[10].get_str();
         resultObj = CPastelTicketProcessor::CreateFakeTransaction(NFTRegTicket, ticketPricePSL, vector<pair<string, CAmount>>{}, strVerb, bSend);
     } break;
 

--- a/src/mnode/rpc/tickets-list.cpp
+++ b/src/mnode/rpc/tickets-list.cpp
@@ -96,7 +96,7 @@ As json rpc
     if (params.size() > 2 && !bSpecialParsingLogic)
         filter = params[2].get_str();
 
-    int minheight = 0;
+    uint32_t minheight = 0;
     if (params.size() > 3 && !bSpecialParsingLogic)
         minheight = get_number(params[3]);
 

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -69,11 +69,11 @@ class CPastelTicketProcessor
     db_map_t dbs; // ticket db storage
 
     template <class _TicketType, typename F>
-    void listTickets(F f, const int minHeight) const;
+    void listTickets(F f, const uint32_t nMinHeight) const;
 
     // filter tickets of the specific type using functor f
     template <class _TicketType, typename F>
-    std::string filterTickets(F f, const int minHeight, const bool bCheckConfirmation = true) const;
+    std::string filterTickets(F f, const uint32_t nMinHeight, const bool bCheckConfirmation = true) const;
 
 public:
     CPastelTicketProcessor() = default;
@@ -134,18 +134,18 @@ public:
     std::string getValueBySecondaryKey(const CPastelTicket& ticket) const;
 
     template <class _TicketType>
-    std::string ListTickets(const int minHeight) const;
+    std::string ListTickets(const uint32_t nMinHeight) const;
 
     // list NFT registration tickets using filter
-    std::string ListFilterPastelIDTickets(const int minHeight, const short filter = 0, // 1 - mn;        2 - personal;     3 - mine
+    std::string ListFilterPastelIDTickets(const uint32_t nMinHeight, const short filter = 0, // 1 - mn;        2 - personal;     3 - mine
                                           const pastelid_store_t* pmapIDs = nullptr) const;
-    std::string ListFilterNFTTickets(const int minHeight, const short filter = 0) const;   // 1 - active;    2 - inactive;     3 - sold
-    std::string ListFilterNFTCollectionTickets(const int minHeight, const short filter = 0) const;   // 1 - active;    2 - inactive;
-    std::string ListFilterActTickets(const int minHeight, const short filter = 0) const;   // 1 - available; 2 - sold
-    std::string ListFilterSellTickets(const int minHeight, const short filter = 0, const std::string& pastelID = "") const;  // 0 - all, 1 - available; 2 - unavailable;  3 - expired; 4 - sold
-    std::string ListFilterBuyTickets(const int minHeight, const short filter = 0, const std::string& pastelID = "") const;   // 0 - all, 1 - traded;    2 - expired
-    std::string ListFilterTradeTickets(const int minHeight, const short filter = 0, const std::string& pastelID = "") const; // 0 - all, 1 - available; 2 - sold
-    std::string ListFilterActionTickets(const int minHeight, const short filter = 0) const; // 1 - active;    2 - inactive
+    std::string ListFilterNFTTickets(const uint32_t nMinHeight, const short filter = 0) const;   // 1 - active;    2 - inactive;     3 - sold
+    std::string ListFilterNFTCollectionTickets(const uint32_t nMinHeight, const short filter = 0) const;   // 1 - active;    2 - inactive;
+    std::string ListFilterActTickets(const uint32_t nMinHeight, const short filter = 0) const;   // 1 - available; 2 - sold
+    std::string ListFilterSellTickets(const uint32_t nMinHeight, const short filter = 0, const std::string& pastelID = "") const;  // 0 - all, 1 - available; 2 - unavailable;  3 - expired; 4 - sold
+    std::string ListFilterBuyTickets(const uint32_t nMinHeight, const short filter = 0, const std::string& pastelID = "") const;   // 0 - all, 1 - traded;    2 - expired
+    std::string ListFilterTradeTickets(const uint32_t nMinHeight, const short filter = 0, const std::string& pastelID = "") const; // 0 - all, 1 - available; 2 - sold
+    std::string ListFilterActionTickets(const uint32_t nMinHeight, const short filter = 0) const; // 1 - active;    2 - inactive
 
     // search for NFT registration tickets, calls functor for each matching ticket
     void SearchForNFTs(const search_thumbids_t &p, std::function<size_t(const CPastelTicket *, const nlohmann::json &)> &fnMatchFound) const;
@@ -165,7 +165,7 @@ public:
     // Add P2FMS transaction to the memory pool
     static bool StoreP2FMSTransaction(const CMutableTransaction& tx_out, std::string& error_ret);
 
-    static std::string SendTicket(const CPastelTicket& ticket, const opt_string_t& sFundingAddress = std::nullopt);
+    static std::tuple<std::string, std::string> SendTicket(const CPastelTicket& ticket, const opt_string_t& sFundingAddress = std::nullopt);
 
     static std::unique_ptr<CPastelTicket> GetTicket(const uint256 &txid);
     static std::unique_ptr<CPastelTicket> GetTicket(const std::string& _txid, const TicketID ticketID);

--- a/src/mnode/tickets/action-reg.h
+++ b/src/mnode/tickets/action-reg.h
@@ -22,8 +22,8 @@ using ActionRegTickets_t = std::vector<CActionRegTicket>;
         "action_type": string,     // action type (sense, cascade)
         "version": integer,        // version of the blockchain representation of ticket, v1
         "signatures": object,      // signatures, see below
-        "key1": string,
-        "key2": string,
+        "key": string,             // primary key
+        "label": string,           // search label
         "called_at": unsigned int, // block at which action was requested,
                                    // is used to check if the SNs that created this ticket was indeed top SN
                                    // when that action call was made
@@ -48,8 +48,8 @@ signatures: {
           "mn3": { "PastelID" : "signature"},
 }
 
-  key #1: keyOne
-  key #2: keyTwo
+  key #1: keyOne (primary)
+  key #2: keyTwo (label)
 mvkey #1: action caller PastelID
 */
 
@@ -91,12 +91,11 @@ public:
     ACTION_TICKET_TYPE GetActionType() const noexcept { return m_ActionType; }
 
     std::string KeyOne() const noexcept override { return m_keyOne; }
-    std::string KeyTwo() const noexcept override { return m_keyTwo; }
     std::string MVKeyOne() const noexcept override { return m_sCallerPastelId; }
 
-    bool HasKeyTwo() const noexcept override { return true; }
     bool HasMVKeyOne() const noexcept override { return true; }
     void SetKeyOne(std::string &&sValue) override { m_keyOne = std::move(sValue); }
+    void GenerateKeyOne() override;
 
     std::string ToJSON() const noexcept override;
     std::string ToStr() const noexcept override { return m_sActionTicket; }
@@ -131,7 +130,7 @@ public:
         const bool bValidActionType = SetActionType(m_sActionType);
         serialize_signatures(s, ser_action);
         READWRITE(m_keyOne);
-        READWRITE(m_keyTwo);
+        READWRITE(m_label);
         READWRITE(m_nCalledAtHeight);
         READWRITE(m_storageFee);
         if (m_nTimestamp == 0)
@@ -144,7 +143,7 @@ public:
     }
 
     static CActionRegTicket Create(std::string && action_ticket, const std::string& signatures, 
-        std::string && sPastelID, SecureString&& strKeyPass, std::string &&keyOne, std::string &&keyTwo, const CAmount storageFee);
+        std::string && sPastelID, SecureString&& strKeyPass, std::string &&label, const CAmount storageFee);
     static bool FindTicketInDb(const std::string& key, CActionRegTicket& _ticket);
     static bool CheckIfTicketInDb(const std::string& key);
     static ActionRegTickets_t FindAllTicketByPastelID(const std::string& pastelID);
@@ -158,9 +157,9 @@ protected:
     std::string m_sCallerPastelId;      // Pastel ID of the Action caller
     uint32_t m_nCalledAtHeight{0};      // block at which action was requested
 
-    std::string m_keyOne;               // key #1
-    std::string m_keyTwo;               // key #2
-    CAmount m_storageFee{0};                // storage fee in PSL
+    std::string m_keyOne;               // key #1 (primary key, generated)
+    std::string m_label;                // ticket label
+    CAmount m_storageFee{0};            // storage fee in PSL
 
     // parse base64-encoded action_ticket in json format, may throw runtime_error exception
     void parse_action_ticket();

--- a/src/mnode/tickets/nft-collection-reg.h
+++ b/src/mnode/tickets/nft-collection-reg.h
@@ -129,7 +129,7 @@ public:
         serialize_signatures(s, ser_action);
 
         READWRITE(m_keyOne);
-        READWRITE(m_keyTwo);
+        READWRITE(m_label);
         READWRITE(m_nCreatorHeight);
         READWRITE(m_nRoyalty);
         READWRITE(m_sGreenAddress);
@@ -140,7 +140,7 @@ public:
     }
 
     static CNFTCollectionRegTicket Create(std::string &&nft_collection_ticket, const std::string& signatures, 
-        std::string &&sPastelID, SecureString&& strKeyPass, std::string &&keyOne, std::string &&keyTwo, const CAmount storageFee);
+        std::string &&sPastelID, SecureString&& strKeyPass, std::string &&label, const CAmount storageFee);
     static bool FindTicketInDb(const std::string& key, CNFTCollectionRegTicket& ticket);
     static bool CheckIfTicketInDb(const std::string& key);
     static NFTCollectionRegTickets_t FindAllTicketByPastelID(const std::string& pastelID);

--- a/src/mnode/tickets/nft-reg.h
+++ b/src/mnode/tickets/nft-reg.h
@@ -34,13 +34,13 @@ nft_ticket as base64(RegistrationTicket({some data}))
 bytes fields are base64 as strings
 
   "nft_ticket_version": integer  // 1 or 2
-  "author": bytes,               // PastelID of the author (creator)
+  "author": bytes,               // PastelID of the NFT creator
   "blocknum": integer,           // block number when the ticket was created - this is to map the ticket to the MNs that should process it
   "block_hash": bytes            // hash of the top block when the ticket was created - this is to map the ticket to the MNs that should process it
-  "copies": integer,             // number of copies, optional in v2
+  "copies": integer,             // number of copies of NFT this ticket is creating, optional in v2
   "royalty": float,              // royalty fee, how much creator should get on all future resales, optional in v2
   "green": boolean,              // is there Green NFT payment or not, optional in v2
-  "nft_collection_txid": bytes,  // transaction id of the NFT collection that NFT belongs to (optional, can be empty)
+  "nft_collection_txid": bytes,  // transaction id of the NFT collection that NFT belongs to, v2 only, optional, can be empty
   "app_ticket": bytes,           // cNode parses app_ticket only for search
   as base64(
   {
@@ -143,7 +143,7 @@ public:
         serialize_signatures(s, ser_action);
 
         READWRITE(m_keyOne);
-        READWRITE(m_keyTwo);
+        READWRITE(m_label);
         READWRITE(m_nCreatorHeight);
         READWRITE(m_nTotalCopies);
         READWRITE(m_nRoyalty);
@@ -155,7 +155,7 @@ public:
     }
 
     static CNFTRegTicket Create(std::string &&nft_ticket, const std::string& signatures, std::string &&sPastelID, 
-        SecureString&& strKeyPass, std::string &&keyOne, std::string &&keyTwo, const CAmount storageFee);
+        SecureString&& strKeyPass, std::string &&label, const CAmount storageFee);
     static bool FindTicketInDb(const std::string& key, CNFTRegTicket& ticket);
     static bool CheckIfTicketInDb(const std::string& key);
     static NFTRegTickets_t FindAllTicketByPastelID(const std::string& pastelID);

--- a/src/mnode/tickets/nft-royalty.cpp
+++ b/src/mnode/tickets/nft-royalty.cpp
@@ -5,6 +5,7 @@
 
 #include <init.h>
 #include <vector_types.h>
+#include <utilstrencodings.h>
 #include <pastelid/common.h>
 #include <pastelid/pastel_key.h>
 #include <mnode/tickets/pastelid-reg.h>
@@ -32,8 +33,19 @@ CNFTRoyaltyTicket CNFTRoyaltyTicket::Create(
 
     const auto strTicket = ticket.ToStr();
     string_to_vector(CPastelID::Sign(strTicket, ticket.pastelID, move(strKeyPass)), ticket.m_signature);
+    ticket.GenerateKeyOne();
 
     return ticket;
+}
+
+void CNFTRoyaltyTicket::SetKeyOne(std::string&& sValue) 
+{ 
+    m_keyOne = move(sValue);
+}
+
+void CNFTRoyaltyTicket::GenerateKeyOne()
+{
+    m_keyOne = EncodeBase32(m_signature.data(), m_signature.size());
 }
 
 string CNFTRoyaltyTicket::ToStr() const noexcept
@@ -208,7 +220,7 @@ string CNFTRoyaltyTicket::ToJSON() const noexcept
 
 bool CNFTRoyaltyTicket::FindTicketInDb(const string& key, CNFTRoyaltyTicket& ticket)
 {
-    string_to_vector(key, ticket.m_signature);
+    ticket.m_keyOne = key;
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
 }
 

--- a/src/mnode/tickets/nft-royalty.h
+++ b/src/mnode/tickets/nft-royalty.h
@@ -45,14 +45,16 @@ public:
         newPastelID.clear();
         NFTTxnId.clear();
         m_signature.clear();
+        m_keyOne.clear();
     }
-    std::string KeyOne() const noexcept final { return {m_signature.cbegin(), m_signature.cend()}; }
+    std::string KeyOne() const noexcept final { return m_keyOne; }
     std::string MVKeyOne() const noexcept final { return pastelID; }
     std::string MVKeyTwo() const noexcept final { return NFTTxnId; }
 
     bool HasMVKeyOne() const noexcept final { return true; }
     bool HasMVKeyTwo() const noexcept final { return true; }
-    void SetKeyOne(std::string&& sValue) final { m_signature = string_to_vector(sValue); }
+    void SetKeyOne(std::string&& sValue) final;
+    void GenerateKeyOne() override;
 
     std::string ToJSON() const noexcept final;
     std::string ToStr() const noexcept final;
@@ -76,6 +78,8 @@ public:
         // v0
         READWRITE(NFTTxnId);
         READWRITE(m_signature);
+        if (bRead)
+            GenerateKeyOne();
         READWRITE(m_nTimestamp);
         READWRITE(m_txid);
         READWRITE(m_nBlock);
@@ -91,5 +95,6 @@ protected:
     std::string pastelID;    //pastelID of the old (current at moment of creation) royalty recipient
     std::string newPastelID; //pastelID of the new royalty recipient
     std::string NFTTxnId;    //txid of the NFT for royalty payments
+    std::string m_keyOne;
     v_uint8 m_signature;
 };

--- a/src/mnode/tickets/ticket-extra-fees.cpp
+++ b/src/mnode/tickets/ticket-extra-fees.cpp
@@ -15,7 +15,7 @@ void CTicketSignedWithExtraFees::Clear() noexcept
     CPastelTicket::Clear();
     clear_signatures();
     m_keyOne.clear();
-    m_keyTwo.clear();
+    m_label.clear();
     m_storageFee = 0;
     m_nCreatorHeight = 0;
     m_nRoyalty = 0.0f;
@@ -99,4 +99,12 @@ bool CTicketSignedWithExtraFees::ValidateFees(string& error) const noexcept
     } while (false);
 
     return bRet;
+}
+
+/**
+ * Generate unique random key #1.
+ */
+void CTicketSignedWithExtraFees::GenerateKeyOne()
+{
+    m_keyOne = generateRandomBase32Str(RANDOM_KEY_BASE_LENGTH);
 }

--- a/src/mnode/tickets/ticket-extra-fees.h
+++ b/src/mnode/tickets/ticket-extra-fees.h
@@ -16,9 +16,8 @@ public:
     void Clear() noexcept override;
 
     std::string KeyOne() const noexcept override { return m_keyOne; }
-    std::string KeyTwo() const noexcept override { return m_keyTwo; }
     void SetKeyOne(std::string &&sValue) override { m_keyOne = std::move(sValue); }
-    bool HasKeyTwo() const noexcept override { return true; }
+    void GenerateKeyOne() override;
 
     static CAmount GreenPercent(const unsigned int nHeight) { return GREEN_FEE_PERCENT; }
     static std::string GreenAddress(const unsigned int nHeight);
@@ -40,8 +39,8 @@ public:
 protected:
     uint32_t m_nCreatorHeight{}; // blocknum when the ticket was created by the wallet
 
-    std::string m_keyOne;        // key #1
-    std::string m_keyTwo;        // key #2
+    std::string m_keyOne;        // key #1 (primary)
+    std::string m_label;         // label
     CAmount m_storageFee{};      // ticket storage fee in PSL
 
     float m_nRoyalty{0.0f};      // how much creator(s) should get on all future resales

--- a/src/mnode/tickets/ticket-types.h
+++ b/src/mnode/tickets/ticket-types.h
@@ -1,11 +1,11 @@
 #pragma once
-// Copyright (c) 2021 The Pastel Core developers
+// Copyright (c) 2021-2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <array>
 
-#include "enum_util.h"
+#include <enum_util.h>
 
 // ticket names
 constexpr auto TICKET_NAME_ID_REG                   = "pastelid";               // Pastel ID registration ticket
@@ -98,16 +98,14 @@ constexpr CAmount GREEN_FEE_PERCENT = 2;
 
 constexpr float MAX_ROYALTY = 0.2f;
 constexpr uint16_t MAX_ROYALTY_PERCENT = 20;
+// length of the random string generated as a primary key of the ticket
+constexpr size_t RANDOM_KEY_BASE_LENGTH = 32;
 
 // action ticket types
 enum class ACTION_TICKET_TYPE
 {
     UNKNOWN = 0, // unknown action type (default)
     SENSE = 1,   // Sense - dupe detection
-    CASCADE = 2, // Cascase - storage
+    CASCADE = 2, // Cascade - storage
     COUNT        // number of supported action types
 };
-
-
-
-

--- a/src/mnode/tickets/ticket.h
+++ b/src/mnode/tickets/ticket.h
@@ -145,6 +145,7 @@ public:
     virtual std::string MVKeyThree() const noexcept { return {}; }
 
     virtual void SetKeyOne(std::string &&sValue) = 0;
+    virtual void GenerateKeyOne() {}
 
 protected:
     std::string m_txid;          // ticket transaction id

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -3,24 +3,22 @@
 // Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
-
-#include "random.h"
-
-#include "support/cleanse.h"
 #ifdef WIN32
-#include "compat.h" // for Windows API
-#endif
-#include "serialize.h"        // for begin_ptr(vec)
-#include "util.h"             // for LogPrint()
-#include "utilstrencodings.h" // for GetTime()
-
-#include <limits>
-
-#ifndef WIN32
+#include <compat.h> // for Windows API
+#else
 #include <sys/time.h>
 #endif
+#include <limits>
 
-#include "sodium.h"
+#include <sodium.h>
+
+#include <serialize.h>        // for begin_ptr(vec)
+#include <util.h>             // for LogPrint()
+#include <utilstrencodings.h> // for GetTime()
+#include <random.h>
+#include <support/cleanse.h>
+
+using namespace std;
 
 static inline int64_t GetPerformanceCounter()
 {
@@ -65,6 +63,48 @@ uint256 GetRandHash()
     uint256 hash;
     GetRandBytes((unsigned char*)&hash, sizeof(hash));
     return hash;
+}
+
+/**
+* generate random string and return base85 encoded.
+* 
+* \param nBaseLength - generated random bytes length
+* \return base85 encoded random string (length differs from nBaseLength)
+*/
+string generateRandomBase85Str(const size_t nBaseLength)
+{
+    string s;
+    s.resize(nBaseLength);
+    GetRandBytes(reinterpret_cast<unsigned char *>(s.data()), nBaseLength);
+    return EncodeAscii85(s);
+}
+
+/**
+* generate random string and return base64 encoded.
+* 
+* \param nBaseLength - generated random bytes length
+* \return base64 encoded random string (length differs from nBaseLength)
+*/
+string generateRandomBase64Str(const size_t nBaseLength)
+{
+    string s;
+    s.resize(nBaseLength);
+    GetRandBytes(reinterpret_cast<unsigned char *>(s.data()), nBaseLength);
+    return EncodeBase64(s);
+}
+
+/**
+* generate random string and return base64 encoded.
+* 
+* \param nBaseLength - generated random bytes length
+* \return base32 encoded random string (length differs from nBaseLength)
+*/
+string generateRandomBase32Str(const size_t nBaseLength)
+{
+    string s;
+    s.resize(nBaseLength);
+    GetRandBytes(reinterpret_cast<unsigned char *>(s.data()), nBaseLength);
+    return EncodeBase32(s);
 }
 
 uint32_t insecure_rand_Rz = 11;

--- a/src/random.h
+++ b/src/random.h
@@ -1,15 +1,13 @@
+#pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_RANDOM_H
-#define BITCOIN_RANDOM_H
-
-#include "uint256.h"
-
 #include <functional>
 #include <stdint.h>
+
+#include <uint256.h>
 
 /**
  * Functions to gather random data via the libsodium CSPRNG
@@ -18,6 +16,13 @@ void GetRandBytes(unsigned char* buf, size_t num);
 uint64_t GetRand(uint64_t nMax);
 int GetRandInt(int nMax);
 uint256 GetRandHash();
+
+// generate random string and return base85 encoded.
+std::string generateRandomBase85Str(const size_t nBaseLength);
+// generate random string and return base64 encoded.
+std::string generateRandomBase64Str(const size_t nBaseLength);
+// generate random string and return base32 encoded.
+std::string generateRandomBase32Str(const size_t nBaseLength);
 
 /**
  * Identity function for MappedShuffle, so that elements retain their original order.
@@ -41,7 +46,7 @@ void MappedShuffle(RandomAccessIterator first,
                    std::function<int(int)> gen)
 {
     for (size_t i = len-1; i > 0; --i) {
-        auto r = gen(i+1);
+        auto r = gen(static_cast<int>(i+1));
         assert(r >= 0);
         assert(r <= i);
         std::swap(first[i], first[r]);
@@ -71,4 +76,3 @@ static inline uint32_t insecure_rand(void)
     return (insecure_rand_Rw << 16) + insecure_rand_Rz;
 }
 
-#endif // BITCOIN_RANDOM_H

--- a/src/rpc/rpc_consts.h
+++ b/src/rpc/rpc_consts.h
@@ -1,7 +1,7 @@
 #pragma once
-// Copyright (c) 2021 Pastel Core developers
+// Copyright (c) 2021-2022 Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 // rpc response object keys
 constexpr auto RPC_KEY_RESULT					= "result";
@@ -13,6 +13,7 @@ constexpr auto RPC_KEY_PASTELID					= "pastelid";
 constexpr auto RPC_KEY_LEGROAST					= "legRoastKey";
 constexpr auto RPC_KEY_CODE                     = "code";
 constexpr auto RPC_KEY_MESSAGE                  = "message";
+constexpr auto RPC_KEY_KEY						= "key";
 
 // rpc response object key values
 constexpr auto RPC_RESULT_FAILED				= "failed";

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -237,5 +237,4 @@ namespace std
             return seed;
         }
     };
-
 }

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -1,21 +1,20 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#include "utilstrencodings.h"
-#include "ascii85.h"
-
-#include "tinyformat.h"
-#include "vector_types.h"
-#include "str_utils.h"
-#include "util.h"
-
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <cstdlib>
 #include <cstring>
 #include <errno.h>
 #include <iomanip>
 #include <limits>
+
+#include <utilstrencodings.h>
+#include <ascii85.h>
+#include <tinyformat.h>
+#include <vector_types.h>
+#include <str_utils.h>
+#include <util.h>
 
 using namespace std;
 
@@ -142,19 +141,19 @@ string EncodeAscii85(const unsigned char* istr, size_t len) noexcept
         if (nMaxLength <= 0)
             break;
         
-        v_uint8 vOut;
-        vOut.resize(nMaxLength);
-
-        const int32_t nEncodedLength = encode_ascii85(reinterpret_cast<const uint8_t*>(istr), nInputSize, vOut.data(), nMaxLength);
+        sRetVal.resize(nMaxLength);
+        const int32_t nEncodedLength = encode_ascii85(reinterpret_cast<const uint8_t*>(istr), nInputSize, reinterpret_cast<uint8_t*>(sRetVal.data()), nMaxLength);
         if (nEncodedLength > 0)
-            sRetVal.assign(vOut.cbegin(), vOut.cbegin() + nEncodedLength);
+            sRetVal.resize(nEncodedLength);
+        else
+            sRetVal.clear();
     } while (false);
     return sRetVal;
 }
 
 string EncodeAscii85(const string& str) noexcept
 {
-    return EncodeAscii85(reinterpret_cast<const unsigned char *>(str.c_str()), str.size());
+    return EncodeAscii85(reinterpret_cast<const unsigned char *>(str.data()), str.size());
 }
 
 v_uint8 DecodeAscii85(const char* ostr, bool* pfInvalid) noexcept
@@ -322,7 +321,8 @@ v_uint8 DecodeBase32(const char* p, bool* pfInvalid)
     const char* e = p;
     v_uint8 val;
     val.reserve(strlen(p));
-    while (*p != 0) {
+    while (*p != 0)
+    {
         int x = decode32_table[(unsigned char)*p];
         if (x == -1) break;
         val.push_back(x);
@@ -334,15 +334,18 @@ v_uint8 DecodeBase32(const char* p, bool* pfInvalid)
     bool valid = ConvertBits<5, 8, false>([&](unsigned char c) { ret.push_back(c); }, val.begin(), val.end());
 
     const char* q = p;
-    while (valid && *p != 0) {
-        if (*p != '=') {
+    while (valid && *p != 0)
+    {
+        if (*p != '=')
+        {
             valid = false;
             break;
         }
         ++p;
     }
     valid = valid && (p - e) % 8 == 0 && p - q < 8;
-    if (pfInvalid) *pfInvalid = !valid;
+    if (pfInvalid)
+        *pfInvalid = !valid;
 
     return ret;
 }

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -1,13 +1,15 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 /**
  * Utilities for converting data from/to strings.
  */
 #include <stdint.h>
+
 #include "vector_types.h"
 
 #define BEGIN(a)            ((char*)&(a))


### PR DESCRIPTION
- key1 (primary key) is generated in pasteld internally for tickets: NFT, NFT collection and Action.
- removed "key1" RPC API parameter from "tickets register ..."
- "key2" RPC API parameter has been renamed to "label", label is not used anymore as a secondary key
Changed APIs:
  tickets register nft "{nft-ticket}" "{signatures}" "pastelid" "passphrase" "label" "fee" ["address"]
  tickets register nft-collection "{nft-collection-ticket}" "{signatures}" "pastelid" "passphrase" "label" "fee" ["address"]
  tickets register action "action-ticket" "{signatures}" "pastelid" "passphrase" "label" "fee" ["address"]
  tickets tools gettotalstoragefee "ticket" "{signatures}" "pastelid" "passphrase" "label" "fee" "imagesize"
- "tickets register" API returns now generated primary key "key" in addition to "txid"
- added gtests for random key generation
- fixed RPC APIs in python tests:
   - mn_tickets.py
   - mn_tickets_validation.py
   - mn_expiration.py