### PR TITLE
[PSL-401] Add support for Cezanne upgrade with activation height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -42,8 +42,16 @@ Genesis block for RegTest found
 
 using namespace std;
 
-constexpr unsigned int OVERWINTER_STARTING_BLOCK = 10;
-constexpr unsigned int SAPLING_STARTING_BLOCK = 20;
+// mainnet upgrades activation heights
+constexpr uint32_t MAINNET_OVERWINTER_STARTING_BLOCK = 10;
+constexpr uint32_t MAINNET_SAPLING_STARTING_BLOCK = 20;
+constexpr uint32_t MAINNET_CEZANNE_UPGRADE_STARTING_BLOCK = 340'000;
+
+// testnet upgrades activation heights
+constexpr uint32_t TESTNET_OVERWINTER_STARTING_BLOCK = 10;
+constexpr uint32_t TESTNET_SAPLING_STARTING_BLOCK = 20;
+constexpr uint32_t TESTNET_CEZANNE_UPGRADE_STARTING_BLOCK = 160'000;
+
 
 static CBlock CreateGenesisBlock(const char* pszTimestamp, 
                                  const v_uint8 &genesisPubKey, 
@@ -322,14 +330,11 @@ public:
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
         consensus.nPowTargetSpacing = static_cast<int64_t>(2.5 * 60);
         consensus.nPowAllowMinDifficultyBlocksAfterHeight = std::nullopt;
-        consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
-        consensus.vUpgrades[Consensus::BASE_SPROUT].nActivationHeight = Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
-        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nProtocolVersion = 170002;
-        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nActivationHeight = Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
-        consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nProtocolVersion = 170005;
-        consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = OVERWINTER_STARTING_BLOCK;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170007;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = SAPLING_STARTING_BLOCK;
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::BASE_SPROUT, 170002, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_TESTDUMMY, 170002, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170005, MAINNET_OVERWINTER_STARTING_BLOCK);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170007, MAINNET_SAPLING_STARTING_BLOCK);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, MAINNET_CEZANNE_UPGRADE_STARTING_BLOCK);
         consensus.nMaxGovernanceAmount = 100'000'000*COIN;
 
         // The best chain should have at least this much work.
@@ -429,14 +434,11 @@ public:
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
         consensus.nPowTargetSpacing = static_cast<int64_t>(2.5 * 60);
         consensus.nPowAllowMinDifficultyBlocksAfterHeight = 299'187;
-        consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
-        consensus.vUpgrades[Consensus::BASE_SPROUT].nActivationHeight = Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
-        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nProtocolVersion = 170002;
-        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nActivationHeight = Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
-        consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nProtocolVersion = 170003;
-        consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = OVERWINTER_STARTING_BLOCK;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170007;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = SAPLING_STARTING_BLOCK;
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::BASE_SPROUT, 170002, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_TESTDUMMY, 170002, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170005, TESTNET_OVERWINTER_STARTING_BLOCK);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170007, TESTNET_SAPLING_STARTING_BLOCK);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, TESTNET_CEZANNE_UPGRADE_STARTING_BLOCK);
         consensus.nMaxGovernanceAmount = 1'000'000*COIN;
 
         // The best chain should have at least this much work.
@@ -532,14 +534,11 @@ public:
         consensus.nPowMaxAdjustUp = 0; // Turn off adjustment up
         consensus.nPowTargetSpacing = static_cast<int64_t>(2.5 * 60);
         consensus.nPowAllowMinDifficultyBlocksAfterHeight = 0;
-        consensus.vUpgrades[Consensus::BASE_SPROUT].nProtocolVersion = 170002;
-        consensus.vUpgrades[Consensus::BASE_SPROUT].nActivationHeight = Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
-        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nProtocolVersion = 170002;
-        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nActivationHeight = Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
-        consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nProtocolVersion = 170003;
-        consensus.vUpgrades[Consensus::UPGRADE_OVERWINTER].nActivationHeight = Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nProtocolVersion = 170008;
-        consensus.vUpgrades[Consensus::UPGRADE_SAPLING].nActivationHeight = Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::BASE_SPROUT, 170002, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_TESTDUMMY, 170002, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170003, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170008, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
         consensus.nMaxGovernanceAmount = 1'000'000*COIN;
 
         // The best chain should have at least this much work.
@@ -604,12 +603,6 @@ public:
         checkpointData.nTransactionsLastCheckpoint = 0;
         checkpointData.fTransactionsPerDay = 0;
     }
-
-    void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, const int nActivationHeight)
-    {
-        assert(idx > Consensus::BASE_SPROUT && idx < Consensus::MAX_NETWORK_UPGRADES);
-        consensus.vUpgrades[idx].nActivationHeight = nActivationHeight;
-    }
 };
 
 // global blockchain parameters
@@ -673,7 +666,7 @@ bool SelectParamsFromCommandLine()
     return true;
 }
 
-void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, const int nActivationHeight)
+void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, const uint32_t nActivationHeight)
 {
     if (globalChainParams && globalChainParams->IsRegTest())
     {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -335,6 +335,8 @@ public:
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170005, MAINNET_OVERWINTER_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170007, MAINNET_SAPLING_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, MAINNET_CEZANNE_UPGRADE_STARTING_BLOCK);
+        // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
+        consensus.nNetworkUpgradePeerPreferenceBlockPeriod = MAINNET_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD;
         consensus.nMaxGovernanceAmount = 100'000'000*COIN;
 
         // The best chain should have at least this much work.
@@ -439,6 +441,8 @@ public:
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170005, TESTNET_OVERWINTER_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170007, TESTNET_SAPLING_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, TESTNET_CEZANNE_UPGRADE_STARTING_BLOCK);
+        // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
+        consensus.nNetworkUpgradePeerPreferenceBlockPeriod = TESTNET_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD;
         consensus.nMaxGovernanceAmount = 1'000'000*COIN;
 
         // The best chain should have at least this much work.
@@ -539,6 +543,8 @@ public:
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170003, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170008, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
+        consensus.nNetworkUpgradePeerPreferenceBlockPeriod = REGTEST_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD;
         consensus.nMaxGovernanceAmount = 1'000'000*COIN;
 
         // The best chain should have at least this much work.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -95,6 +95,12 @@ public:
     bool IsTestNet() const noexcept { return network == CBaseChainParams::Network::TESTNET; }
     bool IsRegTest() const noexcept { return network == CBaseChainParams::Network::REGTEST; }
 
+    void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, const uint32_t nActivationHeight)
+    {
+        if (IsRegTest())
+            consensus.UpdateNetworkUpgradeParameters(idx, nActivationHeight);
+    }
+
 protected:
     CChainParams()
     {
@@ -143,4 +149,4 @@ bool SelectParamsFromCommandLine();
 /**
  * Allows modifying the network upgrade regtest parameters.
  */
-void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, const int nActivationHeight);
+void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, const uint32_t nActivationHeight);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -92,6 +92,9 @@ struct Params
     int64_t MaxActualTimespan() const noexcept { return (AveragingWindowTimespan() * (100 + nPowMaxAdjustDown)) / 100; }
     uint256 nMinimumChainWork;
     int64_t nMaxGovernanceAmount;
+    // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks)
+    uint32_t nNetworkUpgradePeerPreferenceBlockPeriod = 0;
+
 
     /**
      * Add network upgrade.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -1,12 +1,15 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#include "uint256.h"
-#include "key_constants.h"
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <optional>
+#include <limits>
+
+#include <uint256.h>
+#include <key_constants.h>
+#include <enum_util.h>
 
 namespace Consensus {
 
@@ -18,17 +21,20 @@ namespace Consensus {
  * The order of these indices MUST match the order of the upgrades on-chain, as
  * several functions depend on the enum being sorted.
  */
-enum UpgradeIndex {
+enum class UpgradeIndex : int
+{
     // Sprout must be first
     BASE_SPROUT,
     UPGRADE_TESTDUMMY,
     UPGRADE_OVERWINTER,
     UPGRADE_SAPLING,
+    UPGRADE_CEZANNE,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES
 };
 
-struct NetworkUpgrade {
+struct NetworkUpgrade
+{
     /**
      * The first protocol version which will understand the new consensus rules
      */
@@ -37,7 +43,7 @@ struct NetworkUpgrade {
     /**
      * Height of the first block for which the new consensus rules will be active
      */
-    int nActivationHeight;
+    uint32_t nActivationHeight;
 
     /**
      * Special value for nActivationHeight indicating that the upgrade is always active.
@@ -48,20 +54,21 @@ struct NetworkUpgrade {
      * this value. However, additional care must be taken to ensure the genesis block
      * satisfies the enabled rules.
      */
-    static constexpr int ALWAYS_ACTIVE = 0;
+    static constexpr uint32_t ALWAYS_ACTIVE = 0;
 
     /**
      * Special value for nActivationHeight indicating that the upgrade will never activate.
      * This is useful when adding upgrade code that has a testnet activation height, but
      * should remain disabled on mainnet.
      */
-    static constexpr int NO_ACTIVATION_HEIGHT = -1;
+    static constexpr uint32_t NO_ACTIVATION_HEIGHT = std::numeric_limits<uint32_t>::max();
 };
 
 /**
  * Parameters that influence chain consensus.
  */
-struct Params {
+struct Params
+{
     uint256 hashGenesisBlock;
 
     int nSubsidyHalvingInterval;
@@ -69,7 +76,7 @@ struct Params {
     int nMajorityEnforceBlockUpgrade;
     int nMajorityRejectBlockOutdated;
     int nMajorityWindow;
-    NetworkUpgrade vUpgrades[MAX_NETWORK_UPGRADES];
+    NetworkUpgrade vUpgrades[to_integral_type(UpgradeIndex::MAX_NETWORK_UPGRADES)];
     /** Proof of work parameters */
     unsigned int nEquihashN = 0;
     unsigned int nEquihashK = 0;
@@ -79,10 +86,31 @@ struct Params {
     int64_t nPowMaxAdjustDown;
     int64_t nPowMaxAdjustUp;
     int64_t nPowTargetSpacing;
-    int64_t AveragingWindowTimespan() const { return nPowAveragingWindow * nPowTargetSpacing; }
-    int64_t MinActualTimespan() const { return (AveragingWindowTimespan() * (100 - nPowMaxAdjustUp  )) / 100; }
-    int64_t MaxActualTimespan() const { return (AveragingWindowTimespan() * (100 + nPowMaxAdjustDown)) / 100; }
+
+    int64_t AveragingWindowTimespan() const noexcept { return nPowAveragingWindow * nPowTargetSpacing; }
+    int64_t MinActualTimespan() const noexcept { return (AveragingWindowTimespan() * (100 - nPowMaxAdjustUp  )) / 100; }
+    int64_t MaxActualTimespan() const noexcept { return (AveragingWindowTimespan() * (100 + nPowMaxAdjustDown)) / 100; }
     uint256 nMinimumChainWork;
     int64_t nMaxGovernanceAmount;
+
+    /**
+     * Add network upgrade.
+     * 
+     * \param idx - index of the upgrade
+     * \param nProtocolVersion - protocol version for the new upgrade
+     * \param nActivationHeight - height when to activate new protocol version
+     */
+    void AddNetworkUpgrade(const UpgradeIndex idx, const int nProtocolVersion, const uint32_t nActivationHeight) noexcept
+    {
+        const auto nUpgradeIndex = to_integral_type(idx);
+        vUpgrades[nUpgradeIndex].nProtocolVersion = nProtocolVersion;
+        vUpgrades[nUpgradeIndex].nActivationHeight = nActivationHeight;
+    }
+
+    void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, const uint32_t nActivationHeight) noexcept
+    {
+        const auto nUpgradeIndex = to_integral_type(idx);
+        vUpgrades[nUpgradeIndex].nActivationHeight = nActivationHeight;
+    }
 };
 } // namespace Consensus

--- a/src/consensus/upgrades.h
+++ b/src/consensus/upgrades.h
@@ -1,11 +1,14 @@
 #pragma once
 // Copyright (c) 2018 The Zcash developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include "consensus/params.h"
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <optional>
 
-enum UpgradeState {
+#include <consensus/params.h>
+
+enum class UpgradeState
+{
     UPGRADE_DISABLED,
     UPGRADE_PENDING,
     UPGRADE_ACTIVE
@@ -30,9 +33,9 @@ extern const uint32_t SPROUT_BRANCH_ID;
  * Caller must check that the height is >= 0 (and handle unknown heights).
  */
 UpgradeState NetworkUpgradeState(
-    const unsigned int nHeight,
+    const uint32_t nHeight,
     const Consensus::Params& params,
-    Consensus::UpgradeIndex idx);
+    Consensus::UpgradeIndex idx) noexcept;
 
 /**
  * Returns true if the given network upgrade is active as of the given block
@@ -40,57 +43,55 @@ UpgradeState NetworkUpgradeState(
  * heights).
  */
 bool NetworkUpgradeActive(
-    const unsigned int nHeight,
+    const uint32_t nHeight,
     const Consensus::Params& params,
-    Consensus::UpgradeIndex idx);
+    Consensus::UpgradeIndex idx) noexcept;
 
 /**
  * Returns the index of the most recent upgrade as of the given block height
- * (corresponding to the current "epoch"). Consensus::BASE_SPROUT is the
+ * (corresponding to the current "epoch"). Consensus::UpgradeIndex::BASE_SPROUT is the
  * default value if no upgrades are active. Caller must check that the height
  * is >= 0 (and handle unknown heights).
  */
-int CurrentEpoch(int nHeight, const Consensus::Params& params);
+int CurrentEpoch(const uint32_t nHeight, const Consensus::Params& params) noexcept;
 
 /**
  * Returns the branch ID of the most recent upgrade as of the given block height
  * (corresponding to the current "epoch"), or 0 if no upgrades are active.
  * Caller must check that the height is >= 0 (and handle unknown heights).
  */
-uint32_t CurrentEpochBranchId(int nHeight, const Consensus::Params& params);
+uint32_t CurrentEpochBranchId(const uint32_t nHeight, const Consensus::Params& params) noexcept;
 
 /**
  * Returns true if a given branch id is a valid nBranchId for one of the network
  * upgrades contained in NetworkUpgradeInfo.
  */
-bool IsConsensusBranchId(int branchId);
+bool IsConsensusBranchId(const uint32_t branchId) noexcept;
 
 /**
  * Returns true if the given block height is the activation height for the given
  * upgrade.
  */
 bool IsActivationHeight(
-    int nHeight,
+    const uint32_t nHeight,
     const Consensus::Params& params,
-    Consensus::UpgradeIndex upgrade);
+    Consensus::UpgradeIndex upgrade) noexcept;
 
 /**
  * Returns true if the given block height is the activation height for any upgrade.
  */
-bool IsActivationHeightForAnyUpgrade(
-    int nHeight,
-    const Consensus::Params& params);
+bool IsActivationHeightForAnyUpgrade(const uint32_t nHeight, const Consensus::Params& params);
 
 /**
  * Returns the index of the next upgrade after the given block height, or
  * std::nullopt if there are no more known upgrades.
  */
-std::optional<int> NextEpoch(int nHeight, const Consensus::Params& params);
+std::optional<uint32_t> NextEpoch(const uint32_t nHeight, const Consensus::Params& params) noexcept;
 
 /**
  * Returns the activation height for the next upgrade after the given block height,
  * or std::nullopt if there are no more known upgrades.
  */
-std::optional<int> NextActivationHeight(
-    int nHeight,
-    const Consensus::Params& params);
+std::optional<uint32_t> NextActivationHeight(const uint32_t nHeight, const Consensus::Params& params) noexcept;
+
+uint32_t GetUpgradeBranchId(Consensus::UpgradeIndex idx) noexcept;

--- a/src/gtest/test_DoS.cpp
+++ b/src/gtest/test_DoS.cpp
@@ -122,7 +122,7 @@ class PTestDoS : public TestWithParam<int>
 TEST_P(PTestDoS, DoS_mapOrphans)
 {
     const int sample = GetParam();
-    EXPECT_LT(sample, static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_LT(sample, static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 

--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -64,8 +64,8 @@ protected:
 
     void TearDown() override {
         // Revert to test default. No-op on mainnet params.
-        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
     }
 
     // Returns a valid but empty mutable transaction at block height 1.
@@ -204,7 +204,7 @@ TEST_F(ContextualCheckBlockTest, BlockSproutRulesAcceptSproutTx) {
 // Test block evaluated under Overwinter rules will accept Overwinter transactions.
 TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesAcceptOverwinterTx) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 1);
 
     CMutableTransaction mtx = GetFirstBlockCoinbaseTx();
 
@@ -221,8 +221,8 @@ TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesAcceptOverwinterTx) {
 // Test that a block evaluated under Sapling rules can contain Sapling transactions.
 TEST_F(ContextualCheckBlockTest, BlockSaplingRulesAcceptSaplingTx) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, 1);
 
     CMutableTransaction mtx = GetFirstBlockCoinbaseTx();
 
@@ -274,7 +274,7 @@ TEST_F(ContextualCheckBlockTest, BlockSproutRulesRejectOtherTx)
 TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesRejectOtherTx)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 1);
 
     CMutableTransaction mtx = GetFirstBlockCoinbaseTx();
 
@@ -301,8 +301,8 @@ TEST_F(ContextualCheckBlockTest, BlockOverwinterRulesRejectOtherTx)
 // Test block evaluated under Sapling rules cannot contain non-Sapling transactions.
 TEST_F(ContextualCheckBlockTest, BlockSaplingRulesRejectOtherTx) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, 1);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 1);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, 1);
 
     CMutableTransaction mtx = GetFirstBlockCoinbaseTx();
 

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -99,8 +99,8 @@ TEST(checktransaction_tests, BadTxnsOversize)
 
     {
         // But should be fine again once Sapling activates!
-        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+        UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+        UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
         mtx.fOverwintered = true;
         mtx.nVersionGroupId = SAPLING_VERSION_GROUP_ID;
@@ -114,16 +114,16 @@ TEST(checktransaction_tests, BadTxnsOversize)
         EXPECT_TRUE(ContextualCheckTransaction(tx, state, Params(), 1, 100));
 
         // Revert to default
-        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
     }
 }
 
 TEST(checktransaction_tests, OversizeSaplingTxns)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CMutableTransaction mtx = GetValidTransaction();
     mtx.fOverwintered = true;
@@ -171,8 +171,8 @@ TEST(checktransaction_tests, OversizeSaplingTxns)
     }
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(checktransaction_tests, bad_txns_vout_negative) {
@@ -480,7 +480,7 @@ TEST(checktransaction_tests, OverwinterVersionNumberLow)
 TEST(checktransaction_tests, OverwinterVersionNumberHigh)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CMutableTransaction mtx = GetValidTransaction();
     mtx.fOverwintered = true;
@@ -494,7 +494,7 @@ TEST(checktransaction_tests, OverwinterVersionNumberHigh)
     ContextualCheckTransaction(tx, state, Params(), 1, 100);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 
@@ -536,7 +536,7 @@ TEST(checktransaction_tests, OverwinterNotActive) {
 // This tests a transaction without the fOverwintered flag set, against the Overwinter consensus rule set.
 TEST(checktransaction_tests, OverwinterFlagNotSet) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     CMutableTransaction mtx = GetValidTransaction();
     mtx.fOverwintered = false;
@@ -550,7 +550,7 @@ TEST(checktransaction_tests, OverwinterFlagNotSet) {
     ContextualCheckTransaction(tx, state, Params(), 1, 100);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 
@@ -582,8 +582,8 @@ TEST(checktransaction_tests, OverwinteredContextualCreateTx) {
     const Consensus::Params& consensusParams = Params().GetConsensus();
     int activationHeight = 5;
     int saplingActivationHeight = 30;
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, activationHeight);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, saplingActivationHeight);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, activationHeight);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, saplingActivationHeight);
 
     {
         CMutableTransaction mtx = CreateNewContextualCMutableTransaction(
@@ -660,8 +660,8 @@ TEST(checktransaction_tests, OverwinteredContextualCreateTx) {
     }
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 // Test a v1 transaction which has a malformed header, perhaps modified in-flight

--- a/src/gtest/test_multisig.cpp
+++ b/src/gtest/test_multisig.cpp
@@ -48,7 +48,7 @@ TEST_P(PTest_Multisig, multisig_verify)
 {
     const int sample = GetParam();
 
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
     unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
@@ -153,7 +153,7 @@ TEST_P(PTest_Multisig, multisig_Sign)
 {
     const int sample = GetParam();
 
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 

--- a/src/gtest/test_rpc.cpp
+++ b/src/gtest/test_rpc.cpp
@@ -378,7 +378,7 @@ TEST_F(TestRpc, rpc_ban)
 TEST_F(TestRpc, rpc_raw_create_overwinter_v3)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     // Sample regtest address:
     // public: tPmCf9DhN5jv5CgrxDMHRz6wsEjWwM6qJnZ
@@ -410,7 +410,7 @@ TEST_F(TestRpc, rpc_raw_create_overwinter_v3)
     EXPECT_EQ(tx.GetHash().GetHex(), CTransaction(mtx).GetHash().GetHex());
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(test_rpc, rpc_getnetworksolps)

--- a/src/gtest/test_rpc_wallet.cpp
+++ b/src/gtest/test_rpc_wallet.cpp
@@ -856,8 +856,8 @@ TEST_F(TestRpcWallet, rpc_z_sendmany_parameters)
 TEST_F(TestRpcWallet, rpc_z_sendmany_taddr_to_sapling)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
@@ -951,8 +951,8 @@ TEST_F(TestRpcWallet, rpc_z_sendmany_taddr_to_sapling)
     mapArgs.erase("-experimentalfeatures");
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 class TestRpcWallet2 : public Test

--- a/src/gtest/test_script.cpp
+++ b/src/gtest/test_script.cpp
@@ -636,7 +636,7 @@ class PTest_Script : public TestWithParam<int>
 TEST_P(PTest_Script, script_valid)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
@@ -672,7 +672,7 @@ TEST_P(PTest_Script, script_valid)
 TEST_P(PTest_Script, script_invalid)
 {    
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
     // Scripts that should evaluate as invalid
@@ -702,7 +702,7 @@ TEST_P(PTest_Script, script_invalid)
 TEST_P(PTest_Script, script_PushData)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
     // Check that PUSHDATA1, PUSHDATA2, and PUSHDATA4 create the same value on
@@ -769,7 +769,7 @@ sign_multisig(CScript scriptPubKey, const CKey &key, CTransaction transaction, u
 TEST_P(PTest_Script, script_CHECKMULTISIG12)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
     ScriptError err;
@@ -804,7 +804,7 @@ TEST_P(PTest_Script, script_CHECKMULTISIG12)
 TEST_P(PTest_Script, script_CHECKMULTISIG23)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
     ScriptError err;
@@ -880,7 +880,7 @@ TEST_P(PTest_Script, script_CHECKMULTISIG23)
 TEST_P(PTest_Script, script_combineSigs)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
     // Test the CombineSignatures function
@@ -995,7 +995,7 @@ TEST_P(PTest_Script, script_combineSigs)
 TEST_P(PTest_Script, script_standard_push)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
     ScriptError err;

--- a/src/gtest/test_script_P2SH.cpp
+++ b/src/gtest/test_script_P2SH.cpp
@@ -55,7 +55,7 @@ class PTest_ScriptP2SH : public TestWithParam<int>
 TEST_P(PTest_ScriptP2SH, sign)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     LOCK(cs_main);
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
@@ -137,7 +137,7 @@ TEST_P(PTest_ScriptP2SH, sign)
 TEST_P(PTest_ScriptP2SH, norecurse)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
@@ -170,7 +170,7 @@ TEST_P(PTest_ScriptP2SH, norecurse)
 TEST_P(PTest_ScriptP2SH, set)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     LOCK(cs_main);
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
@@ -233,7 +233,7 @@ TEST_P(PTest_ScriptP2SH, set)
 TEST_P(PTest_ScriptP2SH, switchover)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
@@ -259,7 +259,7 @@ TEST_P(PTest_ScriptP2SH, switchover)
 TEST_P(PTest_ScriptP2SH, AreInputsStandard)
 {
     const int sample = GetParam();
-    EXPECT_TRUE(sample < static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_TRUE(sample < static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     LOCK(cs_main);
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;

--- a/src/gtest/test_transaction.cpp
+++ b/src/gtest/test_transaction.cpp
@@ -378,7 +378,7 @@ class PTest_Transaction : public TestWithParam<int>
 TEST_P(PTest_Transaction, test_Get)
 {
     const int sample = GetParam();
-    EXPECT_LT(sample, static_cast<int>(Consensus::MAX_NETWORK_UPGRADES));
+    EXPECT_LT(sample, static_cast<int>(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES));
 
     uint32_t consensusBranchId = NetworkUpgradeInfo[sample].nBranchId;
 
@@ -418,8 +418,9 @@ INSTANTIATE_TEST_SUITE_P(test_Get, PTest_Transaction, Values(
     0,1,2,3
 ));
 
-TEST(test_transaction, test_big_overwinter_transaction) {
-    uint32_t consensusBranchId = NetworkUpgradeInfo[Consensus::UPGRADE_OVERWINTER].nBranchId;
+TEST(test_transaction, test_big_overwinter_transaction)
+{
+    const uint32_t consensusBranchId = GetUpgradeBranchId(Consensus::UpgradeIndex::UPGRADE_OVERWINTER);
     CMutableTransaction mtx;
     mtx.fOverwintered = true;
     mtx.nVersion = OVERWINTER_TX_VERSION;

--- a/src/gtest/test_transaction_builder.cpp
+++ b/src/gtest/test_transaction_builder.cpp
@@ -16,8 +16,8 @@ static const std::string tSecretRegtest = "cND2ZvtabDbJ1gucx9GWH6XT9kgTAqfb6cotP
 TEST(TransactionBuilder, Invoke)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     std::string sKeyError;
@@ -89,8 +89,8 @@ TEST(TransactionBuilder, Invoke)
     EXPECT_EQ(state.GetRejectReason(), "");
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(TransactionBuilder, ThrowsOnTransparentInputWithoutKeyStore)
@@ -127,8 +127,8 @@ TEST(TransactionBuilder, RejectsInvalidTransparentChangeAddress)
 TEST(TransactionBuilder, FailsWithNegativeChange)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     // Generate dummy Sapling address
@@ -179,15 +179,15 @@ TEST(TransactionBuilder, FailsWithNegativeChange)
     EXPECT_TRUE(builder.Build().IsTx());
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(TransactionBuilder, ChangeOutput)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     // Generate dummy Sapling address
@@ -271,15 +271,15 @@ TEST(TransactionBuilder, ChangeOutput)
     }
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(TransactionBuilder, SetFee)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     // Generate dummy Sapling address
@@ -326,14 +326,14 @@ TEST(TransactionBuilder, SetFee)
     }
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(TransactionBuilder, CheckSaplingTxVersion)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -362,5 +362,5 @@ TEST(TransactionBuilder, CheckSaplingTxVersion)
     }
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }

--- a/src/gtest/test_validation.cpp
+++ b/src/gtest/test_validation.cpp
@@ -65,7 +65,8 @@ public:
     }
 };
 
-TEST(Validation, ContextualCheckInputsPassesWithCoinbase) {
+TEST(Validation, ContextualCheckInputsPassesWithCoinbase)
+{
     // Create fake coinbase transaction
     CMutableTransaction mtx;
     mtx.vin.resize(1);
@@ -77,7 +78,8 @@ TEST(Validation, ContextualCheckInputsPassesWithCoinbase) {
     CCoinsViewCache view(&fakeDB);
 
     auto pMainNetParams = CreateChainParams(CBaseChainParams::Network::MAIN);
-    for (int idx = Consensus::BASE_SPROUT; idx < Consensus::MAX_NETWORK_UPGRADES; idx++) {
+    for (auto idx = to_integral_type(Consensus::UpgradeIndex::BASE_SPROUT); idx < to_integral_type(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES); ++idx)
+    {
         auto consensusBranchId = NetworkUpgradeInfo[idx].nBranchId;
         CValidationState state;
         PrecomputedTransactionData txdata(tx);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1134,18 +1134,19 @@ bool AppInit2(CServiceThreadGroup& threadGroup, CScheduler& scheduler)
             if (vDeploymentParams.size() != 2) {
                 return InitError("Network upgrade parameters malformed, expecting hexBranchId:activationHeight");
             }
-            int nActivationHeight;
-            if (!ParseInt32(vDeploymentParams[1], &nActivationHeight)) {
+            int nValue;
+            if (!ParseInt32(vDeploymentParams[1], &nValue) || (nValue < 0))
                 return InitError(strprintf("Invalid nActivationHeight (%s)", vDeploymentParams[1]));
-            }
+            const uint32_t nActivationHeight = static_cast<uint32_t>(nValue);
             bool found = false;
             // Exclude Sprout from upgrades
-            for (auto i = Consensus::BASE_SPROUT + 1; i < Consensus::MAX_NETWORK_UPGRADES; ++i)
+            for (auto i = to_integral_type(Consensus::UpgradeIndex::BASE_SPROUT) + 1; i < to_integral_type(Consensus::UpgradeIndex::MAX_NETWORK_UPGRADES); ++i)
             {
-                if (vDeploymentParams[0].compare(HexInt(NetworkUpgradeInfo[i].nBranchId)) == 0) {
+                if (vDeploymentParams[0].compare(HexInt(NetworkUpgradeInfo[i].nBranchId)) == 0)
+                {
                     UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex(i), nActivationHeight);
                     found = true;
-                    LogPrintf("Setting network upgrade activation parameters for %s to height=%d\n", vDeploymentParams[0], nActivationHeight);
+                    LogPrintf("Setting network upgrade activation parameters for %s to height=%u\n", vDeploymentParams[0], nActivationHeight);
                     break;
                 }
             }

--- a/src/key.h
+++ b/src/key.h
@@ -93,7 +93,7 @@ public:
     }
 
     //! Simple read-only vector-like interface.
-    unsigned int size() const noexcept { return (fValid ? keydata.size() : 0); }
+    unsigned int size() const noexcept { return (fValid ? static_cast<int>(keydata.size()) : 0); }
     const unsigned char* begin() const noexcept { return keydata.data(); }
     const unsigned char* end() const noexcept { return keydata.data() + size(); }
     const unsigned char* cbegin() const noexcept { return keydata.data(); }

--- a/src/main.h
+++ b/src/main.h
@@ -630,7 +630,7 @@ int GetSpendHeight(const CCoinsViewCache& inputs);
 
 int GetChainHeight();
 /** Return a CMutableTransaction with contextual default values based on set of consensus rules at height */
-CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight);
+CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, const uint32_t nHeight);
 
 //INGEST->!!!
 constexpr uint32_t INGEST_MINING_BLOCK = 1;

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -31,10 +31,10 @@ static shared_ptr<ITxMemPoolTracker> TicketTxMemPoolTracker;
  * 
  * \return 0 if chain is not initialized or height of the active chain
  */
-unsigned int GetActiveChainHeight()
+uint32_t GetActiveChainHeight()
 {
     LOCK(cs_main);
-    return static_cast<unsigned int>(chainActive.Height()) + 1;
+    return static_cast<uint32_t>(chainActive.Height()) + 1;
 }
 
 void CPastelTicketProcessor::InitTicketDB()
@@ -860,7 +860,7 @@ template <class _TicketType, typename F>
 string CPastelTicketProcessor::filterTickets(F f, const uint32_t nMinHeight, const bool bCheckConfirmation) const
 {
     json jArray;
-    const unsigned int nChainHeight = GetActiveChainHeight();
+    const auto nChainHeight = GetActiveChainHeight();
     // list tickets with the specific type (_TicketType) and add to json array if functor f applies
     listTickets<_TicketType>([&](const _TicketType& ticket) -> bool
     {
@@ -1227,7 +1227,7 @@ tuple<string, string> CPastelTicketProcessor::SendTicket(const CPastelTicket& ti
         LogPrint("compress", "Ticket (%hhu) data [%zu bytes] was not compressed due to size or bad compression ratio\n", to_integral_type<TicketID>(ticket.ID()), nUncompressedSize);
 #endif
 
-    unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
 
     CMutableTransaction tx;
     if (!CreateP2FMSTransactionWithExtra(data_stream, extraOutputs, extraAmount, tx, 
@@ -1547,7 +1547,7 @@ bool CPastelTicketProcessor::CreateP2FMSTransactionWithExtra(const CDataStream& 
     // total amount to spend in patoshis
     const CAmount allSpentAmount = (pricePSL * COIN) + nAproxFeeNeeded + extraAmount;
 
-    unsigned int chainHeight = GetActiveChainHeight();
+    auto chainHeight = GetActiveChainHeight();
     if (!chainParams.IsRegTest())
         chainHeight = max(chainHeight, APPROX_RELEASE_HEIGHT);
     auto consensusBranchId = CurrentEpochBranchId(chainHeight, chainParams.GetConsensus());

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -28,7 +28,7 @@ constexpr uint8_t TICKET_COMPRESS_DISABLE_MASK = 0x7F;
 using reg_trade_txid_t = std::tuple<std::string, std::string>;
 
 // Get height of the active blockchain + 1
-unsigned int GetActiveChainHeight();
+uint32_t GetActiveChainHeight();
 
 // structure used by 'tickets tools searchthumbids' rpc
 typedef struct _search_thumbids_t

--- a/src/mnode/tickets/action-act.cpp
+++ b/src/mnode/tickets/action-act.cpp
@@ -94,7 +94,7 @@ void CActionActivateTicket::sign(SecureString&& strKeyPass)
  */
 ticket_validation_t CActionActivateTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/action-reg.cpp
+++ b/src/mnode/tickets/action-reg.cpp
@@ -187,7 +187,7 @@ void CActionRegTicket::GenerateKeyOne()
  */
 ticket_validation_t CActionRegTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/etherium-address-change.cpp
+++ b/src/mnode/tickets/etherium-address-change.cpp
@@ -56,7 +56,7 @@ string CChangeEthereumAddressTicket::ToStr() const noexcept
  */
 ticket_validation_t CChangeEthereumAddressTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/nft-act.cpp
+++ b/src/mnode/tickets/nft-act.cpp
@@ -63,7 +63,7 @@ void CNFTActivateTicket::sign(SecureString&& strKeyPass)
  */
 ticket_validation_t CNFTActivateTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/nft-buy.cpp
+++ b/src/mnode/tickets/nft-buy.cpp
@@ -42,7 +42,7 @@ string CNFTBuyTicket::ToStr() const noexcept
 
 ticket_validation_t CNFTBuyTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/nft-collection-act.cpp
+++ b/src/mnode/tickets/nft-collection-act.cpp
@@ -63,7 +63,7 @@ void CNFTCollectionActivateTicket::sign(SecureString&& strKeyPass)
 */
 ticket_validation_t CNFTCollectionActivateTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/nft-collection-reg.cpp
+++ b/src/mnode/tickets/nft-collection-reg.cpp
@@ -218,7 +218,7 @@ void CNFTCollectionRegTicket::parse_nft_collection_ticket()
 */
 ticket_validation_t CNFTCollectionRegTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/nft-reg.cpp
+++ b/src/mnode/tickets/nft-reg.cpp
@@ -314,7 +314,7 @@ ticket_validation_t CNFTRegTicket::IsValidCollection(const bool bPreReg) const n
             break;
         }
 
-        const unsigned int chainHeight = GetActiveChainHeight();
+        const auto chainHeight = GetActiveChainHeight();
 
         // check that NFT reg ticket height is less than closing height for the NFT Collection
         if (bPreReg && (chainHeight > pNFTCollTicket->getClosingHeight()))
@@ -368,7 +368,7 @@ ticket_validation_t CNFTRegTicket::IsValidCollection(const bool bPreReg) const n
  */
 ticket_validation_t CNFTRegTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/nft-royalty.cpp
+++ b/src/mnode/tickets/nft-royalty.cpp
@@ -67,7 +67,7 @@ string CNFTRoyaltyTicket::ToStr() const noexcept
  */
 ticket_validation_t CNFTRoyaltyTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {

--- a/src/mnode/tickets/nft-sell.cpp
+++ b/src/mnode/tickets/nft-sell.cpp
@@ -74,7 +74,7 @@ void CNFTSellTicket::sign(SecureString&& strKeyPass)
  */
 ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
     do
     {
@@ -256,7 +256,7 @@ ticket_validation_t CNFTSellTicket::IsValid(const bool bPreReg, const uint32_t n
                     t.m_txid, copyNumber);
                 break;
             }
-            const unsigned int chainHeight = GetActiveChainHeight();
+            const auto chainHeight = GetActiveChainHeight();
             if (t.m_nBlock + 2880 > chainHeight)
             {
                 // 1 block per 2.5; 4 blocks per 10 min; 24 blocks per 1h; 576 blocks per 24 h;

--- a/src/mnode/tickets/nft-trade.cpp
+++ b/src/mnode/tickets/nft-trade.cpp
@@ -196,7 +196,7 @@ string CNFTTradeTicket::ToStr() const noexcept
  */
 ticket_validation_t CNFTTradeTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
     ticket_validation_t tv;
 
     do
@@ -356,7 +356,7 @@ CAmount CNFTTradeTicket::GetExtraOutputs(vector<CTxOut>& outputs) const
 
     if (NFTRegTicket->hasGreenFee())
     {
-        const unsigned int chainHeight = GetActiveChainHeight();
+        const auto chainHeight = GetActiveChainHeight();
         nGreenNFTAmount = nPriceAmount * CNFTRegTicket::GreenPercent(chainHeight) / 100;
     }
 

--- a/src/mnode/tickets/ticket-utils.h
+++ b/src/mnode/tickets/ticket-utils.h
@@ -102,10 +102,10 @@ ticket_validation_t common_ticket_validation(const T& ticket, bool bPreReg, cons
         // C.1 Something to validate only if NOT Initial Download
         if (masterNodeCtrl.masternodeSync.IsSynced())
         {
-            const unsigned int chainHeight = GetActiveChainHeight();
+            const auto chainHeight = GetActiveChainHeight();
 
             // C.2 Verify Min Confirmations
-            const unsigned int height = ticket.IsBlock(0) ? chainHeight : ticket.GetBlock();
+            const auto height = ticket.IsBlock(0) ? chainHeight : ticket.GetBlock();
             if (chainHeight - parentTicket->GetBlock() < masterNodeCtrl.MinTicketConfirmations)
             {
                 tv.errorMsg = strprintf(

--- a/src/mnode/tickets/username-change.cpp
+++ b/src/mnode/tickets/username-change.cpp
@@ -77,7 +77,7 @@ ticket_validation_t CChangeUsernameTicket::IsValid(const bool bPreReg, const uin
     // username-change ticket keys:
     // 1) username
     // 2) pastelid
-    const unsigned int chainHeight = GetActiveChainHeight();
+    const auto chainHeight = GetActiveChainHeight();
 
     // initialize Pastel Ticket mempool processor for username-change tickets
     // retrieve mempool transactions with TicketID::Username tickets

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -892,7 +892,7 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
 
         if ((nActivationHeight > 0) && (nActivationHeight != Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) &&
             height < nActivationHeight &&
-            height + NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD >= nActivationHeight)
+            height + consensus.nNetworkUpgradePeerPreferenceBlockPeriod >= nActivationHeight)
         {
             // Find any nodes which don't support the protocol version for the next upgrade
             for (const auto &node : vEvictionCandidates)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -869,33 +869,35 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
         }
     }
 
-    if (vEvictionCandidates.empty()) return false;
+    if (vEvictionCandidates.empty())
+        return false;
 
     // Protect connections with certain characteristics
 
     // Check version of eviction candidates and prioritize nodes which do not support network upgrade.
     std::vector<CNodeRef> vTmpEvictionCandidates;
-    int height;
+    uint32_t height;
     {
         LOCK(cs_main);
-        height = chainActive.Height();
+        const int nCurrentHeight = chainActive.Height();
+        height = nCurrentHeight == -1 ? 0 : static_cast<uint32_t>(nCurrentHeight);
     }
 
-    const Consensus::Params& params = Params().GetConsensus();
-    const auto nextEpoch = NextEpoch(height, params);
+    const auto& consensus = Params().GetConsensus();
+    const auto nextEpoch = NextEpoch(height, consensus);
     if (nextEpoch.has_value())
     {
         const auto idx = nextEpoch.value();
-        const auto nActivationHeight = params.vUpgrades[idx].nActivationHeight;
+        const auto nActivationHeight = consensus.vUpgrades[idx].nActivationHeight;
 
-        if (nActivationHeight > 0 &&
+        if ((nActivationHeight > 0) && (nActivationHeight != Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) &&
             height < nActivationHeight &&
-            height >= nActivationHeight - NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD)
+            height + NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD >= nActivationHeight)
         {
             // Find any nodes which don't support the protocol version for the next upgrade
-            for (const CNodeRef &node : vEvictionCandidates)
+            for (const auto &node : vEvictionCandidates)
             {
-                if (node->nVersion < params.vUpgrades[idx].nProtocolVersion)
+                if (node->nVersion < consensus.vUpgrades[idx].nProtocolVersion)
                     vTmpEvictionCandidates.push_back(node);
             }
 

--- a/src/net.h
+++ b/src/net.h
@@ -53,9 +53,11 @@ static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
 /** The maximum number of entries in setAskFor (larger due to getdata latency)*/
 static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
-static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
-/** The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks). */
-static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 24 * 24 * 3;
+static constexpr unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
+// The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
+constexpr uint32_t MAINNET_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 24 * 24 * 3;
+constexpr uint32_t TESTNET_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 24 * 2;
+constexpr uint32_t REGTEST_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 24;
 
 size_t ReceiveFloodSize();
 size_t SendBufferSize();

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -507,7 +507,7 @@ Examples:
     UniValue inputs = params[0].get_array();
     UniValue sendTo = params[1].get_obj();
 
-    int nextBlockHeight;
+    uint32_t nextBlockHeight = 0;
     {
         LOCK(cs_main);
         nextBlockHeight = chainActive.Height() + 1;
@@ -522,9 +522,11 @@ Examples:
         rawTx.nLockTime = static_cast<uint32_t>(nLockTime);
     }
     
-    if (params.size() > 3 && !params[3].isNull()) {
-        if (NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UPGRADE_OVERWINTER)) {
-            int64_t nExpiryHeight = params[3].get_int64();
+    if (params.size() > 3 && !params[3].isNull())
+    {
+        if (NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UpgradeIndex::UPGRADE_OVERWINTER))
+        {
+            const int64_t nExpiryHeight = params[3].get_int64();
             if (nExpiryHeight < 0 || nExpiryHeight >= TX_EXPIRY_HEIGHT_THRESHOLD) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid parameter, expiryheight must be nonnegative and less than %d.", TX_EXPIRY_HEIGHT_THRESHOLD));
             }
@@ -540,7 +542,8 @@ Examples:
         }
     }
 
-    for (size_t idx = 0; idx < inputs.size(); idx++) {
+    for (size_t idx = 0; idx < inputs.size(); idx++)
+    {
         const UniValue& input = inputs[idx];
         const UniValue& o = input.get_obj();
 
@@ -1040,9 +1043,11 @@ As a json rpc call
     auto chainparams = Params();
 
     // DoS mitigation: reject transactions expiring soon
-    if (tx.nExpiryHeight > 0) {
-        int nextBlockHeight = chainActive.Height() + 1;
-        if (NetworkUpgradeActive(nextBlockHeight, chainparams.GetConsensus(), Consensus::UPGRADE_OVERWINTER)) {
+    if (tx.nExpiryHeight > 0)
+    {
+        uint32_t nextBlockHeight = chainActive.Height() + 1;
+        if (NetworkUpgradeActive(nextBlockHeight, chainparams.GetConsensus(), Consensus::UpgradeIndex::UPGRADE_OVERWINTER))
+        {
             if (nextBlockHeight + TX_EXPIRING_SOON_THRESHOLD > tx.nExpiryHeight) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED,
                     strprintf("tx-expiring-soon: expiryheight is %u but should be at least %d to avoid transaction expiring soon",

--- a/src/version.h
+++ b/src/version.h
@@ -17,7 +17,7 @@ inline constexpr int INIT_PROTO_VERSION = 209;
 inline constexpr int GETHEADERS_VERSION = 31800;
 
 //! disconnect from peers older than this proto version
-inline constexpr int MIN_PEER_PROTO_VERSION = 170009;
+inline constexpr int MIN_PEER_PROTO_VERSION = 170008;
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this

--- a/src/wallet/gtest/test_wallet.cpp
+++ b/src/wallet/gtest/test_wallet.cpp
@@ -109,8 +109,8 @@ TEST(WalletTests, SetupDatadirLocationRunAsFirstTest) {
 TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -162,8 +162,8 @@ TEST(WalletTests, SetSaplingNoteAddrsInCWalletTx)
     EXPECT_TRUE(witness == wtx.mapSaplingNoteData[op].witnesses.front());
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 // The following test is the same as SetInvalidSaplingNoteDataInCWalletTx
@@ -184,8 +184,8 @@ TEST(WalletTests, SetInvalidSaplingNoteDataInCWalletTx) {
 
 TEST(WalletTests, FindMySaplingNotes) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -224,15 +224,15 @@ TEST(WalletTests, FindMySaplingNotes) {
     EXPECT_EQ(2, noteMap.size());
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 // Generate note A and spend to create note B, from which we spend to create two conflicting transactions
 TEST(WalletTests, GetConflictedSaplingNotes) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -346,14 +346,14 @@ TEST(WalletTests, GetConflictedSaplingNotes) {
     mapBlockIndex.erase(blockHash);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, SaplingNullifierIsSpent) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -414,14 +414,14 @@ TEST(WalletTests, SaplingNullifierIsSpent) {
     mapBlockIndex.erase(blockHash);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -516,15 +516,15 @@ TEST(WalletTests, NavigateFromSaplingNullifierToNote) {
     mapBlockIndex.erase(blockHash);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 // Create note A, spend A to create note B, spend and verify note B is from me.
 TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -660,15 +660,15 @@ TEST(WalletTests, SpentSaplingNoteIsFromMe) {
     mapBlockIndex.erase(blockHash2);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, UpdatedSaplingNoteData)
 {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -781,14 +781,14 @@ TEST(WalletTests, UpdatedSaplingNoteData)
     mapBlockIndex.erase(blockHash);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     SelectParams(CBaseChainParams::Network::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     auto consensusParams = Params().GetConsensus();
 
     TestWallet wallet;
@@ -897,8 +897,8 @@ TEST(WalletTests, MarkAffectedSaplingTransactionsDirty) {
     mapBlockIndex.erase(blockHash);
 
     // Revert to default
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_SAPLING, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }
 
 TEST(WalletTests, SaplingNoteLocking)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3793,7 +3793,7 @@ Examples:
     mtx.nVersion = SAPLING_TX_VERSION;
     constexpr auto max_tx_size = MAX_TX_SIZE_AFTER_SAPLING;
     // If Sapling is not active, do not allow sending from or sending to Sapling addresses.
-    if (!NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UPGRADE_SAPLING))
+    if (!NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UpgradeIndex::UPGRADE_SAPLING))
     {
         if (bFromSapling || bContainsSaplingOutput)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, Sapling has not activated");
@@ -3978,24 +3978,21 @@ Examples:
         }
     }
 
-    int nextBlockHeight = chainActive.Height() + 1;
-    bool overwinterActive = NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UPGRADE_OVERWINTER);
+    const uint32_t nextBlockHeight = chainActive.Height() + 1;
+    bool overwinterActive = NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UpgradeIndex::UPGRADE_OVERWINTER);
     unsigned int max_tx_size = MAX_TX_SIZE_AFTER_SAPLING;
-    if (!NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UPGRADE_SAPLING)) {
+    if (!NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UpgradeIndex::UPGRADE_SAPLING))
         max_tx_size = MAX_TX_SIZE_BEFORE_SAPLING;
-    }
 
     // If Sapling is not active, do not allow sending to a Sapling address.
-    if (!NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UPGRADE_SAPLING)) {
-        auto res = keyIO.DecodePaymentAddress(destaddress);
-        if (IsValidPaymentAddress(res)) {
-            bool toSapling = get_if<libzcash::SaplingPaymentAddress>(&res) != nullptr;
-            if (toSapling) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, Sapling has not activated");
-            }
-        } else {
+    if (!NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UpgradeIndex::UPGRADE_SAPLING))
+    {
+        const auto res = keyIO.DecodePaymentAddress(destaddress);
+        if (!IsValidPaymentAddress(res))
             throw JSONRPCError(RPC_INVALID_PARAMETER, string("Invalid parameter, unknown address format: ") + destaddress );
-        }
+        bool toSapling = get_if<libzcash::SaplingPaymentAddress>(&res) != nullptr;
+        if (toSapling)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, Sapling has not activated");
     }
 
     // Prepare to get coinbase utxos
@@ -4008,9 +4005,8 @@ Examples:
 
     // Set of addresses to filter utxos by
     set<CTxDestination> destinations = {};
-    if (!isFromWildcard) {
+    if (!isFromWildcard)
         destinations.insert(taddr);
-    }
 
     // Get available utxos
     vector<COutput> vecOutputs;
@@ -4241,9 +4237,9 @@ Examples:
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot specify specific zaddrs when using \"ANY_SAPLING\"");
     }
 
-    const int nextBlockHeight = chainActive.Height() + 1;
-    const bool overwinterActive = NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UPGRADE_OVERWINTER);
-    const bool saplingActive = NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UPGRADE_SAPLING);
+    const uint32_t nextBlockHeight = chainActive.Height() + 1;
+    const bool overwinterActive = NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UpgradeIndex::UPGRADE_OVERWINTER);
+    const bool saplingActive = NetworkUpgradeActive(nextBlockHeight, Params().GetConsensus(), Consensus::UpgradeIndex::UPGRADE_SAPLING);
 
     // Validate the destination address
     auto destaddress = params[1].get_str();

--- a/src/zcbenchmarks.cpp
+++ b/src/zcbenchmarks.cpp
@@ -193,7 +193,7 @@ double benchmark_large_tx(size_t nInputs)
     }
 
     // Sign for all the inputs
-    auto consensusBranchId = NetworkUpgradeInfo[Consensus::UPGRADE_SAPLING].nBranchId;
+    const auto consensusBranchId = NetworkUpgradeInfo[to_integral_type(Consensus::UpgradeIndex::UPGRADE_SAPLING)].nBranchId;
     for (size_t i = 0; i < nInputs; i++)
         SignSignature(tempKeystore, prevPubKey, spending_tx, static_cast<unsigned int>(i), 1'000'000, to_integral_type(SIGHASH::ALL), consensusBranchId);
 


### PR DESCRIPTION
- activate Cezanne upgrade (protocol 170009) by height
  used different activation parameters for mainnet, testnet and regtest
- changed min protocol version to 170008.
Peers with old version will still be able to connect until Cezanne activation height.
Starting from that height all nodes with old version will be banned.