### PR TITLE
[PSL-348] Add RCP API to search NFT,NFT collection, Action tickets by label

### DIFF
--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
@@ -128,6 +128,7 @@
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-activate.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-fake.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-find.cpp" />
+    <ClCompile Include="..\..\..\src\mnode\rpc\tickets-findbylabel.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-get.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-list.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-register.cpp" />
@@ -216,6 +217,7 @@
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-activate.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-fake.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-find.h" />
+    <ClInclude Include="..\..\..\src\mnode\rpc\tickets-findbylabel.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-get.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-list.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-register.h" />

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
@@ -298,6 +298,9 @@
     <ClCompile Include="..\..\..\src\mnode\tickets\nft-collection-act.cpp">
       <Filter>Source Files\mnode\tickets</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\mnode\rpc\tickets-findbylabel.cpp">
+      <Filter>Source Files\mnode\rpc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\addrman.h">
@@ -638,6 +641,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\src\mnode\tickets\nft-collection-act.h">
       <Filter>Source Files\mnode\tickets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\mnode\rpc\tickets-findbylabel.h">
+      <Filter>Source Files\mnode\rpc</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/qa/rpc-tests/mn_tickets.py
+++ b/qa/rpc-tests/mn_tickets.py
@@ -180,7 +180,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.action_reg_ticket_tests("sense", "sense-action-label")
         self.action_activate_ticket_tests(False)
         self.nft_collection_reg_ticket_tests(TEST_COLLECTION_NAME + " #1", "coll-label")
-        self.nft_collection_tests("v2-coll-label")
+        self.nft_collection_tests("coll-label-v2")
         self.nft_collection_activate_ticket_tests(False)
 
         self.nft_reg_ticket_tests("nft-label")
@@ -232,7 +232,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             self.nft_reg_ticket_tests("nft-label2")
             self.nft_activate_ticket_tests(True)
             self.nft_collection_reg_ticket_tests(TEST_COLLECTION_NAME + " #2", "coll-label2")
-            self.nft_collection_tests("v2_coll-label2")
+            self.nft_collection_tests("coll-label2-v2")
             self.nft_collection_activate_ticket_tests(True)
             self.nft_sell_ticket_tests(True)
             self.nft_buy_ticket_tests(True)
@@ -1069,7 +1069,9 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         assert_equal(result, "OK")
 
         #       3. by fingerprints, compare to ticket from 2 (label)
-        tkt2 = self.nodes[self.non_mn3].tickets("find", ticket_type, label)["ticket"]
+        lblNodes = self.nodes[self.non_mn3].tickets("findbylabel", ticket_type, label)
+        assert_equal(1, len(lblNodes), f"findbylabel {ticket_type} {label} was supposed to return only one ticket")
+        tkt2 = lblNodes[0]["ticket"]
         assert_equal(tkt2["type"], "action-reg")
         assert_equal(tkt2["action_ticket"], self.ticket)
         assert_equal(tkt2["key"], ticket_key)
@@ -1160,11 +1162,6 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         print(f"NFT collection registration ticket price - {self.nftcoll_reg_ticket_price}")
         assert_equal(coins_after, coins_before-self.nftcoll_reg_ticket_price)  # no fee yet, but ticket cost NFT ticket price
 
-
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, f"This NFT collection '{nft_collection_name}' is already registered in blockchain",
-            self.nodes[self.top_mns_index0].tickets, "register", ticket_type,
-            self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, self.passphrase, label, str(self.storage_fee))
-
         #   c.b find registration ticket
         #       c.b.1 by creators PastelID (this is MultiValue key)
         # TODO Pastel:
@@ -1200,7 +1197,9 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         assert_equal(result, "OK")
 
         #       c.b.3 by fingerprints, compare to ticket from c.b.2 (label)
-        tkt2 = self.nodes[self.non_mn3].tickets("find", ticket_type, label)["ticket"]
+        lblNodes = self.nodes[self.non_mn3].tickets("findbylabel", ticket_type, label)
+        assert_equal(1, len(lblNodes), f"findbylabel {ticket_type} {label} was supposed to return only one ticket")
+        tkt2 = lblNodes[0]["ticket"]
         assert_equal(tkt2['type'], "nft-collection-reg")
         assert_equal(tkt2['nft_collection_ticket'], self.ticket)
         assert_equal(tkt2["key"], ticket_key)
@@ -1553,11 +1552,6 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         print(f"NFT registration ticket price - {self.nftreg_ticket_price}")
         assert_equal(coins_after, coins_before-self.nftreg_ticket_price)  # no fee yet, but ticket cost NFT ticket price
 
-        #       c.a.8 fail if already registered
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, "This NFT is already registered in blockchain",
-            self.nodes[self.top_mns_index0].tickets, "register", ticket_type,
-            self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, self.passphrase, label, str(self.storage_fee))
-
         #   c.b find registration ticket
         #       c.b.1 by creators PastelID (this is MultiValue key)
         # TODO Pastel:
@@ -1588,7 +1582,9 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         assert_equal(result, "OK")
 
         #       c.b.3 by fingerprints, compare to ticket from c.b.2 (label)
-        tkt2 = self.nodes[self.non_mn3].tickets("find", ticket_type, label)["ticket"]
+        lblNodes = self.nodes[self.non_mn3].tickets("findbylabel", ticket_type, label)
+        assert_equal(1, len(lblNodes), f"findbylabel {ticket_type} {label} was supposed to return only one ticket")
+        tkt2 = lblNodes[0]["ticket"]
         assert_equal(tkt2['type'], "nft-reg")
         assert_equal(tkt2['nft_ticket'], self.ticket)
         assert_equal(tkt2["key"], ticket1_key)
@@ -2717,7 +2713,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         nft_ticket2_txid = self.nodes[self.top_mns_index0].tickets("register", "nft",
                                                                    self.ticket, json.dumps(self.signatures_dict),
                                                                    self.top_mn_pastelid0, self.passphrase,
-                                                                   "key3"+str(loop_number), "key4"+str(loop_number), str(self.storage_fee))["txid"]
+                                                                   "nft-label3_"+str(loop_number), str(self.storage_fee))["txid"]
         assert_true(nft_ticket2_txid, "No ticket was created")
         self.__wait_for_ticket_tnx()
 
@@ -2735,7 +2731,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         nft_ticket3_txid = self.nodes[self.top_mns_index0].tickets("register", "nft",
                                                                    self.ticket, json.dumps(self.signatures_dict),
                                                                    self.top_mn_pastelid0, self.passphrase,
-                                                                   "key5"+str(loop_number), "key6"+str(loop_number), str(self.storage_fee))["txid"]
+                                                                   "nft-label4_"+str(loop_number), str(self.storage_fee))["txid"]
         assert_true(nft_ticket3_txid, "No ticket was created")
         self.__wait_for_ticket_tnx()
 

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) 2014-2016 The Bitcoin Core developers
+# Copyright (c) 2018-2022 The Pastel Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
-
 
 #
 # Helpful routines for regression testing
@@ -263,7 +263,8 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
         '-nuparams=5ba81b19:1', # Overwinter
         '-nuparams=76b809bb:1', # Sapling
     ])
-    if extra_args is not None: args.extend(extra_args)
+    if extra_args is not None:
+        args.extend(extra_args)
     pasteld_processes[i] = subprocess.Popen(args)
     devnull = open("/dev/null", "w+")
     if os.getenv("PYTHON_DEBUG", ""):
@@ -276,9 +277,9 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     devnull.close()
     url = "http://rt:rt@%s:%d" % (rpchost or '127.0.0.1', rpc_port(i))
     if timewait is not None:
-        proxy = AuthServiceProxy(url, timeout=timewait)
+        proxy = AuthServiceProxy(url, timeout=timewait, _alias=str(i))
     else:
-        proxy = AuthServiceProxy(url)
+        proxy = AuthServiceProxy(url, _alias=str(i))
     proxy.url = url # store URL on proxy for info
     return proxy
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,6 +125,7 @@ MNODE_CPP =\
   mnode/rpc/tickets-list.cpp\
   mnode/rpc/tickets-register.cpp\
   mnode/rpc/tickets-find.cpp\
+  mnode/rpc/tickets-findbylabel.cpp\
   mnode/rpc/tickets-get.cpp\
   mnode/rpc/tickets-tools.cpp\
   mnode/tickets/action-reg.cpp\
@@ -174,6 +175,7 @@ MNODE_H = \
   mnode/rpc/tickets-list.h\
   mnode/rpc/tickets-register.h\
   mnode/rpc/tickets-find.h\
+  mnode/rpc/tickets-findbylabel.h\
   mnode/rpc/tickets-get.h\
   mnode/rpc/tickets-tools.h\
   mnode/tickets/action-reg.h\

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -9,6 +9,7 @@
 #include <sys/ioctl.h>
 #endif
 #include <unistd.h>
+#include <inttypes.h>
 
 #include <boost/thread/synchronized_value.hpp>
 
@@ -22,23 +23,25 @@
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 
+using namespace std;
 
 void AtomicTimer::start()
 {
-    std::unique_lock<std::mutex> lock(mtx);
-    if (threads < 1) {
+    unique_lock<mutex> lock(mtx);
+    if (threads < 1)
         start_time = GetTime();
-    }
     ++threads;
 }
 
 void AtomicTimer::stop()
 {
-    std::unique_lock<std::mutex> lock(mtx);
+    unique_lock<mutex> lock(mtx);
     // Ignore excess calls to stop()
-    if (threads > 0) {
+    if (threads > 0)
+    {
         --threads;
-        if (threads < 1) {
+        if (threads < 1)
+        {
             int64_t time_span = GetTime() - start_time;
             total_time += time_span;
         }
@@ -47,21 +50,22 @@ void AtomicTimer::stop()
 
 bool AtomicTimer::running()
 {
-    std::unique_lock<std::mutex> lock(mtx);
+    unique_lock<mutex> lock(mtx);
     return threads > 0;
 }
 
 uint64_t AtomicTimer::threadCount()
 {
-    std::unique_lock<std::mutex> lock(mtx);
+    unique_lock<mutex> lock(mtx);
     return threads;
 }
 
 double AtomicTimer::rate(const AtomicCounter& count)
 {
-    std::unique_lock<std::mutex> lock(mtx);
+    unique_lock<mutex> lock(mtx);
     int64_t duration = total_time;
-    if (threads > 0) {
+    if (threads > 0)
+    {
         // Timer is running, so get the latest count
         duration += GetTime() - start_time;
     }
@@ -70,18 +74,17 @@ double AtomicTimer::rate(const AtomicCounter& count)
 
 static CCriticalSection cs_metrics;
 
-static boost::synchronized_value<int64_t> nNodeStartTime;
-static boost::synchronized_value<int64_t> nNextRefresh;
+static atomic_uint64_t nNodeStartTime;
+static atomic_uint64_t nNextRefresh;
 AtomicCounter transactionsValidated;
 AtomicCounter ehSolverRuns;
 AtomicCounter solutionTargetChecks;
 static AtomicCounter minedBlocks;
 AtomicTimer miningTimer;
 
-static boost::synchronized_value<std::list<uint256>> trackedBlocks;
-
-static boost::synchronized_value<std::list<std::string>> messageBox;
-static boost::synchronized_value<std::string> initMessage;
+static boost::synchronized_value<list<uint256>> trackedBlocks;
+static boost::synchronized_value<list<string>> messageBox;
+static boost::synchronized_value<string> initMessage;
 static bool loaded = false;
 
 extern int64_t GetNetworkHashPS(int lookup, int height);
@@ -95,12 +98,12 @@ void TrackMinedBlock(uint256 hash)
 
 void MarkStartTime()
 {
-    *nNodeStartTime = GetTime();
+    nNodeStartTime = GetTime();
 }
 
 int64_t GetUptime()
 {
-    return GetTime() - *nNodeStartTime;
+    return GetTime() - nNodeStartTime;
 }
 
 double GetLocalSolPS()
@@ -115,18 +118,17 @@ int EstimateNetHeightInner(int height, int64_t tipmediantime,
     // We average the target spacing with the observed spacing to the last
     // checkpoint (either from below or above depending on the current height),
     // and use that to estimate the current network height.
-    int medianHeight = height > CBlockIndex::nMedianTimeSpan ?
+    const int medianHeight = height > CBlockIndex::nMedianTimeSpan ?
             height - (1 + ((CBlockIndex::nMedianTimeSpan - 1) / 2)) :
             height / 2;
     
     double checkpointSpacing = 0;
-    if (medianHeight > heightLastCheckpoint) {
+    if (medianHeight > heightLastCheckpoint)
         checkpointSpacing = (double (tipmediantime - timeLastCheckpoint)) / (medianHeight - heightLastCheckpoint);
-    } else if (heightLastCheckpoint != 0) {
+    else if (heightLastCheckpoint != 0)
         checkpointSpacing = (double (timeLastCheckpoint - genesisTime)) / heightLastCheckpoint;
-    }
-    double averageSpacing = checkpointSpacing == 0? targetSpacing: (targetSpacing + checkpointSpacing) / 2;
-    int netheight = medianHeight + ((GetTime() - tipmediantime) / averageSpacing);
+    const double averageSpacing = checkpointSpacing == 0? targetSpacing: (targetSpacing + checkpointSpacing) / 2;
+    const int netheight = medianHeight + static_cast<int>((GetTime() - tipmediantime) / averageSpacing);
     // Round to nearest ten to reduce noise
     return ((netheight + 5) / 10) * 10;
 }
@@ -144,19 +146,19 @@ int EstimateNetHeight(int height, int64_t tipmediantime, CChainParams chainParam
 
 void TriggerRefresh()
 {
-    *nNextRefresh = GetTime();
+    nNextRefresh = GetTime();
     // Ensure that the refresh has started before we return
     MilliSleep(200);
 }
 
-static bool metrics_ThreadSafeMessageBox(const std::string& message,
-                                      const std::string& caption,
+static bool metrics_ThreadSafeMessageBox(const string& message,
+                                      const string& caption,
                                       unsigned int style)
 {
     // The SECURE flag has no effect in the metrics UI.
     style &= ~CClientUIInterface::SECURE;
 
-    std::string strCaption;
+    string strCaption;
     // Check for usage of predefined caption
     switch (style) {
     case CClientUIInterface::MSG_ERROR:
@@ -172,7 +174,7 @@ static bool metrics_ThreadSafeMessageBox(const std::string& message,
         strCaption += caption; // Use supplied caption (can be empty)
     }
 
-    boost::strict_lock_ptr<std::list<std::string>> u = messageBox.synchronize();
+    boost::strict_lock_ptr<list<string>> u = messageBox.synchronize();
     u->push_back(strCaption + ": " + message);
     if (u->size() > 5) {
         u->pop_back();
@@ -182,12 +184,12 @@ static bool metrics_ThreadSafeMessageBox(const std::string& message,
     return false;
 }
 
-static bool metrics_ThreadSafeQuestion(const std::string& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style)
+static bool metrics_ThreadSafeQuestion(const string& /* ignored interactive message */, const string& message, const string& caption, unsigned int style)
 {
     return metrics_ThreadSafeMessageBox(message, caption, style);
 }
 
-static void metrics_InitMessage(const std::string& message)
+static void metrics_InitMessage(const string& message)
 {
     *initMessage = message;
 }
@@ -224,17 +226,18 @@ int printStats(bool mining)
     if (fnIsInitialBlockDownload(consensusParams)) {
         int netheight = EstimateNetHeight(height, tipmediantime, Params());
         int downloadPercent = netheight == 0? netheight: height * 100 / netheight;
-        std::cout << "     " << _("Downloading blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << std::endl;
-    } else {
-        std::cout << "           " << _("Block height") << " | " << height << std::endl;
-    }
-    std::cout << "            " << _("Connections") << " | " << connections << std::endl;
-    std::cout << "  " << _("Network solution rate") << " | " << netsolps << " Sol/s" << std::endl;
-    if (mining && miningTimer.running()) {
-        std::cout << "    " << _("Local solution rate") << " | " << strprintf("%.4f Sol/s", localsolps) << std::endl;
+        cout << "     " << _("Downloading blocks") << " | " << height << " / ~" << netheight << " (" << downloadPercent << "%)" << endl;
+    } else
+        cout << "           " << _("Block height") << " | " << height << endl;
+    
+    cout << "            " << _("Connections") << " | " << connections << endl;
+    cout << "  " << _("Network solution rate") << " | " << netsolps << " Sol/s" << endl;
+    if (mining && miningTimer.running())
+    {
+        cout << "    " << _("Local solution rate") << " | " << strprintf("%.4f Sol/s", localsolps) << endl;
         lines++;
     }
-    std::cout << std::endl;
+    cout << endl;
 
     return lines;
 }
@@ -249,8 +252,8 @@ int printMiningStatus(bool mining)
         auto nThreads = miningTimer.threadCount();
         const auto& consensusParams = Params().GetConsensus();
         if (nThreads > 0) {
-            std::cout << strprintf(_("You are mining with the %s solver on %d threads."),
-                                   GetArg("-equihashsolver", "default"), nThreads) << std::endl;
+            cout << strprintf(_("You are mining with the %s solver on %d threads."),
+                                   GetArg("-equihashsolver", "default"), nThreads) << endl;
         } else {
             bool fvNodesEmpty;
             {
@@ -258,20 +261,20 @@ int printMiningStatus(bool mining)
                 fvNodesEmpty = vNodes.empty();
             }
             if (fvNodesEmpty) {
-                std::cout << _("Mining is paused while waiting for connections.") << std::endl;
+                cout << _("Mining is paused while waiting for connections.") << endl;
             } else if (fnIsInitialBlockDownload(consensusParams)) {
-                std::cout << _("Mining is paused while downloading blocks.") << std::endl;
+                cout << _("Mining is paused while downloading blocks.") << endl;
             } else {
-                std::cout << _("Mining is paused (a JoinSplit may be in progress).") << std::endl;
+                cout << _("Mining is paused (a JoinSplit may be in progress).") << endl;
             }
         }
         lines++;
     } else {
-        std::cout << _("You are currently not mining.") << std::endl;
-        std::cout << _("To enable mining, add 'gen=1' to your pastel.conf and restart.") << std::endl;
+        cout << _("You are currently not mining.") << endl;
+        cout << _("To enable mining, add 'gen=1' to your pastel.conf and restart.") << endl;
         lines += 2;
     }
-    std::cout << std::endl;
+    cout << endl;
 
     return lines;
 #else // ENABLE_MINING
@@ -285,118 +288,118 @@ int printMetrics(size_t cols, bool mining)
     int lines = 3;
 
     // Calculate uptime
-    int64_t uptime = GetUptime();
-    int days = uptime / (24 * 60 * 60);
-    int hours = (uptime - (days * 24 * 60 * 60)) / (60 * 60);
-    int minutes = (uptime - (((days * 24) + hours) * 60 * 60)) / 60;
-    int seconds = uptime - (((((days * 24) + hours) * 60) + minutes) * 60);
+    const int64_t uptime = GetUptime();
+    const int days = static_cast<int>(uptime / (24 * 60 * 60));
+    const int hours = static_cast<int>((uptime - (days * 24 * 60 * 60)) / (60 * 60));
+    const int minutes = static_cast<int>((uptime - (((days * 24) + hours) * 60 * 60)) / 60);
+    const int seconds = static_cast<int>(uptime - (((((days * 24) + hours) * 60) + minutes) * 60));
 
     // Display uptime
-    std::string duration;
-    if (days > 0) {
+    string duration;
+    if (days > 0)
         duration = strprintf(_("%d days, %d hours, %d minutes, %d seconds"), days, hours, minutes, seconds);
-    } else if (hours > 0) {
+    else if (hours > 0)
         duration = strprintf(_("%d hours, %d minutes, %d seconds"), hours, minutes, seconds);
-    } else if (minutes > 0) {
+    else if (minutes > 0)
         duration = strprintf(_("%d minutes, %d seconds"), minutes, seconds);
-    } else {
+    else
         duration = strprintf(_("%d seconds"), seconds);
-    }
-    std::string strDuration = strprintf(_("Since starting this node %s ago:"), duration);
-    std::cout << strDuration << std::endl;
-    lines += (strDuration.size() / cols);
 
-    int validatedCount = transactionsValidated.get();
-    if (validatedCount > 1) {
-      std::cout << "- " << strprintf(_("You have validated %d transactions!"), validatedCount) << std::endl;
-    } else if (validatedCount == 1) {
-      std::cout << "- " << _("You have validated a transaction!") << std::endl;
-    } else {
-      std::cout << "- " << _("You have validated no transactions.") << std::endl;
-    }
+    string strDuration = strprintf(_("Since starting this node %s ago:"), duration);
+    cout << strDuration << endl;
+    lines += static_cast<int>(strDuration.size() / cols);
 
-    if (mining && loaded) {
-        std::cout << "- " << strprintf(_("You have completed %d Equihash solver runs."), ehSolverRuns.get()) << std::endl;
+    const auto validatedCount = transactionsValidated.get();
+    if (validatedCount > 1)
+      cout << "- " << strprintf(_("You have validated %d transactions!"), validatedCount) << endl;
+    else if (validatedCount == 1)
+      cout << "- " << _("You have validated a transaction!") << endl;
+    else
+      cout << "- " << _("You have validated no transactions.") << endl;
+
+    if (mining && loaded)
+    {
+        cout << "- " << strprintf(_("You have completed %d Equihash solver runs."), ehSolverRuns.get()) << endl;
         lines++;
 
-        int mined = 0;
-        int orphaned = 0;
+        uint64_t mined = 0;
+        uint64_t orphaned = 0;
         CAmount immature {0};
         CAmount mature {0};
         {
             LOCK2(cs_main, cs_metrics);
-            boost::strict_lock_ptr<std::list<uint256>> u = trackedBlocks.synchronize();
+            boost::strict_lock_ptr<list<uint256>> u = trackedBlocks.synchronize();
             auto consensusParams = Params().GetConsensus();
             auto tipHeight = chainActive.Height();
 
             // Update orphans and calculate subsidies
-            std::list<uint256>::iterator it = u->begin();
-            while (it != u->end()) {
+            auto it = u->begin();
+            while (it != u->end())
+            {
                 auto hash = *it;
                 if (mapBlockIndex.count(hash) > 0 &&
-                        chainActive.Contains(mapBlockIndex[hash])) {
+                        chainActive.Contains(mapBlockIndex[hash]))
+                {
                     int height = mapBlockIndex[hash]->nHeight;
                     CAmount subsidy = GetBlockSubsidy(height, consensusParams);
-                    if (std::max(0, COINBASE_MATURITY - (tipHeight - height)) > 0) {
+                    if (max(0, COINBASE_MATURITY - (tipHeight - height)) > 0)
                         immature += subsidy;
-                    } else {
+                    else
                         mature += subsidy;
-                    }
                     it++;
-                } else {
+                } else
                     it = u->erase(it);
-                }
             }
 
             mined = minedBlocks.get();
             orphaned = mined - u->size();
         }
 
-        if (mined > 0) {
-            std::string units = Params().CurrencyUnits();
-            std::cout << "- " << strprintf(_("You have mined %d blocks!"), mined) << std::endl;
-            std::cout << "  "
-                      << strprintf(_("Orphaned: %d blocks, Immature: %u %s, Mature: %u %s"),
+        if (mined > 0)
+        {
+            string units = Params().CurrencyUnits();
+            cout << "- " << strprintf(_("You have mined %" PRIu64 " blocks!"), mined) << endl;
+            cout << "  "
+                      << strprintf(_("Orphaned: %" PRIu64 " blocks, Immature: %u %s, Mature: %u %s"),
                                      orphaned,
                                      FormatMoney(immature), units,
                                      FormatMoney(mature), units)
-                      << std::endl;
+                      << endl;
             lines += 2;
         }
     }
-    std::cout << std::endl;
+    cout << endl;
 
     return lines;
 }
 
 int printMessageBox(size_t cols)
 {
-    boost::strict_lock_ptr<std::list<std::string>> u = messageBox.synchronize();
+    boost::strict_lock_ptr<list<string>> u = messageBox.synchronize();
 
-    if (u->size() == 0) {
+    if (u->size() == 0)
         return 0;
-    }
 
-    int lines = 2 + u->size();
-    std::cout << _("Messages:") << std::endl;
-    for (auto it = u->cbegin(); it != u->cend(); ++it) {
+    int lines = static_cast<int>(2 + u->size());
+    cout << _("Messages:") << endl;
+    for (auto it = u->cbegin(); it != u->cend(); ++it)
+    {
         auto msg = FormatParagraph(*it, cols, 2);
-        std::cout << "- " << msg << std::endl;
+        cout << "- " << msg << endl;
         // Handle newlines and wrapped lines
         size_t i = 0;
         size_t j = 0;
-        while (j < msg.size()) {
+        while (j < msg.size())
+        {
             i = msg.find('\n', j);
-            if (i == std::string::npos) {
+            if (i == string::npos)
                 i = msg.size();
-            } else {
-                // Newline
+            else // Newline
                 lines++;
-            }
             j = i + 1;
         }
     }
-    std::cout << std::endl;
+    cout << endl;
     return lines;
 }
 
@@ -406,9 +409,9 @@ int printInitMessage()
         return 0;
     }
 
-    std::string msg = *initMessage;
-    std::cout << _("Init message:") << " " << msg << std::endl;
-    std::cout << std::endl;
+    string msg = *initMessage;
+    cout << _("Init message:") << " " << msg << endl;
+    cout << endl;
 
     if (msg == _("Done loading")) {
         loaded = true;
@@ -445,14 +448,14 @@ void SendVTSequence(const char *szVTcmd)
 {
     if (!szVTcmd)
         return;
-    std::string s;
+    string s;
 #ifdef WIN32
     s = "\x1b[";
 #else
     s = "\e[";
 #endif
     s += szVTcmd;
-    std::cout << s;
+    cout << s;
 }
 
 void ThreadShowMetricsScreen()
@@ -473,19 +476,20 @@ void ThreadShowMetricsScreen()
         SendVTSequence("2J");
 
         // Print art
-        // std::cout << METRICS_ART << std::endl;
-        // std::cout << std::endl;
+        // cout << METRICS_ART << endl;
+        // cout << endl;
 
         // Thank you text
-        std::cout << _("Thank you for running a Pastel node!") << std::endl;
-        std::cout << _("You're helping to strengthen the network and contributing to a social good :)") << std::endl;
+        cout << _("Thank you for running a Pastel node!") << endl;
+        cout << _("You're helping to strengthen the network and contributing to a social good :)") << endl;
 
         // Privacy notice text
-        std::cout << PrivacyInfo();
-        std::cout << std::endl;
+        cout << PrivacyInfo();
+        cout << endl;
     }
 
-    while (true) {
+    while (true)
+    {
         // Number of lines that are always displayed
         int lines = 1;
         int cols = 80;
@@ -494,15 +498,13 @@ void ThreadShowMetricsScreen()
         if (isTTY) {
 #ifdef WIN32
             CONSOLE_SCREEN_BUFFER_INFO csbi;
-            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi) != 0) {
+            if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi) != 0)
                 cols = csbi.srWindow.Right - csbi.srWindow.Left + 1;
-            }
 #else
             struct winsize w;
             w.ws_col = 0;
-            if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) != -1 && w.ws_col != 0) {
+            if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) != -1 && w.ws_col != 0)
                 cols = w.ws_col;
-            }
 #endif
         }
 
@@ -517,7 +519,8 @@ void ThreadShowMetricsScreen()
         bool mining = false;
 #endif
 
-        if (loaded) {
+        if (loaded)
+        {
             lines += printStats(mining);
             lines += printMiningStatus(mining);
         }
@@ -527,20 +530,20 @@ void ThreadShowMetricsScreen()
 
         if (isScreen) {
             // Explain how to exit
-            std::cout << "[";
+            cout << "[";
 #ifdef WIN32
-            std::cout << _("'pascal-cli.exe stop' to exit");
+            cout << _("'pascal-cli.exe stop' to exit");
 #else
-            std::cout << _("Press Ctrl+C to exit");
+            cout << _("Press Ctrl+C to exit");
 #endif
-            std::cout << "] [" << _("Set 'showmetrics=0' to hide") << "]" << std::endl;
+            cout << "] [" << _("Set 'showmetrics=0' to hide") << "]" << endl;
         } else {
             // Print delineator
-            std::cout << "----------------------------------------" << std::endl;
+            cout << "----------------------------------------" << endl;
         }
 
-        *nNextRefresh = GetTime() + nRefresh;
-        while (GetTime() < *nNextRefresh)
+        nNextRefresh = GetTime() + nRefresh;
+        while (static_cast<uint64_t>(GetTime()) < nNextRefresh)
         {
             func_thread_interrupt_point();
             MilliSleep(200);

--- a/src/mnode/rpc/mnode-rpc.cpp
+++ b/src/mnode/rpc/mnode-rpc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -18,6 +18,7 @@
 #include <mnode/rpc/tickets-list.h>
 #include <mnode/rpc/tickets-register.h>
 #include <mnode/rpc/tickets-find.h>
+#include <mnode/rpc/tickets-findbylabel.h>
 #include <mnode/rpc/tickets-get.h>
 #include <mnode/rpc/tickets-tools.h>
 #include <mnode/rpc/storage-fee.h>
@@ -307,9 +308,9 @@ Retrieve "data" from the blockchain by "txid".)"
 UniValue tickets(const UniValue& params, bool fHelp)
 {
 #ifdef FAKE_TICKET
-    RPC_CMD_PARSER(TICKETS, params, Register, activate, find, list, get, tools, makefaketicket, sendfaketicket);
+    RPC_CMD_PARSER(TICKETS, params, Register, activate, find, findbylabel, list, get, tools, makefaketicket, sendfaketicket);
 #else
-    RPC_CMD_PARSER(TICKETS, params, Register, activate, find, list, get, tools);
+    RPC_CMD_PARSER(TICKETS, params, Register, activate, find, findbylabel, list, get, tools);
 #endif // FAKE_TICKET
 	if (fHelp || !TICKETS.IsCmdSupported())
 		throw runtime_error(
@@ -320,12 +321,13 @@ Arguments:
 1. "command"        (string or set of strings, required) The command to execute
 
 Available commands:
-  register ... - Register specific Pastel tickets into the blockchain. If successful, returns "txid".
-  activate ... - Activate Pastel tickets.
-  find ...     - Find specific Pastel tickets in the blockchain.
-  list ...     - List all specific Pastel tickets in the blockchain.
-  get  ...     - Get Pastel ticket by txid.
-  tools...     - Pastel ticket tools.
+  register    ... - Register specific Pastel tickets into the blockchain. If successful, returns "txid".
+  activate    ... - Activate Pastel tickets.
+  find        ... - Find specific Pastel tickets in the blockchain.
+  findbylabel ... - Find specific Pastel tickets in the blockchain by label.
+  list        ... - List all specific Pastel tickets in the blockchain.
+  get         ... - Get Pastel ticket by txid.
+  tools       ... - Pastel ticket tools.
 
 Examples:
 )"
@@ -344,6 +346,9 @@ Examples:
 
         case RPC_CMD_TICKETS::find:
             return tickets_find(params);
+
+        case RPC_CMD_TICKETS::findbylabel:
+            return tickets_findbylabel(params);
 
         case RPC_CMD_TICKETS::list:
             return tickets_list(params);

--- a/src/mnode/rpc/tickets-find.cpp
+++ b/src/mnode/rpc/tickets-find.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -18,14 +18,16 @@ static UniValue getTickets(const std::string& key, T2 key2 = "", Lambda otherFun
         return obj;
     }
     auto tickets = T::FindAllTicketByPastelID(key);
-    if (tickets.empty() && otherFunc != nullptr)
+    if (tickets.empty() && otherFunc)
         tickets = otherFunc(key2);
-    if (!tickets.empty()) {
+    if (!tickets.empty())
+    {
         UniValue tArray(UniValue::VARR);
-        for (auto t : tickets) {
+        for (const auto &t : tickets)
+        {
             UniValue obj(UniValue::VOBJ);
             obj.read(t.ToJSON());
-            tArray.push_back(obj);
+            tArray.push_back(move(obj));
         }
         return tArray;
     }

--- a/src/mnode/rpc/tickets-find.h
+++ b/src/mnode/rpc/tickets-find.h
@@ -1,5 +1,5 @@
 #pragma once
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 

--- a/src/mnode/rpc/tickets-findbylabel.cpp
+++ b/src/mnode/rpc/tickets-findbylabel.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 The Pastel Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <rpc/rpc_parser.h>
+#include <mnode/tickets/tickets-all.h>
+#include <mnode/rpc/tickets-findbylabel.h>
+#include <rpc/server.h>
+
+using namespace std;
+
+template <class _TicketType>
+void ListTicketsByLabel(const string& label, UniValue &vOut)
+{
+    masterNodeCtrl.masternodeTickets.ProcessTicketsByMVKey<_TicketType>(label,
+        [&](const _TicketType& tkt) -> bool
+        {
+            UniValue obj(UniValue::VOBJ);
+            obj.read(tkt.ToJSON());
+            vOut.push_back(move(obj));
+            return true;
+        });
+}
+
+UniValue tickets_findbylabel(const UniValue& params)
+{
+    RPC_CMD_PARSER2(FIND, params, nft, nft__collection, action);
+
+    if (!FIND.IsCmdSupported())
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(tickets findbylabel <ticket-type> "label"
+Set of commands to find different types of Pastel tickets by label.
+
+Available ticket types:
+  nft      - Find NFT registration tickets by label.
+  nft-collection - Find NFT collection registration tickets by label.
+  action   - Find action registration tickets by label.
+
+Arguments:
+1. "label"   (string, required) The label to use for ticket search. See types above...
+
+Example: Find NFT ticket by label
+)" + HelpExampleCli("tickets findbylabel nft", "bc1c5243284272dbb22c301a549d112e8bc9bc454b5ff50b1e5f7959d6b56726") +
+R"(
+As json rpc
+)" + HelpExampleRpc("tickets", R"("findbylabel", "nft", "bc1c5243284272dbb22c301a549d112e8bc9bc454b5ff50b1e5f7959d6b56726")"));
+
+    string label;
+    if (params.size() > 2)
+        label = params[2].get_str();
+    UniValue tktArray(UniValue::VARR);
+    switch (FIND.cmd())
+    {
+        case RPC_CMD_FIND::nft:
+            ListTicketsByLabel<CNFTRegTicket>(label, tktArray);
+            break;
+
+        case RPC_CMD_FIND::nft__collection:
+            ListTicketsByLabel<CNFTCollectionRegTicket>(label, tktArray);
+            break;
+
+        case RPC_CMD_FIND::action: 
+            ListTicketsByLabel<CActionRegTicket>(label, tktArray);
+            break;
+
+        default:
+            break;
+    }
+    return tktArray;
+}

--- a/src/mnode/rpc/tickets-findbylabel.h
+++ b/src/mnode/rpc/tickets-findbylabel.h
@@ -1,6 +1,8 @@
 #pragma once
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <univalue.h>
 
+UniValue tickets_findbylabel(const UniValue& params);

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -132,10 +132,6 @@ void CPastelTicketProcessor::UpdatedBlockTip(const CBlockIndex* cBlockIndex, boo
     if (!cBlockIndex)
         return;
 
-    if (fInitialDownload) {
-        //??
-    }
-
     CBlock block;
     if (!ReadBlockFromDisk(block, cBlockIndex, Params().GetConsensus()))
     {
@@ -143,7 +139,7 @@ void CPastelTicketProcessor::UpdatedBlockTip(const CBlockIndex* cBlockIndex, boo
         return;
     }
 
-    for (const CTransaction& tx : block.vtx)
+    for (const auto& tx : block.vtx)
     {
         CMutableTransaction mtx(tx);
         ParseTicketAndUpdateDB(mtx, cBlockIndex->nHeight);
@@ -722,16 +718,26 @@ bool CPastelTicketProcessor::FindTicketBySecondaryKey(CPastelTicket& ticket)
     return false;
 }
 
+/**
+ * Find all tickets by mvKey.
+ * 
+ * \param mvKey - key to search for. Tickets support up to 3 mvkeys.
+ * \return vector of found tickets with the given mvKey
+ */
 template <class _TicketType>
 vector<_TicketType> CPastelTicketProcessor::FindTicketsByMVKey(const string& mvKey)
 {
     vector<_TicketType> tickets;
     v_strings vMainKeys;
+    // get real MV key stored in DB: "@M@" + key
     auto realMVKey = RealMVKey(mvKey);
+    // get DB for the given ticket type
     const auto itDB = dbs.find(_TicketType::GetID());
     if (itDB != dbs.cend())
     {
+        // find primary keys of the tickets with mvKey
         itDB->second->Read(realMVKey, vMainKeys);
+        // read all tickets
         for (const auto& key : vMainKeys)
         {
             _TicketType ticket;

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -104,19 +104,24 @@ public:
     *   functor F should return false to stop enumeration.
     *
     * \param mvKey - mvKey to use for tickets enumeration
-    * \param f - functor to call for each ticket found by mvKey
+    * \param f - functor to call for each ticket found by mvKey.
+    *       Functor f should return false to stop enumeration.
     */
     template <class _TicketType, typename _TicketFunctor>
     void ProcessTicketsByMVKey(const std::string& mvKey, _TicketFunctor f) const
     {
         v_strings vMainKeys;
+        // get real MV key: "@M@" + key
         const auto realMVKey = RealMVKey(mvKey);
+        // get DB for the given ticket type
         const auto itDB = dbs.find(_TicketType::GetID());
         if (itDB == dbs.cend())
             return;
+        // read primary keys for the given MV key
         itDB->second->Read(realMVKey, vMainKeys);
         for (const auto& key : vMainKeys)
         {
+            // read ticket & call the functor
             _TicketType ticket;
             if (itDB->second->Read(key, ticket))
             {
@@ -126,6 +131,7 @@ public:
         }
     }
 
+    // find all tickets by mvKey
     template <class _TicketType>
     std::vector<_TicketType> FindTicketsByMVKey(const std::string& mvKey);
 

--- a/src/mnode/tickets/action-reg.h
+++ b/src/mnode/tickets/action-reg.h
@@ -48,9 +48,10 @@ signatures: {
           "mn3": { "PastelID" : "signature"},
 }
 
-  key #1: keyOne (primary)
-  key #2: keyTwo (label)
+  key #1: primary key (generated)
 mvkey #1: action caller PastelID
+mvkey #3: lable (optional)
+
 */
 
 constexpr auto ACTION_TICKET_TYPE_SENSE = "sense";
@@ -90,10 +91,13 @@ public:
     bool SetActionType(const std::string& sActionType);
     ACTION_TICKET_TYPE GetActionType() const noexcept { return m_ActionType; }
 
+    bool HasMVKeyOne() const noexcept override { return true; }
+    bool HasMVKeyTwo() const noexcept override { return !m_label.empty(); }
+
     std::string KeyOne() const noexcept override { return m_keyOne; }
     std::string MVKeyOne() const noexcept override { return m_sCallerPastelId; }
+    std::string MVKeyTwo() const noexcept override { return m_label; }
 
-    bool HasMVKeyOne() const noexcept override { return true; }
     void SetKeyOne(std::string &&sValue) override { m_keyOne = std::move(sValue); }
     void GenerateKeyOne() override;
 

--- a/src/mnode/tickets/nft-collection-reg.h
+++ b/src/mnode/tickets/nft-collection-reg.h
@@ -66,9 +66,9 @@ signatures: {
     "mn3": { "PastelID" : "signature" },
 }
 
-key #1: keyOne
-key #2: keyTwo
+key   #1: primary key (generated)
 mvkey #1: creator PastelID
+mvkey #2: label (optional)
 }
 */
 class CNFTCollectionRegTicket : public CTicketSignedWithExtraFees
@@ -89,7 +89,10 @@ public:
     void Clear() noexcept override;
 
     bool HasMVKeyOne() const noexcept override { return true; }
+    bool HasMVKeyTwo() const noexcept override { return !m_label.empty(); }
+
     std::string MVKeyOne() const noexcept override { return getCreatorPastelId(); }
+    std::string MVKeyTwo() const noexcept override { return m_label; }
 
     std::string ToJSON() const noexcept override;
     std::string ToStr() const noexcept override { return m_sNFTCollectionTicket; }

--- a/src/mnode/tickets/nft-reg.h
+++ b/src/mnode/tickets/nft-reg.h
@@ -79,10 +79,10 @@ signatures: {
           "mn3": { "PastelID" : "signature"},
 }
 
-  key #1: keyOne
-  key #2: keyTwo
+  key #1: primary key (generated)
 mvkey #1: Creator PastelID
 mvkey #2: NFT Collection TxID (optional)
+mvket #3: label (optional)
 }
  */
 class CNFTRegTicket : public CTicketSignedWithExtraFees 
@@ -104,9 +104,11 @@ public:
 
     bool HasMVKeyOne() const noexcept override { return true; }
     bool HasMVKeyTwo() const noexcept override { return !m_sNFTCollectionTxid.empty(); }
+    bool HasMVKeyThree() const noexcept override { return !m_label.empty(); }
 
     std::string MVKeyOne() const noexcept override { return getCreatorPastelId(); }
     std::string MVKeyTwo() const noexcept override { return m_sNFTCollectionTxid; }
+    std::string MVKeyThree() const noexcept override { return m_label; }
 
     std::string ToJSON() const noexcept override;
     std::string ToStr() const noexcept override { return m_sNFTTicket; }


### PR DESCRIPTION
- added label as a MVkey for the following tickets: NFT Reg, NFT-collection Reg, ActionReg
- added new RPC API to search tickets by label:
tickets findbylabel <ticket-type> "label"
Set of commands to find different types of Pastel tickets by label.

Available ticket types:
  nft      - Find NFT registration tickets by label.
  nft-collection - Find NFT collection registration tickets by label.
  action   - Find action registration tickets by label.

Arguments:
1. "label"   (string, required) The label to use for ticket search. See types above...

This API searches for tickets by MV key (passed via "label" parameter) and returns json array of found tickets.
- added python tests to mn_tickets.py for the new findbylabel API