### PR TITLE
[PSL-342] `IsValid` for `Buy` and `Trade` check `intendedFor` field

### DIFF
--- a/src/gtest/test_mnode/test_mnode_rpc.cpp
+++ b/src/gtest/test_mnode/test_mnode_rpc.cpp
@@ -1,16 +1,18 @@
-// Copyright (c) 2021 The Pastel developers
+// Copyright (c) 2021-2022 The Pastel developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include <gtest/gtest.h>
 #include <tuple>
 
+#include <gtest/gtest.h>
+
 #include <base58.h>
-#include <mnode/rpc/mnode-rpc.h>
 #include <utilstrencodings.h>
 #include <vector_types.h>
 #include <chainparams.h>
+#include <mnode/rpc/mnode-rpc.h>
 #include <mnode/rpc/ingest.h>
+#include <mnode/rpc/mnode-rpc-utils.h>
 
 using namespace testing;
 using namespace std;
@@ -92,3 +94,14 @@ INSTANTIATE_TEST_SUITE_P(mnode_rpc_ani2psl, PTest_ani2psl_secret,
         }, true, true)
 	));
 
+TEST(mnode_rpc, rpc_check_unsigned_param)
+{
+    EXPECT_THROW(rpc_check_unsigned_param<uint16_t>("test-negative", -1), UniValue);
+    EXPECT_THROW(rpc_check_unsigned_param<uint16_t>("test-overflow", 100'000), UniValue);
+    EXPECT_NO_THROW(rpc_check_unsigned_param<uint16_t>("test", 42));
+
+    EXPECT_THROW(rpc_check_unsigned_param<uint32_t>("test-negative", -5), UniValue);
+    constexpr int64_t nOverflowUint32Value = 0x1'0000'000F;
+    EXPECT_THROW(rpc_check_unsigned_param<uint32_t>("test-overflow", nOverflowUint32Value), UniValue);
+    EXPECT_NO_THROW(rpc_check_unsigned_param<uint32_t>("test", 42));
+}

--- a/src/mnode/rpc/mnode-rpc-utils.cpp
+++ b/src/mnode/rpc/mnode-rpc-utils.cpp
@@ -11,9 +11,9 @@ int get_number(const UniValue& v)
     return v.isStr() ? std::stoi(v.get_str()) : v.get_int();
 }
 
-long long get_long_number(const UniValue& v)
+int64_t get_long_number(const UniValue& v)
 {
-    return v.isStr() ? std::stoll(v.get_str()) : (long long)v.get_int();
+    return v.isStr() ? std::stoll(v.get_str()) : (long long)v.get_int64();
 }
 
 /**

--- a/src/mnode/rpc/mnode-rpc-utils.h
+++ b/src/mnode/rpc/mnode-rpc-utils.h
@@ -6,8 +6,29 @@
 #include <string>
 
 #include <univalue.h>
+#include <tinyformat.h>
+
+#include <rpc/protocol.h>
 
 int get_number(const UniValue& v);
-long long get_long_number(const UniValue& v);
+int64_t get_long_number(const UniValue& v);
+
+/**
+* Check numeric rpc parameter - expected type _ExpectedType.
+* Throws JSONRPCError if the parameter value is invalid:
+*   - negative
+*   - exceeds max value for the expected numeric type
+* 
+* \param szParamName - rpc parameter name
+* \param nParamValue - rpc parameter value
+*/
+template<typename _ExpectedType>
+void rpc_check_unsigned_param(const char *szParamName, const int64_t nParamValue)
+{
+    if (nParamValue < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s parameter cannot be negative", szParamName));
+    if (nParamValue >= std::numeric_limits<_ExpectedType>::max())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("%s parameter is too big", szParamName));
+}
 
 UniValue GenerateSendTicketResult(std::tuple<std::string, std::string>&& resultIDs);

--- a/src/mnode/rpc/tickets-fake.cpp
+++ b/src/mnode/rpc/tickets-fake.cpp
@@ -87,7 +87,8 @@ UniValue tickets_fake(const UniValue& params, const bool bSend)
         
         string intendedFor;
 
-        auto NFTSellTicket = CNFTSellTicket::Create(NFTTicketTxnID, price, after, before, 0, intendedFor, pastelID, move(strKeyPass));
+        auto NFTSellTicket = CNFTSellTicket::Create(move(NFTTicketTxnID), price, after, before, 0, 
+            move(intendedFor), move(pastelID), move(strKeyPass));
 
         const CAmount ticketPricePSL = get_long_number(params[8].get_str());
         string strVerb = params[9].get_str();

--- a/src/mnode/tickets/nft-buy.h
+++ b/src/mnode/tickets/nft-buy.h
@@ -20,12 +20,13 @@ using NFTBuyTickets_t = std::vector<CNFTBuyTicket>;
 		"reserved": "",
 		"signature": ""
 	}
+
+       key #1: sell ticket txid
+    mv key #1: Pastel ID of the buyer
  */
 class CNFTBuyTicket : public CPastelTicket
 {
 public:
-    std::string pastelID;
-    std::string sellTxnId;
     unsigned int price{};
     std::string reserved;
     v_uint8 m_signature;
@@ -33,7 +34,8 @@ public:
 public:
     CNFTBuyTicket() = default;
 
-    explicit CNFTBuyTicket(std::string _pastelID) : pastelID(std::move(_pastelID))
+    explicit CNFTBuyTicket(std::string &&sPastelID) : 
+        m_sPastelID(std::move(sPastelID))
     {}
 
     TicketID ID() const noexcept override { return TicketID::Buy; }
@@ -46,19 +48,19 @@ public:
     void Clear() noexcept override
     {
         CPastelTicket::Clear();
-        pastelID.clear();
-        sellTxnId.clear();
+        m_sPastelID.clear();
+        m_sellTxId.clear();
         price = 0;
         reserved.clear();
         m_signature.clear();
     }
-    std::string KeyOne() const noexcept override { return sellTxnId; } // this is the latest (active) buy ticket for this sell ticket
-    std::string MVKeyOne() const noexcept override { return pastelID; }
+    std::string KeyOne() const noexcept override { return m_sellTxId; } // this is the latest (active) buy ticket for this sell ticket
+    std::string MVKeyOne() const noexcept override { return m_sPastelID; }
     //    std::string MVKeyTwo() const override {return sellTxnId;} // these are all buy (1 active and many inactive) tickets for this sell ticket
 
     bool HasMVKeyOne() const noexcept override { return true; }
     bool HasMVKeyTwo() const noexcept override { return false; }
-    void SetKeyOne(std::string&& sValue) override { sellTxnId = std::move(sValue); }
+    void SetKeyOne(std::string&& sValue) override { m_sellTxId = std::move(sValue); }
 
     // get ticket price in PSL (1% from price)
     CAmount TicketPricePSL(const uint32_t nHeight) const noexcept override { return std::max<CAmount>(10, price / 100); }
@@ -69,7 +71,8 @@ public:
     bool IsSameSignature(const v_uint8& signature) const noexcept { return m_signature == signature; }
 
     // getters for ticket fields
-    const std::string& getPastelID() const noexcept { return pastelID; }
+    const std::string& getPastelID() const noexcept { return m_sPastelID; }
+    const std::string& getSellTxId() const noexcept { return m_sellTxId; }
     const std::string getSignature() const noexcept { return vector_to_string(m_signature); }
 
     void SerializationOp(CDataStream& s, const SERIALIZE_ACTION ser_action) override
@@ -78,10 +81,10 @@ public:
         std::string error;
         if (!VersionMgmt(error, bRead))
             throw std::runtime_error(error);
-        READWRITE(pastelID);
+        READWRITE(m_sPastelID);
         READWRITE(m_nVersion);
         // v0
-        READWRITE(sellTxnId);
+        READWRITE(m_sellTxId);
         READWRITE(price);
         READWRITE(reserved);
         READWRITE(m_signature);
@@ -90,10 +93,14 @@ public:
         READWRITE(m_nBlock);
     }
 
-    static CNFTBuyTicket Create(std::string _sellTxnId, int _price, std::string _pastelID, SecureString&& strKeyPass);
+    static CNFTBuyTicket Create(std::string &&sellTxId, int _price, std::string &&sPastelID, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CNFTBuyTicket& ticket);
 
     static bool CheckBuyTicketExistBySellTicket(const std::string& _sellTxnId);
 
     static NFTBuyTickets_t FindAllTicketByPastelID(const std::string& pastelID);
+
+protected:
+    std::string m_sPastelID; // Pastel ID of the buyer
+    std::string m_sellTxId;  // sell ticket txid
 };

--- a/src/mnode/tickets/nft-sell.cpp
+++ b/src/mnode/tickets/nft-sell.cpp
@@ -18,23 +18,30 @@ using json = nlohmann::json;
 using namespace std;
 
 // CNFTSellTicket ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-CNFTSellTicket CNFTSellTicket::Create(string _NFTTxnId, int _askedPrice, int _validAfter, int _validBefore, int _copy_number, std::string _intendedFor, string _pastelID, SecureString&& strKeyPass)
+CNFTSellTicket CNFTSellTicket::Create(string &&NFTTxnId, 
+    const unsigned int nAskedPricePSL, 
+    const unsigned int nValidAfter, 
+    const unsigned int nValidBefore, 
+    const unsigned short nCopyNumber, 
+    std::string &&sIntendedForPastelID, 
+    string &&pastelID, 
+    SecureString&& strKeyPass)
 {
-    CNFTSellTicket ticket(move(_pastelID));
+    CNFTSellTicket ticket(move(pastelID));
 
-    ticket.NFTTxnId = move(_NFTTxnId);
-    ticket.askedPrice = _askedPrice;
-    ticket.activeBefore = _validBefore;
-    ticket.activeAfter = _validAfter;
-    ticket.intendedFor = _intendedFor;
+    ticket.m_nftTxId = move(NFTTxnId);
+    ticket.m_nAskedPricePSL = nAskedPricePSL;
+    ticket.m_nValidAfter = nValidAfter;
+    ticket.m_nValidBefore = nValidBefore;
+    ticket.m_sIntendedForPastelID = move(sIntendedForPastelID);
 
     ticket.GenerateTimestamp();
 
     //NOTE: Sell ticket for Trade ticket will always has copyNumber = 1
-    ticket.copyNumber = _copy_number > 0 ?
-                            _copy_number :
-                            static_cast<decltype(ticket.copyNumber)>(CNFTSellTicket::FindAllTicketByNFTTxnID(ticket.NFTTxnId).size()) + 1;
-    ticket.key = ticket.NFTTxnId + ":" + to_string(ticket.copyNumber);
+    ticket.m_nCopyNumber = nCopyNumber > 0 ?
+        nCopyNumber :
+        static_cast<decltype(ticket.m_nCopyNumber)>(CNFTSellTicket::FindAllTicketByNFTTxnID(ticket.m_nftTxId).size()) + 1;
+    ticket.key = ticket.m_nftTxId + ":" + to_string(ticket.m_nCopyNumber);
     ticket.sign(move(strKeyPass));
     return ticket;
 }
@@ -43,12 +50,12 @@ string CNFTSellTicket::ToStr() const noexcept
 {
     stringstream ss;
     ss << m_sPastelID;
-    ss << NFTTxnId;
-    ss << askedPrice;
-    ss << copyNumber;
-    ss << activeBefore;
-    ss << activeAfter;
-    ss << intendedFor;
+    ss << m_nftTxId;
+    ss << m_nAskedPricePSL;
+    ss << m_nCopyNumber;
+    ss << m_nValidBefore;
+    ss << m_nValidAfter;
+    ss << m_sIntendedForPastelID;
     ss << m_nTimestamp;
     return ss.str();
 }
@@ -63,6 +70,51 @@ string CNFTSellTicket::ToStr() const noexcept
 void CNFTSellTicket::sign(SecureString&& strKeyPass)
 {
     string_to_vector(CPastelID::Sign(ToStr(), m_sPastelID, move(strKeyPass)), m_signature);
+}
+
+/**
+ * Check sell ticket valid state.
+ * 
+ * \param nHeight - current blockchain height to check for
+ * \return sell ticket validation state
+ */
+SELL_TICKET_STATE CNFTSellTicket::checkValidState(const uint32_t nHeight) const noexcept
+{
+    SELL_TICKET_STATE state = SELL_TICKET_STATE::NOT_DEFINED;
+    do
+    {
+        if (m_nValidAfter > 0)
+        {
+            if (nHeight <= m_nValidAfter)
+            {
+                state = SELL_TICKET_STATE::NOT_ACTIVE;
+                break;
+            }
+            if (m_nValidBefore > 0)
+            {
+                if (nHeight >= m_nValidBefore)
+                {
+                    state = SELL_TICKET_STATE::EXPIRED;
+                    break;
+                }
+                state = SELL_TICKET_STATE::ACTIVE;
+                break;
+            }
+            state = SELL_TICKET_STATE::UNAVAILABLE;
+            break;
+        }
+        if (m_nValidBefore > 0)
+        {
+            if (nHeight >= m_nValidBefore)
+            {
+                state = SELL_TICKET_STATE::EXPIRED;
+                break;
+            }
+            state = SELL_TICKET_STATE::ACTIVE;
+            break;
+        }
+    } while (false);
+    return state;
 }
 
 /**
@@ -81,23 +133,23 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
         // 0. Common validations
         unique_ptr<CPastelTicket> pastelTicket;
         const ticket_validation_t commonTV = common_ticket_validation(
-            *this, bPreReg, NFTTxnId, pastelTicket,
+            *this, bPreReg, m_nftTxId, pastelTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::Activate && tid != TicketID::Trade); },
             GetTicketDescription(), "activation or trade", nCallDepth, TicketPricePSL(chainHeight));
         if (commonTV.IsNotValid())
         {
             tv.errorMsg = strprintf(
                 "The Sell ticket with this txid [%s] is not validated. %s", 
-                NFTTxnId, commonTV.errorMsg);
+                m_nftTxId, commonTV.errorMsg);
             tv.state = commonTV.state;
             break;
         }
 
-        if (!askedPrice)
+        if (!m_nAskedPricePSL)
         {
             tv.errorMsg = strprintf(
                 "The asked price for Sell ticket with NFT txid [%s] should be not 0", 
-                NFTTxnId);
+                m_nftTxId);
             break;
         }
 
@@ -117,7 +169,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
         const auto fnVerifyAvailableCopies = [this](const string& strTicket, const size_t nTotalCopies) -> ticket_validation_t
         {
             ticket_validation_t tv;
-            const auto existingTradeTickets = CNFTTradeTicket::FindAllTicketByNFTTxnID(NFTTxnId);
+            const auto existingTradeTickets = CNFTTradeTicket::FindAllTicketByNFTTxnID(m_nftTxId);
             const size_t nSoldCopies = existingTradeTickets.size();
             do
             {
@@ -126,7 +178,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
                     tv.errorMsg = strprintf(
                         "The NFT you are trying to sell - from %s ticket [%s] - is already sold - "
                         "there are already [%zu] sold copies, but only [%zu] copies were available",
-                        strTicket, NFTTxnId, nSoldCopies, nTotalCopies);
+                        strTicket, m_nftTxId, nSoldCopies, nTotalCopies);
                     break;
                 }
                 tv.setValid();
@@ -141,7 +193,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
             {
                 tv.errorMsg = strprintf(
                     "The activation ticket with this txid [%s] referred by this sell ticket is invalid",
-                    NFTTxnId);
+                    m_nftTxId);
                 break;
             }
             const string& creatorPastelID = actTicket->getPastelID();
@@ -149,7 +201,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
             {
                 tv.errorMsg = strprintf(
                     "The PastelID [%s] in this ticket is not matching the Creator's PastelID [%s] in the NFT Activation ticket with this txid [%s]",
-                    m_sPastelID, creatorPastelID, NFTTxnId);
+                    m_sPastelID, creatorPastelID, m_nftTxId);
                 break;
             }
             //  Get ticket pointed by NFTTxnId. Here, this is an Activation ticket
@@ -188,15 +240,15 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
             {
                 tv.errorMsg = strprintf(
                     "The trade ticket with this txid [%s] referred by this sell ticket is invalid", 
-                    NFTTxnId);
+                    m_nftTxId);
                 break;
             }
-            const string& ownersPastelID = tradeTicket->pastelID;
+            const string& ownersPastelID = tradeTicket->getPastelID();
             if (ownersPastelID != m_sPastelID)
             {
                 tv.errorMsg = strprintf(
                     "The PastelID [%s] in this ticket is not matching the PastelID [%s] in the Trade ticket with this txid [%s]",
-                    m_sPastelID, ownersPastelID, NFTTxnId);
+                    m_sPastelID, ownersPastelID, m_nftTxId);
                 break;
             }
             nTotalCopies = 1;
@@ -213,11 +265,11 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
             }
         }
 
-        if (copyNumber > nTotalCopies || copyNumber == 0)
+        if (m_nCopyNumber > nTotalCopies || m_nCopyNumber == 0)
         {
             tv.errorMsg = strprintf(
                 "Invalid Sell ticket - copy number [%hu] cannot exceed the total number of available copies [%zu] or be 0",
-                copyNumber, nTotalCopies);
+                m_nCopyNumber, nTotalCopies);
             break;
         }
 
@@ -225,17 +277,17 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
         // (ticket transaction replay attack protection)
         // If found similar ticket, replacement is possible if allowed
         // Can be a few Sell tickets
-        const auto existingSellTickets = CNFTSellTicket::FindAllTicketByNFTTxnID(NFTTxnId);
+        const auto existingSellTickets = CNFTSellTicket::FindAllTicketByNFTTxnID(m_nftTxId);
         for (const auto& t : existingSellTickets)
         {
-            if (t.IsBlock(m_nBlock) || t.IsTxId(m_txid) || t.copyNumber != copyNumber)
+            if (t.IsBlock(m_nBlock) || t.IsTxId(m_txid) || t.m_nCopyNumber != m_nCopyNumber)
                 continue;
 
             if (CNFTTradeTicket::CheckTradeTicketExistBySellTicket(t.m_txid))
             {
                 tv.errorMsg = strprintf(
                     "Cannot replace Sell ticket - it has been already sold, txid - [%s], copyNumber [%hu].",
-                    t.m_txid, copyNumber);
+                    t.m_txid, m_nCopyNumber);
                 break;
             }
 
@@ -244,7 +296,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
             {
                 tv.errorMsg = strprintf(
                     "This Sell ticket has been replaced with another ticket, txid - [%s], copyNumber [%hu].",
-                    t.m_txid, copyNumber);
+                    t.m_txid, m_nCopyNumber);
                 break;
             }
 
@@ -253,7 +305,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
             {
                 tv.errorMsg = strprintf(
                     "Can not replace the Sell ticket as master node not is not synced, txid - [%s], copyNumber [%hu].",
-                    t.m_txid, copyNumber);
+                    t.m_txid, m_nCopyNumber);
                 break;
             }
             const unsigned int chainHeight = GetActiveChainHeight();
@@ -262,7 +314,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
                 // 1 block per 2.5; 4 blocks per 10 min; 24 blocks per 1h; 576 blocks per 24 h;
                 tv.errorMsg = strprintf(
                     "Can only replace Sell ticket after 5 days, txid - [%s] copyNumber [%hu].",
-                    t.m_txid, copyNumber);
+                    t.m_txid, m_nCopyNumber);
                 break;
             }
         }
@@ -282,12 +334,12 @@ string CNFTSellTicket::ToJSON() const noexcept
                 {"type", GetTicketName()}, 
                 {"version", GetStoredVersion()}, 
                 {"pastelID", m_sPastelID}, 
-                {"nft_txid", NFTTxnId}, 
-                {"copy_number", copyNumber}, 
-                {"asked_price", askedPrice}, 
-                {"valid_before", activeBefore},
-                {"valid_after", activeAfter},
-                {"locked_recipient", intendedFor.empty()? "not defined": intendedFor},
+                {"nft_txid", m_nftTxId}, 
+                {"copy_number", m_nCopyNumber}, 
+                {"asked_price", m_nAskedPricePSL}, 
+                {"valid_before", m_nValidBefore},
+                {"valid_after", m_nValidAfter},
+                {"locked_recipient", m_sIntendedForPastelID.empty()? "not defined": m_sIntendedForPastelID},
                 {"signature", ed_crypto::Hex_Encode(m_signature.data(), m_signature.size())}
             }
         }

--- a/src/mnode/tickets/nft-sell.h
+++ b/src/mnode/tickets/nft-sell.h
@@ -10,6 +10,15 @@ class CNFTSellTicket;
 // ticket vector
 using NFTSellTickets_t = std::vector<CNFTSellTicket>;
 
+typedef enum class _SELL_TICKET_STATE : uint8_t
+{
+    NOT_DEFINED = 0, // <valid-before> and <valid-after> are not defined (=0)
+    NOT_ACTIVE,      // current-height <= <valid-after>
+    ACTIVE,          // <valid-after> .. current-height .. <valid-before>
+    EXPIRED,         // current-height >= <valid-before>
+    UNAVAILABLE      // current-height > <valid-after>, but <valid-before> not defined
+} SELL_TICKET_STATE;
+
 // NFT Sell Ticket /////////////////////////////////////////////////////////////////////////////////////////////////////
 /*
 	"ticket": {
@@ -23,19 +32,16 @@ using NFTSellTickets_t = std::vector<CNFTSellTicket>;
 		"reserved": "",
 		"signature": ""
 	}
+
+       key #1: <NFT_txid>:<copy_number>
+    MV key #1: seller PastelID
+    MV key #2: NFT txid
  */
 
 class CNFTSellTicket : public CPastelTicket
 {
 public:
-    std::string NFTTxnId;
-    unsigned int askedPrice{};
-    unsigned int activeAfter{};  //as a block height
-    unsigned int activeBefore{}; //as a block height
-    unsigned short copyNumber{};
-    std::string intendedFor;
     std::string reserved;
-
     std::string key;
 
 public:
@@ -56,19 +62,19 @@ public:
     {
         CPastelTicket::Clear();
         m_sPastelID.clear();
-        NFTTxnId.clear();
-        askedPrice = 0;
-        activeAfter = 0;
-        activeBefore = 0;
-        copyNumber = 0;
-        intendedFor.clear();
+        m_nftTxId.clear();
+        m_nAskedPricePSL = 0;
+        m_nValidAfter = 0;
+        m_nValidBefore = 0;
+        m_nCopyNumber = 0;
+        m_sIntendedForPastelID.clear();
         reserved.clear();
         clearSignature();
         key.clear();
     }
-    std::string KeyOne() const noexcept override { return !key.empty() ? key : NFTTxnId + ":" + std::to_string(copyNumber); } //txid:#
+    std::string KeyOne() const noexcept override { return !key.empty() ? key : m_nftTxId + ":" + std::to_string(m_nCopyNumber); } //txid:#
     std::string MVKeyOne() const noexcept override { return m_sPastelID; }
-    std::string MVKeyTwo() const noexcept override { return NFTTxnId; }
+    std::string MVKeyTwo() const noexcept override { return m_nftTxId; }
 
     bool HasMVKeyOne() const noexcept override { return true; }
     bool HasMVKeyTwo() const noexcept override { return true; }
@@ -77,15 +83,24 @@ public:
     std::string ToJSON() const noexcept override;
     std::string ToStr() const noexcept override;
     ticket_validation_t IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept override;
-    // get ticket price in PSL (2% of asked price)
-    CAmount TicketPricePSL(const uint32_t nHeight) const noexcept override { return std::max<CAmount>(10, askedPrice / 50); }
+
+    // get ticket price in PSL (2% of the NFT's asked price)
+    CAmount TicketPricePSL(const uint32_t nHeight) const noexcept override { return std::max<CAmount>(10, m_nAskedPricePSL / 50); }
     bool IsSameSignature(const v_uint8& signature) const noexcept { return m_signature == signature; }
     // sign the ticket with the PastelID's private key - creates signature
     void sign(SecureString&& strKeyPass);
+    // check sell ticket valid state
+    SELL_TICKET_STATE checkValidState(const uint32_t nHeight) const noexcept;
 
     // getters for ticket fields
     const std::string& getPastelID() const noexcept { return m_sPastelID; }
+    const std::string& getNFTTxId() const noexcept { return m_nftTxId; }
+    const std::string& getIntendedForPastelID() const noexcept { return m_sIntendedForPastelID; }
     const std::string getSignature() const noexcept { return vector_to_string(m_signature); }
+    const uint32_t getValidBefore() const noexcept { return m_nValidBefore; }
+    const uint32_t getValidAfter() const noexcept { return m_nValidAfter; }
+    const uint32_t getAskedPricePSL() const noexcept { return m_nAskedPricePSL; }
+    const uint16_t getCopyNumber() const noexcept { return m_nCopyNumber; }
 
     // setters for ticket fields
     void clearSignature() { m_signature.clear(); }
@@ -99,12 +114,12 @@ public:
         READWRITE(m_sPastelID);
         READWRITE(m_nVersion);
         // v0
-        READWRITE(NFTTxnId);
-        READWRITE(askedPrice);
-        READWRITE(activeAfter);
-        READWRITE(activeBefore);
-        READWRITE(copyNumber);
-        READWRITE(intendedFor);
+        READWRITE(m_nftTxId);
+        READWRITE(m_nAskedPricePSL);
+        READWRITE(m_nValidAfter);
+        READWRITE(m_nValidBefore);
+        READWRITE(m_nCopyNumber);
+        READWRITE(m_sIntendedForPastelID);
         READWRITE(reserved);
         READWRITE(m_signature);
         READWRITE(m_nTimestamp);
@@ -112,13 +127,26 @@ public:
         READWRITE(m_nBlock);
     }
 
-    static CNFTSellTicket Create(std::string _NFTTxnId, int _askedPrice, int _validAfter, int _validBefore, int _copy_number, std::string _intendedFor, std::string _pastelID, SecureString&& strKeyPass);
+    static CNFTSellTicket Create(std::string &&NFTTxnId, 
+        const unsigned int nAskedPricePSL, 
+        const uint32_t nValidAfter, 
+        const uint32_t nValidBefore, 
+        const unsigned short nCopyNumber, 
+        std::string &&sIntendedForPastelID, 
+        std::string &&pastelID, 
+        SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CNFTSellTicket& ticket);
 
     static NFTSellTickets_t FindAllTicketByPastelID(const std::string& pastelID);
     static NFTSellTickets_t FindAllTicketByNFTTxnID(const std::string& NFTTxnId);
 
 protected:
-    std::string m_sPastelID;
+    std::string m_nftTxId;
+    std::string m_sPastelID; // Pastel ID of the NFT seller
+    std::string m_sIntendedForPastelID; // Pastel ID of intended recipient of the NFT (can be empty)
+    unsigned int m_nAskedPricePSL = 0;
+    uint32_t m_nValidAfter = 0;  //as a block height
+    uint32_t m_nValidBefore = 0; //as a block height
+    unsigned short m_nCopyNumber = 0;
     v_uint8 m_signature;
 };

--- a/src/mnode/tickets/nft-trade.cpp
+++ b/src/mnode/tickets/nft-trade.cpp
@@ -113,21 +113,21 @@ ticket_validation_t trade_copy_validation(const string& nftTxnId, const v_uint8&
 }
 
 // CNFTTradeTicket ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-CNFTTradeTicket CNFTTradeTicket::Create(string _sellTxnId, string _buyTxnId, string _pastelID, SecureString&& strKeyPass)
+CNFTTradeTicket CNFTTradeTicket::Create(string &&sellTxId, string &&buyTxId, string &&sPastelID, SecureString&& strKeyPass)
 {
-    CNFTTradeTicket ticket(move(_pastelID));
+    CNFTTradeTicket ticket(move(sPastelID));
 
-    ticket.sellTxnId = move(_sellTxnId);
-    ticket.buyTxnId = move(_buyTxnId);
+    ticket.m_sellTxId = move(sellTxId);
+    ticket.m_buyTxId = move(buyTxId);
 
-    auto pSellTicket = CPastelTicketProcessor::GetTicket(ticket.sellTxnId, TicketID::Sell);
+    auto pSellTicket = CPastelTicketProcessor::GetTicket(ticket.m_sellTxId, TicketID::Sell);
     auto sellTicket = dynamic_cast<CNFTSellTicket*>(pSellTicket.get());
     if (!sellTicket)
         throw runtime_error(strprintf("The NFT Sell ticket [txid=%s] referred by this NFT Buy ticket is not in the blockchain. [txid=%s]",
-                                             ticket.sellTxnId, ticket.buyTxnId));
+                                             ticket.m_sellTxId, ticket.m_buyTxId));
 
-    ticket.NFTTxnId = sellTicket->NFTTxnId;
-    ticket.price = sellTicket->askedPrice;
+    ticket.m_nftTxId = sellTicket->getNFTTxId();
+    ticket.price = sellTicket->getAskedPricePSL();
 
     ticket.GenerateTimestamp();
 
@@ -135,8 +135,9 @@ CNFTTradeTicket CNFTTradeTicket::Create(string _sellTxnId, string _buyTxnId, str
     // available within the trade tickets.
     // [0]: original registration ticket's txid
     // [1]: copy number for a given NFT
-    auto NFTRegTicket_TxId_Serial = CNFTTradeTicket::GetNFTRegTxIDAndSerialIfResoldNft(sellTicket->NFTTxnId);
-    if (!NFTRegTicket_TxId_Serial.has_value()) {
+    auto NFTRegTicket_TxId_Serial = CNFTTradeTicket::GetNFTRegTxIDAndSerialIfResoldNft(sellTicket->getNFTTxId());
+    if (!NFTRegTicket_TxId_Serial.has_value())
+    {
         auto NFTTicket = ticket.FindNFTRegTicket();
         if (!NFTTicket)
             throw runtime_error("NFT Reg ticket not found");
@@ -144,14 +145,14 @@ CNFTTradeTicket CNFTTradeTicket::Create(string _sellTxnId, string _buyTxnId, str
         //Original TxId
         ticket.SetNFTRegTicketTxid(NFTTicket->GetTxId());
         //Copy nr.
-        ticket.SetCopySerialNr(to_string(sellTicket->copyNumber));
+        ticket.SetCopySerialNr(to_string(sellTicket->getCopyNumber()));
     } else {
         //This is the re-sold case
         ticket.SetNFTRegTicketTxid(get<0>(NFTRegTicket_TxId_Serial.value()));
         ticket.SetCopySerialNr(get<1>(NFTRegTicket_TxId_Serial.value()));
     }
     const auto strTicket = ticket.ToStr();
-    string_to_vector(CPastelID::Sign(strTicket, ticket.pastelID, move(strKeyPass)), ticket.m_signature);
+    string_to_vector(CPastelID::Sign(strTicket, ticket.m_sPastelID, move(strKeyPass)), ticket.m_signature);
 
     return ticket;
 }
@@ -177,12 +178,12 @@ optional<txid_serial_tuple_t> CNFTTradeTicket::GetNFTRegTxIDAndSerialIfResoldNft
 string CNFTTradeTicket::ToStr() const noexcept
 {
     stringstream ss;
-    ss << pastelID;
-    ss << sellTxnId;
-    ss << buyTxnId;
-    ss << NFTTxnId;
+    ss << m_sPastelID;
+    ss << m_sellTxId;
+    ss << m_buyTxId;
+    ss << m_nftTxId;
     ss << m_nTimestamp;
-    ss << nftRegTxnId;
+    ss << m_nftRegTxId;
     ss << nftCopySerialNr;
     return ss.str();
 }
@@ -204,7 +205,7 @@ ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t 
         // 0. Common validations
         unique_ptr<CPastelTicket> sellTicket;
         ticket_validation_t commonTV = common_ticket_validation(
-            *this, bPreReg, sellTxnId, sellTicket,
+            *this, bPreReg, m_sellTxId, sellTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::Sell); },
             GetTicketDescription(), ::GetTicketDescription(TicketID::Sell), nCallDepth, 
             price + TicketPricePSL(chainHeight));
@@ -212,14 +213,14 @@ ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t 
         {
             tv.errorMsg = strprintf(
                 "The Trade ticket with Sell txid [%s] is not validated. %s", 
-                sellTxnId, commonTV.errorMsg);
+                m_sellTxId, commonTV.errorMsg);
             tv.state = commonTV.state;
             break;
         }
 
         unique_ptr<CPastelTicket> buyTicket;
         commonTV = common_ticket_validation(
-            *this, bPreReg, buyTxnId, buyTicket,
+            *this, bPreReg, m_buyTxId, buyTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::Buy); },
             GetTicketDescription(), ::GetTicketDescription(TicketID::Buy), nCallDepth, 
             price + TicketPricePSL(chainHeight));
@@ -227,14 +228,14 @@ ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t 
         {
             tv.errorMsg = strprintf(
                 "The Trade ticket with Buy txid [%s] is not validated. %s", 
-                buyTxnId, commonTV.errorMsg);
+                m_buyTxId, commonTV.errorMsg);
             tv.state = commonTV.state;
             break;
         }
 
         // 1. Verify that there is no another Trade ticket for the same Sell ticket
         CNFTTradeTicket _tradeTicket;
-        if (CNFTTradeTicket::GetTradeTicketBySellTicket(sellTxnId, _tradeTicket))
+        if (CNFTTradeTicket::GetTradeTicketBySellTicket(m_sellTxId, _tradeTicket))
         {
             // (ticket transaction replay attack protection)
             if (!_tradeTicket.IsSameSignature(m_signature) ||
@@ -243,7 +244,7 @@ ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t 
             {
                 tv.errorMsg = strprintf(
                     "There is already exist trade ticket for the sell ticket with this txid [%s]. Signature - our=%s; their=%s [%sfound ticket block=%u, txid=%s]",
-                    sellTxnId,
+                    m_sellTxId,
                     ed_crypto::Hex_Encode(m_signature.data(), m_signature.size()),
                     ed_crypto::Hex_Encode(_tradeTicket.m_signature.data(), _tradeTicket.m_signature.size()),
                     bPreReg ? "" : strprintf("this ticket block=%u txid=%s; ", m_nBlock, m_txid),
@@ -252,8 +253,8 @@ ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t 
             }
         }
         // 1. Verify that there is no another Trade ticket for the same Buy ticket
-        _tradeTicket.sellTxnId.clear();
-        if (CNFTTradeTicket::GetTradeTicketByBuyTicket(buyTxnId, _tradeTicket))
+        _tradeTicket.m_sellTxId.clear();
+        if (CNFTTradeTicket::GetTradeTicketByBuyTicket(m_buyTxId, _tradeTicket))
         {
             //Compare signatures to skip if the same ticket
             if (!_tradeTicket.IsSameSignature(m_signature) || 
@@ -262,47 +263,60 @@ ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t 
             {
                 tv.errorMsg = strprintf(
                     "There is already exist trade ticket for the buy ticket with this txid [%s]", 
-                    buyTxnId);
+                    m_buyTxId);
                 break;
             }
         }
 
         // Verify asked price
-        const auto sellTicketReal = dynamic_cast<const CNFTSellTicket*>(sellTicket.get());
-        if (!sellTicketReal)
+        const auto pSellTicket = dynamic_cast<const CNFTSellTicket*>(sellTicket.get());
+        if (!pSellTicket)
         {
             tv.errorMsg = strprintf(
                 "The sell ticket with txid [%s] referred by this trade ticket is invalid", 
-                sellTxnId);
+                m_sellTxId);
             break;
         }
-        if (!sellTicketReal->askedPrice)
+        if (!pSellTicket->getAskedPricePSL())
         {
             tv.errorMsg = strprintf(
                 "The NFT Sell ticket with txid [%s] asked price should be not 0", 
-                sellTxnId);
+                m_sellTxId);
             break;
         }
 
-        // 2. Verify Trade ticket PastelID is the same as in Buy Ticket
-        const auto buyTicketReal = dynamic_cast<CNFTBuyTicket*>(buyTicket.get());
-        if (!buyTicketReal)
+        // Verify that Trade ticket's PastelID is the same as in Buy Ticket
+        const auto pBuyTicket = dynamic_cast<CNFTBuyTicket*>(buyTicket.get());
+        if (!pBuyTicket)
         {
             tv.errorMsg = strprintf(
                 "The buy ticket with this txid [%s] referred by this trade ticket is invalid", 
-                buyTxnId);
+                m_buyTxId);
             break;
         }
-        const string& buyersPastelID = buyTicketReal->pastelID;
-        if (buyersPastelID != pastelID)
+        const string& buyersPastelID = pBuyTicket->getPastelID();
+        if (buyersPastelID != m_sPastelID)
         {
             tv.errorMsg = strprintf(
                 "The PastelID [%s] in this Trade ticket is not matching the PastelID [%s] in the Buy ticket with this txid [%s]",
-                pastelID, buyersPastelID, buyTxnId);
+                m_sPastelID, buyersPastelID, m_buyTxId);
             break;
         }
 
-        trade_copy_validation(NFTTxnId, m_signature);
+        // Verify intended recipient of the Sell ticket
+        const auto &sIntendedFor = pSellTicket->getIntendedForPastelID();
+        if (!sIntendedFor.empty())
+        {
+            if (sIntendedFor != buyersPastelID)
+            {
+                tv.errorMsg = strprintf(
+                    "The intended recipient's Pastel ID [%s] in the sell ticket [%s] referred by this Trade ticket is not matching Buyer's Pastel ID [%s]",
+                    sIntendedFor, pSellTicket->GetTxId(), buyersPastelID);
+                break;
+            }
+        }
+
+        trade_copy_validation(m_nftTxId, m_signature);
 
         tv.setValid();
     } while (false);
@@ -311,27 +325,28 @@ ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t 
 
 CAmount CNFTTradeTicket::GetExtraOutputs(vector<CTxOut>& outputs) const
 {
-    auto pNFTSellTicket = CPastelTicketProcessor::GetTicket(sellTxnId, TicketID::Sell);
+    auto pNFTSellTicket = CPastelTicketProcessor::GetTicket(m_sellTxId, TicketID::Sell);
     if (!pNFTSellTicket) {
-        throw runtime_error(strprintf("The NFT Sell ticket with this txid [%s] is not in the blockchain", sellTxnId));
+        throw runtime_error(strprintf("The NFT Sell ticket with this txid [%s] is not in the blockchain", m_sellTxId));
     }
 
     auto NFTSellTicket = dynamic_cast<const CNFTSellTicket*>(pNFTSellTicket.get());
     if (!NFTSellTicket)
-        throw runtime_error(strprintf("The NFT Sell ticket with this txid [%s] is not in the blockchain", sellTxnId));
+        throw runtime_error(strprintf("The NFT Sell ticket with this txid [%s] is not in the blockchain", m_sellTxId));
 
     auto sellerPastelID = NFTSellTicket->getPastelID();
     CPastelIDRegTicket sellerPastelIDticket;
     if (!CPastelIDRegTicket::FindTicketInDb(sellerPastelID, sellerPastelIDticket))
         throw runtime_error(strprintf(
             "The PastelID [%s] from sell ticket with this txid [%s] is not in the blockchain or is invalid",
-            sellerPastelID, sellTxnId));
+            sellerPastelID, m_sellTxId));
 
-    if (!NFTSellTicket->askedPrice) {
-        throw runtime_error(strprintf("The NFT Sell ticket with txid [%s] asked price should be not 0", sellTxnId));
-    }
+    const auto nAskedPricePSL = NFTSellTicket->getAskedPricePSL();
+    if (!nAskedPricePSL)
+        throw runtime_error(strprintf(
+            "The NFT Sell ticket with txid [%s] asked price should be not 0", m_sellTxId));
 
-    CAmount nPriceAmount = NFTSellTicket->askedPrice * COIN;
+    CAmount nPriceAmount = nAskedPricePSL * COIN;
     CAmount nRoyaltyAmount = 0;
     CAmount nGreenNFTAmount = 0;
 
@@ -377,19 +392,19 @@ CAmount CNFTTradeTicket::GetExtraOutputs(vector<CTxOut>& outputs) const
     if (!addOutput(sellerPastelIDticket.address, nPriceAmount)) {
         throw runtime_error(
             strprintf("The PastelID [%s] from sell ticket with this txid [%s] has invalid address",
-                      sellerPastelID, sellTxnId));
+                      sellerPastelID, m_sellTxId));
     }
 
     if (!strRoyaltyAddress.empty() && !addOutput(strRoyaltyAddress, nRoyaltyAmount)) {
         throw runtime_error(
             strprintf("The PastelID [%s] from sell ticket with this txid [%s] has invalid address",
-                      sellerPastelID, sellTxnId));
+                      sellerPastelID, m_sellTxId));
     }
 
     if (NFTRegTicket->hasGreenFee() && !addOutput(NFTRegTicket->getGreenAddress(), nGreenNFTAmount)) {
         throw runtime_error(
             strprintf("The PastelID [%s] from sell ticket with this txid [%s] has invalid address",
-                      sellerPastelID, sellTxnId));
+                      sellerPastelID, m_sellTxId));
     }
 
     return nPriceAmount + nRoyaltyAmount + nGreenNFTAmount;
@@ -405,11 +420,11 @@ string CNFTTradeTicket::ToJSON() const noexcept
             {
                 {"type", GetTicketName()}, 
                 {"version", GetStoredVersion()}, 
-                {"pastelID", pastelID}, 
-                {"sell_txid", sellTxnId}, 
-                {"buy_txid", buyTxnId}, 
-                {"nft_txid", NFTTxnId}, 
-                {"registration_txid", nftRegTxnId}, 
+                {"pastelID", m_sPastelID}, 
+                {"sell_txid", m_sellTxId}, 
+                {"buy_txid", m_buyTxId}, 
+                {"nft_txid", m_nftTxId}, 
+                {"registration_txid", m_nftRegTxId}, 
                 {"copy_serial_nr", nftCopySerialNr}, 
                 {"signature", ed_crypto::Hex_Encode(m_signature.data(), m_signature.size())}
             }
@@ -420,8 +435,8 @@ string CNFTTradeTicket::ToJSON() const noexcept
 
 bool CNFTTradeTicket::FindTicketInDb(const string& key, CNFTTradeTicket& ticket)
 {
-    ticket.sellTxnId = key;
-    ticket.buyTxnId = key;
+    ticket.m_sellTxId = key;
+    ticket.m_buyTxId = key;
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket) ||
            masterNodeCtrl.masternodeTickets.FindTicketBySecondaryKey(ticket);
 }
@@ -469,7 +484,7 @@ mu_strings CNFTTradeTicket::GetPastelIdAndTxIdWithTopHeightPerCopy(const NFTTrad
     // we need to extract owners pastelId and TxnIds
     for (const auto& winners : copyOwner_Idxs) {
         const auto& winnerTradeTkt = filteredTickets[winners.second.second];
-        ownerPastelIDs_and_txids.emplace(winnerTradeTkt.pastelID, winnerTradeTkt.GetTxId());
+        ownerPastelIDs_and_txids.emplace(winnerTradeTkt.getPastelID(), winnerTradeTkt.GetTxId());
     }
 
     return ownerPastelIDs_and_txids;
@@ -478,26 +493,26 @@ mu_strings CNFTTradeTicket::GetPastelIdAndTxIdWithTopHeightPerCopy(const NFTTrad
 bool CNFTTradeTicket::CheckTradeTicketExistBySellTicket(const string& _sellTxnId)
 {
     CNFTTradeTicket _ticket;
-    _ticket.sellTxnId = _sellTxnId;
+    _ticket.m_sellTxId = _sellTxnId;
     return masterNodeCtrl.masternodeTickets.CheckTicketExist(_ticket);
 }
 
 bool CNFTTradeTicket::CheckTradeTicketExistByBuyTicket(const string& _buyTxnId)
 {
     CNFTTradeTicket _ticket;
-    _ticket.buyTxnId = _buyTxnId;
+    _ticket.m_buyTxId = _buyTxnId;
     return masterNodeCtrl.masternodeTickets.CheckTicketExistBySecondaryKey(_ticket);
 }
 
 bool CNFTTradeTicket::GetTradeTicketBySellTicket(const string& _sellTxnId, CNFTTradeTicket& ticket)
 {
-    ticket.sellTxnId = _sellTxnId;
+    ticket.m_sellTxId = _sellTxnId;
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
 }
 
 bool CNFTTradeTicket::GetTradeTicketByBuyTicket(const string& _buyTxnId, CNFTTradeTicket& ticket)
 {
-    ticket.buyTxnId = _buyTxnId;
+    ticket.m_buyTxId = _buyTxnId;
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
 }
 
@@ -505,7 +520,7 @@ unique_ptr<CPastelTicket> CNFTTradeTicket::FindNFTRegTicket() const
 {
     vector<unique_ptr<CPastelTicket>> chain;
     string errRet;
-    if (!CPastelTicketProcessor::WalkBackTradingChain(NFTTxnId, chain, true, errRet)) {
+    if (!CPastelTicketProcessor::WalkBackTradingChain(m_nftTxId, chain, true, errRet)) {
         throw runtime_error(errRet);
     }
 
@@ -521,12 +536,12 @@ unique_ptr<CPastelTicket> CNFTTradeTicket::FindNFTRegTicket() const
 
 void CNFTTradeTicket::SetNFTRegTicketTxid(const string& _NftRegTxid)
 {
-    nftRegTxnId = _NftRegTxid;
+    m_nftRegTxId = _NftRegTxid;
 }
 
 const string CNFTTradeTicket::GetNFTRegTicketTxid() const
 {
-    return nftRegTxnId;
+    return m_nftRegTxId;
 }
 
 void CNFTTradeTicket::SetCopySerialNr(const string& _nftCopySerialNr)

--- a/src/mnode/tickets/nft-trade.h
+++ b/src/mnode/tickets/nft-trade.h
@@ -32,11 +32,6 @@ using txid_serial_tuple_t = std::tuple<std::string, std::string>;
 class CNFTTradeTicket : public CPastelTicket
 {
 public:
-    std::string pastelID;
-    std::string sellTxnId;
-    std::string buyTxnId;
-    std::string NFTTxnId;
-    std::string nftRegTxnId;
     std::string nftCopySerialNr;
 
     unsigned int price{};
@@ -48,8 +43,8 @@ protected:
 public:
     CNFTTradeTicket() = default;
 
-    explicit CNFTTradeTicket(std::string _pastelID) : 
-        pastelID(std::move(_pastelID))
+    explicit CNFTTradeTicket(std::string &&sPastelID) : 
+        m_sPastelID(std::move(sPastelID))
     {}
 
     TicketID ID() const noexcept override { return TicketID::Trade; }
@@ -61,28 +56,28 @@ public:
 
     void Clear() noexcept override
     {
-        pastelID.clear();
-        sellTxnId.clear();
-        buyTxnId.clear();
-        NFTTxnId.clear();
-        nftRegTxnId.clear();
+        m_sPastelID.clear();
+        m_sellTxId.clear();
+        m_buyTxId.clear();
+        m_nftTxId.clear();
+        m_nftRegTxId.clear();
         nftCopySerialNr.clear();
         price = 0;
         reserved.clear();
         m_signature.clear();
     }
-    std::string KeyOne() const noexcept override { return sellTxnId; }
-    std::string KeyTwo() const noexcept override { return buyTxnId; }
-    std::string MVKeyOne() const noexcept override { return pastelID; }
-    std::string MVKeyTwo() const noexcept override { return NFTTxnId; }
-    std::string MVKeyThree() const noexcept override { return nftRegTxnId; }
+    std::string KeyOne() const noexcept override { return m_sellTxId; }
+    std::string KeyTwo() const noexcept override { return m_buyTxId; }
+    std::string MVKeyOne() const noexcept override { return m_sPastelID; }
+    std::string MVKeyTwo() const noexcept override { return m_nftTxId; }
+    std::string MVKeyThree() const noexcept override { return m_nftRegTxId; }
 
     bool HasKeyTwo() const noexcept override { return true; }
     bool HasMVKeyOne() const noexcept override { return true; }
     bool HasMVKeyTwo() const noexcept override { return true; }
     bool HasMVKeyThree() const noexcept override { return true; }
 
-    void SetKeyOne(std::string&& sValue) override { sellTxnId = std::move(sValue); }
+    void SetKeyOne(std::string&& sValue) override { m_sellTxId = std::move(sValue); }
 
     std::string ToJSON() const noexcept override;
     std::string ToStr() const noexcept override;
@@ -90,7 +85,10 @@ public:
     bool IsSameSignature(const v_uint8& signature) const noexcept { return m_signature == signature; }
 
     // getters for ticket fields
-    const std::string& getPastelID() const noexcept { return pastelID; }
+    const std::string& getPastelID() const noexcept { return m_sPastelID; }
+    const std::string& getSellTxId() const noexcept { return m_sellTxId; }
+    const std::string& getBuyTxId() const noexcept { return m_buyTxId; }
+    const std::string& getNFTTxId() const noexcept { return m_nftTxId; }
     const std::string getSignature() const noexcept { return vector_to_string(m_signature); }
 
     void SerializationOp(CDataStream& s, const SERIALIZE_ACTION ser_action) override
@@ -99,25 +97,25 @@ public:
         std::string error;
         if (!VersionMgmt(error, bRead))
             throw std::runtime_error(error);
-        READWRITE(pastelID);
+        READWRITE(m_sPastelID);
         READWRITE(m_nVersion);
         // v0
-        READWRITE(sellTxnId);
-        READWRITE(buyTxnId);
-        READWRITE(NFTTxnId);
+        READWRITE(m_sellTxId);
+        READWRITE(m_buyTxId);
+        READWRITE(m_nftTxId);
         READWRITE(price);
         READWRITE(reserved);
         READWRITE(m_signature);
         READWRITE(m_nTimestamp);
         READWRITE(m_txid);
         READWRITE(m_nBlock);
-        READWRITE(nftRegTxnId);
+        READWRITE(m_nftRegTxId);
         READWRITE(nftCopySerialNr);
     }
 
     CAmount GetExtraOutputs(std::vector<CTxOut>& outputs) const override;
 
-    static CNFTTradeTicket Create(std::string _sellTxnId, std::string _buyTxnId, std::string _pastelID, SecureString&& strKeyPass);
+    static CNFTTradeTicket Create(std::string &&sellTxId, std::string &&buyTxId, std::string &&sPastelID, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CNFTTradeTicket& ticket);
 
     static NFTTradeTickets_t FindAllTicketByPastelID(const std::string& pastelID);
@@ -138,4 +136,11 @@ public:
     const std::string& GetCopySerialNr() const;
 
     static std::optional<txid_serial_tuple_t> GetNFTRegTxIDAndSerialIfResoldNft(const std::string& _txid);
+
+protected:
+    std::string m_sPastelID; // buyer Pastel ID
+    std::string m_sellTxId;  // sell ticket txid
+    std::string m_buyTxId;   // buy ticket txid
+    std::string m_nftTxId;   // txid with either 1) NFT activation ticket or 2) trade ticket in it
+    std::string m_nftRegTxId;// NFT registration ticket txid
 };


### PR DESCRIPTION
 - added additional check to IsValid method for Buy and Trade tickets.
When 'intendedFor' field in Sell ticket is not empty - it should match the Pastel ID of the Buy ticket (Buyer Pastel ID).
Same check is added to Trade ticket.ticket-processor
- refactored checks in Sell ticket for valid-before/valid-after fields.
Used new enum class SELL_TICKET_STATE to check Sell ticket status (not defined, not active, active, expired, unavailable).UNAVAILABLE
- added new parameter 'intendedFor' to 'tickets register sell' rpc API:
tickets register sell "nft-txid" "price" "PastelID" "passphrase" [valid-after] [valid-before] [copy-number] ["address"] ["intendedFor"]
....
9. "intendedFor"   (string, optional) The PastelID of the intended recipient of the NFT (empty by default).
- added additional checks for valid-before/valid-after parameters in "tickets register sell" API (rpc_check_unsigned_param)
- gtest for rpc_check_unsigned_param
- python test for intendedFor feature in mn_tickets.py:
   - create, register and activate NFT ticket
   - register Sell ticket with intendedFor field
   - check that Buy ticket cannot be registered with a Pastel ID not matching intendedFor
   - register Buy ticket
   - check that Trade ticket cannot be registered with a Pastel ID not matching intendedFor
   - register Trade ticket