### PR TITLE
[PSL-352] Disable governance tickets

### DIFF
--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="..\..\..\src\mnode\mnode-validation.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\mnode-rpc-utils.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\pastelid-rpc.cpp" />
+    <ClCompile Include="..\..\..\src\mnode\rpc\governance-rpc.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\storage-fee.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-activate.cpp" />
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-fake.cpp" />
@@ -213,6 +214,7 @@
     <ClInclude Include="..\..\..\src\mnode\rpc\masternodebroadcast.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\mnode-rpc-utils.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\pastelid-rpc.h" />
+    <ClInclude Include="..\..\..\src\mnode\rpc\governance-rpc.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\storage-fee.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-activate.h" />
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-fake.h" />

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
@@ -301,6 +301,9 @@
     <ClCompile Include="..\..\..\src\mnode\rpc\tickets-findbylabel.cpp">
       <Filter>Source Files\mnode\rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\mnode\rpc\governance-rpc.cpp">
+      <Filter>Source Files\mnode\rpc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\addrman.h">
@@ -643,6 +646,9 @@
       <Filter>Source Files\mnode\tickets</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\mnode\rpc\tickets-findbylabel.h">
+      <Filter>Source Files\mnode\rpc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\mnode\rpc\governance-rpc.h">
       <Filter>Source Files\mnode\rpc</Filter>
     </ClInclude>
   </ItemGroup>

--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -110,7 +110,6 @@ declare -a testScriptsMN=(
     'secure_container.py'
     'mn_tickets_username_change.py'
     'mn_tickets_validation.py'
-    'mn_governance.py'
     'mn_messaging.py'
     'mn_payment.py'
     'mn_bugs.py'
@@ -119,6 +118,10 @@ declare -a testScriptsMN=(
 declare -a testScriptsMNslow=(
     'mn_main.py'
     'mn_tickets.py'
+)
+
+declare -a testScriptsMNdisabled=(
+    'mn_governance.py'
 )
 
 declare -a testScriptsExt=(

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -113,6 +113,7 @@ LIBZCASH_H = \
   zcash/Zcash.h
 
 MNODE_CPP =\
+  mnode/rpc/governance-rpc.cpp\
   mnode/rpc/ingest.cpp\
   mnode/rpc/masternode.cpp\
   mnode/rpc/masternodebroadcast.cpp\
@@ -162,6 +163,7 @@ MNODE_CPP =\
   mnode/mnode-controller.cpp
 
 MNODE_H = \
+  mnode/rpc/governance-rpc.h\
   mnode/rpc/ingest.h\
   mnode/rpc/masternode.h\
   mnode/rpc/masternodebroadcast.h\

--- a/src/gtest/test_mnode/test_governance.cpp
+++ b/src/gtest/test_mnode/test_governance.cpp
@@ -1,20 +1,21 @@
-// Copyright (c) 2021 The Pastel developers
+// Copyright (c) 2021-2022 The Pastel developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <gtest/gtest.h>
-
 #include <string>
 
-#include "main.h"
-#include "key.h"
-#include "key_io.h"
-#include "chain.h"
-#include "chainparams.h"
+#include <gtest/gtest.h>
 
-#include "mnode/mnode-governance.h"
+#include <main.h>
+#include <key.h>
+#include <key_io.h>
+#include <chain.h>
+#include <chainparams.h>
+#include <mnode/mnode-governance.h>
 
-TEST(mnode_governance, CalculateLastPaymentBlock) {
+#ifdef GOVERNANCE_TICKETS
+TEST(mnode_governance, CalculateLastPaymentBlock)
+{
     SelectParams(CBaseChainParams::Network::TESTNET);
 
     CMasternodeGovernance gov;
@@ -31,7 +32,8 @@ TEST(mnode_governance, CalculateLastPaymentBlock) {
     // gov.AddTicket("tPVQMdSyVnSYgrww5TTXSJeF75aPQ3bAfdm", 1000000, "", true);
 }
 
-TEST(mnode_governance, TicketProcessing) {
+TEST(mnode_governance, TicketProcessing)
+{
     SelectParams(CBaseChainParams::Network::TESTNET);
 
     std::string address("tPVQMdSyVnSYgrww5TTXSJeF75aPQ3bAfdm");
@@ -140,3 +142,5 @@ TEST(mnode_governance, TicketProcessing) {
     res = gov.GetCurrentPaymentTicket(143+1001, ticket);
     EXPECT_EQ(false, res);
 }
+
+#endif // GOVERNANCE_TICKETS

--- a/src/mnode/mnode-controller.h
+++ b/src/mnode/mnode-controller.h
@@ -45,12 +45,14 @@ public:
     CMasternodePayments masternodePayments;
     // Keep track of what node has/was asked for and when
     CMasternodeRequestTracker requestTracker;
-    // Keep track of what node has/was asked for and when
-    CMasternodeGovernance masternodeGovernance;
     // Keep track of the latest messages
     CMasternodeMessageProcessor masternodeMessages;
 	// Keep track of the tickets
 	CPastelTicketProcessor masternodeTickets;
+#ifdef GOVERNANCE_TICKETS
+    // Keep track of what node has/was asked for and when
+    CMasternodeGovernance masternodeGovernance;
+#endif // GOVERNANCE_TICKETS
 
     bool fMasterNode;
 

--- a/src/mnode/mnode-governance.cpp
+++ b/src/mnode/mnode-governance.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include <mnode/mnode-governance.h>
+#ifdef GOVERNANCE_TICKETS
 #include <main.h>
 #include <key_io.h>
 #include <enum_util.h>
-
 #include <mnode/mnode-controller.h>
 #include <mnode/mnode-msgsigner.h>
-#include <mnode/mnode-governance.h>
 
 CCriticalSection cs_mapTickets;
 CCriticalSection cs_mapPayments;
@@ -818,3 +818,5 @@ void CGovernanceVote::Relay()
     CInv inv(MSG_MASTERNODE_GOVERNANCE_VOTE, GetHash());
     CNodeHelper::RelayInv(inv);
 }
+
+#endif // GOVERNANCE_TICKETS

--- a/src/mnode/mnode-governance.h
+++ b/src/mnode/mnode-governance.h
@@ -6,6 +6,8 @@
 #include <map>
 #include <mutex>
 
+#include <mnode/tickets/ticket-types.h>
+#ifdef GOVERNANCE_TICKETS
 #include <main.h>
 
 extern CCriticalSection cs_mapPayments;
@@ -249,3 +251,4 @@ public:
 protected:
     bool ProcessGovernanceVotes(const bool bVoteOnlyMsg, std::vector<CGovernanceVote>& vVotesToCheck, CNode* pfrom);
 };
+#endif // GOVERNANCE_TICKETS

--- a/src/mnode/mnode-notificationinterface.cpp
+++ b/src/mnode/mnode-notificationinterface.cpp
@@ -1,13 +1,14 @@
 // Copyright (c) 2014-2017 The Dash Core developers
-// Copyright (c) 2018 The Pastel developers
+// Copyright (c) 2018-2022 The Pastel developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include "main.h"
-#include "chainparams.h"
+#include <main.h>
+#include <chainparams.h>
 
-#include "mnode/mnode-notificationinterface.h"
-#include "mnode/mnode-controller.h"
+#include <mnode/mnode-notificationinterface.h>
+#include <mnode/mnode-controller.h>
+#include <mnode/tickets/ticket-types.h>
 
 void CACNotificationInterface::InitializeCurrentBlockTip()
 {
@@ -36,5 +37,7 @@ void CACNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, boo
 	
 	masterNodeCtrl.masternodeManager.UpdatedBlockTip(pindexNew);
 	masterNodeCtrl.masternodePayments.UpdatedBlockTip(pindexNew);
+#ifdef GOVERNANCE_TICKETS
 	masterNodeCtrl.masternodeGovernance.UpdatedBlockTip(pindexNew);
+#endif // GOVERNANCE_TICKETS
 }

--- a/src/mnode/mnode-notificationinterface.h
+++ b/src/mnode/mnode-notificationinterface.h
@@ -1,9 +1,9 @@
 #pragma once
 // Copyright (c) 2015 The Bitcoin Core developers
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include "validationinterface.h"
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <validationinterface.h>
 
 class CACNotificationInterface : public CValidationInterface
 {

--- a/src/mnode/mnode-sync.cpp
+++ b/src/mnode/mnode-sync.cpp
@@ -3,12 +3,13 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
-#include "main.h"
+#include <util.h>
+#include <main.h>
 
-#include "mnode/mnode-sync.h"
-#include "mnode/mnode-manager.h"
-#include "mnode/mnode-controller.h"
+#include <mnode/mnode-sync.h>
+#include <mnode/mnode-manager.h>
+#include <mnode/mnode-controller.h>
+#include <mnode/tickets/ticket-types.h>
 
 using namespace std;
 
@@ -333,17 +334,20 @@ void CMasternodeSync::ProcessTick()
                 return; //this will cause each peer to get one request each six seconds for the various assets we need
             }
 
+#ifdef GOVERNANCE_TICKETS
             if(syncState == MasternodeSyncState::Governance)
             {
                 LogPrint("governace", "CMasternodeSync::ProcessTick -- nTick %d syncState %d nTimeLastBumped %lld GetTime() %lld diff %lld\n", nTick, (int)syncState, nTimeLastBumped, GetTime(), GetTime() - nTimeLastBumped);
                 // check for timeout first
-                if (!CheckSyncTimeout(nTick, vNodesCopy)) {
+                if (!CheckSyncTimeout(nTick, vNodesCopy))
+                {
                     CNodeHelper::ReleaseNodeVector(vNodesCopy);
                     return; //this will cause each peer to get one request each six seconds for the various assets we need
                 }
 
                 // only request once from each peer
-                if(masterNodeCtrl.requestTracker.HasFulfilledRequest(pnode->addr, "governance-payment-sync")) continue;
+                if(masterNodeCtrl.requestTracker.HasFulfilledRequest(pnode->addr, "governance-payment-sync"))
+                    continue;
                 masterNodeCtrl.requestTracker.AddFulfilledRequest(pnode->addr, "governance-payment-sync");
 
                 nRequestedMasternodeAttempt++;
@@ -354,6 +358,7 @@ void CMasternodeSync::ProcessTick()
                 CNodeHelper::ReleaseNodeVector(vNodesCopy);
                 return; //this will cause each peer to get one request each six seconds for the various assets we need
             }
+#endif // GOVERNANCE_TICKETS
         }
     }
 

--- a/src/mnode/mnode-validation.cpp
+++ b/src/mnode/mnode-validation.cpp
@@ -2,8 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <cinttypes>
+
 #include <mnode/mnode-validation.h>
 #include <mnode/mnode-controller.h>
+#include <mnode/tickets/ticket-types.h>
 
 /*
 Wrappers for BlockChain specific logic
@@ -116,8 +118,10 @@ void FillOtherBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmoun
 {
     // Fill Governance payment
     //TODO: Fix governance tickets processing
+#ifdef GOVERNANCE_TICKETS
     masterNodeCtrl.masternodeGovernance.FillGovernancePayment(txNew, nBlockHeight, blockReward, txoutGovernanceRet);
-    
+#endif // GOVERNANCE_TICKETS
+
     // FILL BLOCK PAYEE WITH MASTERNODE PAYMENT
     masterNodeCtrl.masternodePayments.FillMasterNodePayment(txNew, nBlockHeight, blockReward, txoutMasternodeRet);
 
@@ -162,11 +166,13 @@ bool IsBlockValid(const Consensus::Params& consensusParams, const CBlock& block,
         strErrorRet = strprintf("Invalid coinbase transaction (MN payment) at height %d: %s", nBlockHeight, block.vtx[0].ToString());
         return false;
     }
+#ifdef GOVERNANCE_TICKETS
     if(!masterNodeCtrl.masternodeGovernance.IsTransactionValid(block.vtx[0], nBlockHeight))
     {
         strErrorRet = strprintf("Invalid coinbase transaction (governance payment) at height %d: %s", nBlockHeight, block.vtx[0].ToString());
         return false;
     }
+#endif // GOVERNANCE_TICKETS
 
     // there was no MN for Governance payments on this block
     LogPrint("mnpayments", "IsBlockValid -- Valid masternode payment at height %d: %s", nBlockHeight, block.vtx[0].ToString());

--- a/src/mnode/mnode-validation.h
+++ b/src/mnode/mnode-validation.h
@@ -1,15 +1,14 @@
 #pragma once
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <string>
 
-#include "main.h"
+#include <main.h>
 
 #ifdef ENABLE_WALLET
-#include "wallet/wallet.h"
+#include <wallet/wallet.h>
 #endif
-
 
 bool GetBlockHash(uint256& hashRet, int nBlockHeight);
 bool GetUTXOCoin(const COutPoint& outpoint, CCoins& coins);

--- a/src/mnode/rpc/governance-rpc.cpp
+++ b/src/mnode/rpc/governance-rpc.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2018-2022 The Pastel Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <stdexcept>
+
+#include <mnode/rpc/governance-rpc.h>
+#ifdef GOVERNANCE_TICKETS
+#include <rpc/rpc_consts.h>
+#include <rpc/server.h>
+#include <mnode/rpc/mnode-rpc-utils.h>
+#include <mnode/mnode-controller.h>
+
+using namespace std;
+
+UniValue governance(const UniValue& params, bool fHelp)
+{
+    string strMode;
+    if (!params.empty())
+        strMode = params[0].get_str();
+
+    if (fHelp || (strMode != "ticket" && strMode != "list"))
+        throw runtime_error(
+            R"(governance [ticket|list]
+
+Cast a governance vote for new or existing ticket.
+
+Examples:
+)"
++ HelpExampleCli("governance", "")
++ HelpExampleRpc("governance", "")
+);
+
+    string strCmd, strError;
+    if (strMode == "ticket")
+    {
+        if (params.size() < 4 || params.size() > 6)
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                R"(1.
+governance ticket add "address" amount "note" <yes|no>
+2.
+governance ticket vote "ticketID" <yes|no>
+)"
+);
+
+        UniValue resultObj(UniValue::VOBJ);
+
+        strCmd = params[1].get_str();
+        if (strCmd == "add")
+        {
+            if (params.size() != 6)
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    R"(governance ticket add "address" amount "note" <yes|no>)");
+
+            string address = params[2].get_str();
+            CAmount amount = get_number(params[3]) * COIN;
+            string note = params[4].get_str();
+            string vote = params[5].get_str();
+
+            if (vote != "yes" && vote != "no")
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    R"(governance ticket add "address" amount "note" <yes|no>)");
+
+            uint256 newTicketId;
+            if (!masterNodeCtrl.masternodeGovernance.AddTicket(address, amount, note, (vote == "yes"), newTicketId, strError)) {
+                resultObj.pushKV(RPC_KEY_RESULT, RPC_RESULT_FAILED);
+                resultObj.pushKV(RPC_KEY_ERROR_MESSAGE, strError);
+            } else {
+                resultObj.pushKV(RPC_KEY_RESULT, RPC_RESULT_SUCCESS);
+                resultObj.pushKV("ticketId", newTicketId.ToString());
+            }
+            return resultObj;
+        }
+        if (strCmd == "vote")
+        {
+            if (params.size() != 4)
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    R"(governance ticket vote "ticketID" <yes|no>)");
+
+            string ticketIdstr = params[2].get_str();
+            string vote = params[3].get_str();
+
+            if (vote != "yes" && vote != "no")
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    R"(governance ticket add "address" amount "note" <yes|no>)");
+
+            if (!IsHex(ticketIdstr))
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                    "Invalid parameter, expected hex ticketId");
+
+            uint256 ticketId = uint256S(ticketIdstr);
+
+            if (!masterNodeCtrl.masternodeGovernance.VoteForTicket(ticketId, (vote == "yes"), strError)) {
+                resultObj.pushKV(RPC_KEY_RESULT, RPC_RESULT_FAILED);
+                resultObj.pushKV(RPC_KEY_ERROR_MESSAGE, strError);
+            } else {
+                resultObj.pushKV(RPC_KEY_RESULT, RPC_RESULT_SUCCESS);
+            }
+            return resultObj;
+        }
+    }
+
+    if(strMode == "list")
+    {
+        UniValue resultArray(UniValue::VARR);
+
+        if (params.size() != 2)
+            throw JSONRPCError(RPC_INVALID_PARAMETER,
+                R"(1.
+governance list tickets
+2.
+governance list winners)"
+);
+        strCmd = params[1].get_str();
+        if (strCmd == "tickets")
+        {
+            for (auto& s : masterNodeCtrl.masternodeGovernance.mapTickets) {
+                string id = s.first.ToString();
+
+                UniValue obj(UniValue::VOBJ);
+                obj.pushKV("id", id);
+                obj.pushKV("ticket", s.second.ToString());
+                resultArray.push_back(obj);
+            }
+        }
+        if (strCmd == "winners")
+        {
+            for (auto& s : masterNodeCtrl.masternodeGovernance.mapTickets) {
+                if (s.second.nLastPaymentBlockHeight != 0) {
+                    string id = s.first.ToString();
+
+                    UniValue obj(UniValue::VOBJ);
+                    obj.pushKV("id", id);
+                    obj.pushKV("ticket", s.second.ToString());
+                    resultArray.push_back(obj);
+                }
+            }
+        }
+
+        return resultArray;
+    }
+    return NullUniValue;
+}
+#endif // GOVERNANCE_TICKETS

--- a/src/mnode/rpc/governance-rpc.h
+++ b/src/mnode/rpc/governance-rpc.h
@@ -1,0 +1,11 @@
+#pragma once
+// Copyright (c) 2018-2022 The Pastel Core developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include <univalue.h>
+#include <mnode/tickets/ticket-types.h>
+
+#ifdef GOVERNANCE_TICKETS
+UniValue governance(const UniValue& params, bool fHelp);
+#endif // GOVERNANCE_TICKETS

--- a/src/mnode/rpc/pastelid-rpc.cpp
+++ b/src/mnode/rpc/pastelid-rpc.cpp
@@ -1,12 +1,13 @@
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include "pastelid/pastel_key.h"
-#include "rpc/rpc_parser.h"
-#include "rpc/rpc_consts.h"
-#include "rpc/server.h"
-#include "mnode/rpc/pastelid-rpc.h"
+#include <pastelid/pastel_key.h>
+#include <rpc/rpc_parser.h>
+#include <rpc/rpc_consts.h>
+#include <rpc/server.h>
+#include <mnode/rpc/pastelid-rpc.h>
+#include <mnode/rpc/governance-rpc.h>
 
 using namespace std;
 

--- a/src/mnode/tickets/action-reg.h
+++ b/src/mnode/tickets/action-reg.h
@@ -50,7 +50,7 @@ signatures: {
 
   key #1: primary key (generated)
 mvkey #1: action caller PastelID
-mvkey #3: lable (optional)
+mvkey #3: label (optional)
 
 */
 

--- a/src/mnode/tickets/ticket-types.h
+++ b/src/mnode/tickets/ticket-types.h
@@ -6,6 +6,7 @@
 #include <array>
 
 #include <enum_util.h>
+#include <amount.h>
 
 // ticket names
 constexpr auto TICKET_NAME_ID_REG                   = "pastelid";               // Pastel ID registration ticket
@@ -27,6 +28,8 @@ constexpr auto TICKET_NAME_NFT_COLLECTION_ACT       = "nft-collection-act";     
 #ifndef FAKE_TICKET
 #define FAKE_TICKET
 #endif
+
+//#define GOVERNANCE_TICKETS
 
 /**
  * Ticket Type IDs.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
@@ -981,19 +982,21 @@ Examples:
     CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());
 
     CAmount nGovernancePayment = 0;
-    if (!masterNodeCtrl.masternodeGovernance.mapTickets.empty()){
+#ifdef GOVERNANCE_TICKETS
+    if (!masterNodeCtrl.masternodeGovernance.mapTickets.empty())
         nGovernancePayment = masterNodeCtrl.masternodeGovernance.GetCurrentPaymentAmount(nHeight, nReward);
-    }
+#endif // GOVERNANCE_TICKETS
 
     CAmount nMasternodePayment = 0;
-    if (masterNodeCtrl.masternodePayments.mapMasternodeBlockPayees.count(nHeight)){
+    if (masterNodeCtrl.masternodePayments.mapMasternodeBlockPayees.count(nHeight))
         nMasternodePayment = masterNodeCtrl.masternodePayments.GetMasternodePayment(0, nReward);//same for any height currently
-    }
 
     UniValue result(UniValue::VOBJ);
-    result.pushKV("miner", ValueFromAmount(nReward-nGovernancePayment-nMasternodePayment));
+    result.pushKV("miner", ValueFromAmount(nReward - nGovernancePayment - nMasternodePayment));
     result.pushKV("masternode", ValueFromAmount(nMasternodePayment));
+#ifdef GOVERNANCE_TICKETS
     result.pushKV("governance", ValueFromAmount(nGovernancePayment));
+#endif // GOVERNANCE_TICKETS
     return result;
 }
 
@@ -1024,19 +1027,21 @@ Examples:
     CAmount nReward = GetBlockSubsidy(nHeight, Params().GetConsensus());
     
     CAmount nGovernancePayment = 0;
-    if (!masterNodeCtrl.masternodeGovernance.mapTickets.empty()){
+#ifdef GOVERNANCE_TICKETS
+    if (!masterNodeCtrl.masternodeGovernance.mapTickets.empty())
         nGovernancePayment = masterNodeCtrl.masternodeGovernance.GetCurrentPaymentAmount(nHeight, nReward);
-    }
-    
+#endif // GOVERNANCE_TICKETS
+
     CAmount nMasternodePayment = 0;
-    if (masterNodeCtrl.masternodePayments.mapMasternodeBlockPayees.count(nHeight)){
+    if (masterNodeCtrl.masternodePayments.mapMasternodeBlockPayees.count(nHeight))
         nMasternodePayment = masterNodeCtrl.masternodePayments.GetMasternodePayment(0, nReward);//same for any height currently
-    }
     
     UniValue result(UniValue::VOBJ);
-    result.pushKV("miner", ValueFromAmount(nReward-nGovernancePayment-nMasternodePayment));
+    result.pushKV("miner", ValueFromAmount(nReward - nGovernancePayment - nMasternodePayment));
     result.pushKV("masternode", ValueFromAmount(nMasternodePayment));
+#ifdef GOVERNANCE_TICKETS
     result.pushKV("governance", ValueFromAmount(nGovernancePayment));
+#endif // GOVERNANCE_TICKETS
     return result;
 }
 


### PR DESCRIPTION
- disable all governance tickets logic depending on macro definition GOVERNANCE_TICKETS (can be defined in mnode/tickets/ticket-types.h)
   - block validations
   - governance RPC API
- moved mn_governance.py python test to the separate test group (MNdisabled)