### PR TITLE
[PSL-413] SuperNode should have registered Pastel ID

### DIFF
--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -43,7 +43,7 @@ class LongpollThread(threading.Thread):
         self.longpollid = templat['longpollid']
         # create a new connection to the node, we can't use the same
         # connection from two threads
-        self.node = AuthServiceProxy(node.url, timeout=600)
+        self.node = AuthServiceProxy(0, node.url, timeout=600)
 
     def run(self):
         self.node.getblocktemplate({'longpollid':self.longpollid})

--- a/qa/rpc-tests/mn_bugs.py
+++ b/qa/rpc-tests/mn_bugs.py
@@ -43,9 +43,6 @@ class MasterNodeGovernanceTest (MasterNodeCommon):
             self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
 
     def run_test (self):
-        self.reconnect_all_nodes()
-        self.sync_all()
-
         print("Run freedcamp ID specific test")
         
         if(TEST_CASE_EXEC_NR == 40300409):

--- a/qa/rpc-tests/mn_common.py
+++ b/qa/rpc-tests/mn_common.py
@@ -3,49 +3,55 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php.
 from pathlib import Path
-import os
 import time
 import itertools
 import json
 import random
 from decimal import getcontext
+
 from pastel_test_framework import PastelTestFramework
 from test_framework.util import (
+    assert_true,
     assert_equal,
     start_node,
     connect_nodes_bi,
     p2p_port,
-    stop_node
+    Timer
 )
 getcontext().prec = 16
 
 class MasterNodeCommon (PastelTestFramework):
-    collateral = int(1000)
 
+    """ Class to represent MasterNode.
+    """
     class MasterNode:
-        index = None            # masternode index
-        passphrase = None       # passphrase to access secure container data
-        mnid = None             # generated Pastel ID
-        lrKey = None            # generated LegRoast key
-        privKey = None          # generated private key
-        port = None
-        collateral_address = None
-        collateral_txid = None
-        collateral_index = None
+        index: int = None            # masternode index
+        passphrase: str = None       # passphrase to access secure container data
+        mnid: str = None             # generated Pastel ID
+        lrKey: str = None            # generated LegRoast key
+        privKey: str = None          # generated private key
+        port: int = None
+        collateral_address: str = None
+        collateral_txid: str = None
+        collateral_index: int = None
+        mnid_reg_address: str = None # address for mnid registration
+        mnid_reg_txid: str = None    # txid for mnid registration   
 
         def __init__(self, index, passphrase):
             self.index = index
             self.passphrase = passphrase
             self.port = p2p_port(index)
 
+
         @property
-        def id(self) -> str:
+        def collateral_id(self) -> str:
             """ masternode collateral id property
 
             Returns:
                 str: masternode collateral id (txid-index)
             """
             return str(self.collateral_txid) + "-" + str(self.collateral_index)
+
 
         @property
         def alias(self) -> str:
@@ -56,7 +62,8 @@ class MasterNodeCommon (PastelTestFramework):
             """
             return f'mn{self.index}'
 
-        def create_masternode_conf(self, dirname):
+
+        def create_masternode_conf(self, dirname: str, node_index: int):
             """create masternode.conf for this masternode
 
             Args:
@@ -65,7 +72,7 @@ class MasterNodeCommon (PastelTestFramework):
             Returns:
                 str: node data directory
             """
-            datadir = Path(dirname, f"node{self.index}")
+            datadir = Path(dirname, f"node{node_index}")
             if not datadir.is_dir():
                 datadir.mkdir()
             regtestdir = datadir / "regtest"
@@ -75,7 +82,7 @@ class MasterNodeCommon (PastelTestFramework):
         
             config = {}
             if cfg_file.is_file():
-                with cfg_file.open() as json_file:  
+                with cfg_file.open() as json_file:
                     config = json.load(json_file)
 
             name = self.alias
@@ -86,7 +93,7 @@ class MasterNodeCommon (PastelTestFramework):
             config[name]["outIndex"] = str(self.collateral_index)
             config[name]["extAddress"] = f"127.0.0.1:{random.randint(2000, 5000)}"
             config[name]["extP2P"] = f"127.0.0.1:{random.randint(22000, 25000)}"
-            config[name]["extKey"] = self.mnid
+            config[name]["extKey"] = self.mnid if self.mnid else ""
             config[name]["extCfg"] = {}
             config[name]["extCfg"]["param1"] = str(random.randint(0, 9))
             config[name]["extCfg"]["param2"] = str(random.randint(0, 9))
@@ -97,27 +104,27 @@ class MasterNodeCommon (PastelTestFramework):
             return str(datadir)
 
 
-    mnNodes = list()
+    def __init__(self):
+        super().__init__()
 
-    def setup_masternodes_network(self, private_keys_list, number_of_non_mn_to_start=0, debug_flags=""):
-        for index, key in enumerate(private_keys_list):
-            print(f"start MN {index}")
-            self.nodes.append(start_node(index, self.options.tmpdir, [f"-debug={debug_flags}", "-masternode", "-txindex=1", "-reindex", f"-masternodeprivkey={key}"]))
-        
-        for index2 in range (index+1, index+number_of_non_mn_to_start+1):
-            print(f"start non-MN {index2}")
-            self.nodes.append(start_node(index2, self.options.tmpdir, [f"-debug={debug_flags}"]))
+        # list of master nodes (MasterNode)
+        self.mn_nodes = []
+        self.collateral = int(1000)
+        # flag to use new "masternode init" API
+        self.use_masternode_init = False
 
-        for pair in itertools.combinations(range(index2+1), 2):
-            connect_nodes_bi(self.nodes, pair[0], pair[1])
 
-    def setup_masternodes_network_new(self, mn_count=1, non_mn_count=2, mining_node_num=1, hot_node_num=2, debug_flags=""):
+    def setup_masternodes_network(self, mn_count=1, non_mn_count: int = 2,
+                                  mining_node_num=1, hot_node_num=2, cold_node_count=1,
+                                  debug_flags: str = ""):
+        timer = Timer()
+        timer.start()
         # create list of mns
         # start only non-mn nodes
         for index in range(mn_count + non_mn_count):
             if index < mn_count:
                 mn = self.MasterNode(index, self.passphrase)
-                self.mnNodes.append(mn)
+                self.mn_nodes.append(mn)
                 self.nodes.append(None) # add dummy node for now
             else:
                 print(f"starting non-mn{index} node")
@@ -130,40 +137,115 @@ class MasterNodeCommon (PastelTestFramework):
         # mining enough coins for collateral for mn_count nodes
         self.mining_enough(mining_node_num, mn_count)
 
-        # send coins to the collateral address on hot node
-        for index, mn in enumerate(self.mnNodes):
+        # hot node will keep all collateral amounts in its wallet to activate all master nodes
+        for mn in self.mn_nodes:
+            # create collateral address for each MN
+            # number of nodes to activate is defined by cold_node_count
+            if mn.index >= cold_node_count:
+                continue
             mn.collateral_address = self.nodes[hot_node_num].getnewaddress()
-            print(f"{index}: Sending {self.collateral} coins to node {hot_node_num}; collateral address {mn.collateral_address} ...")
+            # send coins to the collateral addresses on hot node
+            print(f"{mn.index}: Sending {self.collateral} coins to node{hot_node_num}; collateral address {mn.collateral_address} ...")
             mn.collateral_txid = self.nodes[mining_node_num].sendtoaddress(mn.collateral_address, self.collateral, "", "", False)
-            
-        self.generate_and_sync_inc(1, mining_node_num)
-        assert_equal(self.nodes[hot_node_num].getbalance(), self.collateral * len(self.mnNodes))
-        
-        # prepare parameters and create masternode.conf for all masternodes
-        for index, mn in enumerate(self.mnNodes):
-            # get the collateral outpoint indexes
-            outputs = self.nodes[hot_node_num].masternode("outputs")
-            mn.collateral_index = int(outputs[mn.collateral_txid])
-            print(f"node{hot_node_num} collateral outputs: {outputs}")
-            # generate info for masternodes (masternode init)
-            params = self.nodes[hot_node_num].masternode("init", mn.passphrase, mn.collateral_txid, mn.collateral_index)
-            mn.mnid = params["mnid"]
-            mn.lrKey = params["legRoastKey"]
-            mn.privKey = params["privKey"]
-            print(f"mn{index} id: {mn.mnid}")
-            mn.create_masternode_conf(self.options.tmpdir)
-        self.generate_and_sync_inc(1, mining_node_num)
 
-        # starting masternodes
-        for index, mn in enumerate(self.mnNodes):
-            print(f"starting {mn.alias} masternode")
-            self.nodes[index] = start_node(index, self.options.tmpdir, [f"-debug={debug_flags}", "-masternode", "-txindex=1", "-reindex", f"-masternodeprivkey={mn.privKey}"])
-        
+        self.generate_and_sync_inc(1, mining_node_num)
+        assert_equal(self.nodes[hot_node_num].getbalance(), self.collateral * cold_node_count)
+
+        # prepare parameters and create masternode.conf for all masternodes
+        outputs = self.nodes[hot_node_num].masternode("outputs")
+        print(f"hot node{hot_node_num} collateral outputs\n{outputs}")
+        for mn in self.mn_nodes:
+            # get the collateral outpoint indexes
+            if mn.index < cold_node_count:
+                mn.collateral_index = int(outputs[mn.collateral_txid])
+            if self.use_masternode_init:
+                # generate info for masternodes (masternode init)
+                params = self.nodes[hot_node_num].masternode("init", mn.passphrase, mn.collateral_txid, mn.collateral_index)
+                mn.mnid = params["mnid"]
+                mn.lrKey = params["legRoastKey"]
+                mn.privKey = params["privKey"]
+                print(f"mn{index} id: {mn.mnid}")
+                mn.create_masternode_conf(self.options.tmpdir, hot_node_num)
+            else:
+                mn.privKey = self.nodes[hot_node_num].masternode("genkey")
+                assert_true(mn.privKey, "Failed to generate private key for Master Node")
+        if self.use_masternode_init:
+            self.generate_and_sync_inc(1, mining_node_num)
+
+        # starting all master nodes
+        for mn in self.mn_nodes:
+            print(f"starting masternode {mn.alias}")
+            self.nodes[mn.index] = start_node(mn.index, self.options.tmpdir, [f"-debug={debug_flags}", "-masternode", "-txindex=1", "-reindex", f"-masternodeprivkey={mn.privKey}"])
+
         # connect nodes (non-mn nodes already interconnected)
         for pair in itertools.combinations(range(mn_count + non_mn_count), 2):
             connect_nodes_bi(self.nodes, pair[0], pair[1])
 
         self.sync_all()
+        # wait for sync status for up to 2 mins
+        wait_counter = 24
+        while not all(self.nodes[mn.index].mnsync("status")["IsSynced"] for mn in self.mn_nodes):
+            time.sleep(5)
+            wait_counter -= 1
+            assert_true(wait_counter, "Timeout period elapsed waiting for the MN synced status")
+
+        # for old MN initialization
+        if not self.use_masternode_init:
+            # create & register mnid
+            for mn in self.mn_nodes:
+                mn.mnid, mn.lrKey = self.create_pastelid(mn.index)
+                if mn.index >= cold_node_count:
+                    continue
+                # get new address and send some coins for mnid registration
+                mn.mnid_reg_address = self.nodes[mn.index].getnewaddress()
+                self.nodes[mining_node_num].sendtoaddress(mn.mnid_reg_address, 100, "", "", False)
+                mn.create_masternode_conf(self.options.tmpdir, hot_node_num)
+            self.generate_and_sync_inc(1, mining_node_num)
+
+            for mn in self.mn_nodes:
+                if mn.index >= cold_node_count:
+                    continue
+                print(f"Enabling master node: {mn.alias}...")
+                res = self.nodes[hot_node_num].masternode("start-alias", mn.alias)
+                print(res)
+                assert_equal(res["alias"], mn.alias)
+                assert_equal(res["result"], "successful")
+
+            print("Waiting for PRE_ENABLED status...")
+            initial_wait = 10
+            for mn in self.mn_nodes:
+                if mn.index >= cold_node_count:
+                    continue
+                self.wait_for_mn_state(initial_wait, 10, "PRE_ENABLED", mn.index, 3)
+                initial_wait = 0
+                
+            # register mnids
+            for mn in self.mn_nodes:
+                if mn.index >= cold_node_count:
+                    continue
+                result = self.nodes[mn.index].tickets("register", "mnid", mn.mnid,
+                    self.passphrase, mn.mnid_reg_address)
+                mn.mnid_reg_txid = result["txid"]
+                self.generate_and_sync_inc(1, mining_node_num)
+            # wait for ticket transactions
+            time.sleep(10)
+            for _ in range(5):
+                self.generate_and_sync_inc(1, mining_node_num)
+                self.sync_all(10, 3)
+            self.sync_all(10, 30)
+
+
+            print("Waiting for ENABLED status...")
+            initial_wait = 15
+            for mn in self.mn_nodes:
+                if mn.index >= cold_node_count:
+                    continue
+                self.wait_for_mn_state(initial_wait, 10, "ENABLED", mn.index, 10)
+                initial_wait = 0
+     
+        timer.stop()
+        print(f"<<<< MasterNode network INITIALIZED in {timer.elapsed_time} secs >>>>")
+
 
     def mining_enough(self, mining_node_num, nodes_to_start):
         min_blocks_to_mine = nodes_to_start*self.collateral/self._reward
@@ -182,127 +264,57 @@ class MasterNodeCommon (PastelTestFramework):
         assert_equal(self.nodes[mining_node_num].getbalance(), self._reward*blocks_to_mine)
 
 
-    def start_mn(self, mining_node_num, hot_node_num, cold_nodes, num_of_nodes):
-        
-        mn_ids = dict()
-        mn_aliases = dict()
-        mn_collateral_addresses = dict()
-
-        #1
-        for ind, num in enumerate(cold_nodes):
-            collateral_address = self.nodes[hot_node_num].getnewaddress()
-            print(f"{ind}: Sending {self.collateral} coins to node {hot_node_num}; collateral address {collateral_address} ...")
-            collateral_txid = self.nodes[mining_node_num].sendtoaddress(collateral_address, self.collateral, "", "", False)
-
-            self.generate_and_sync_inc(1, mining_node_num)
-            assert_equal(self.nodes[hot_node_num].getbalance(), self.collateral*(ind+1))
-            
-            # print("node {0} collateral outputs".format(hot_node_num))
-            # print(self.nodes[hot_node_num].masternode("outputs"))
-            
-            collateralvin = self.nodes[hot_node_num].masternode("outputs")[collateral_txid]
-            mn_ids[num] = str(collateral_txid) + "-" + str(collateralvin)
-            mn_collateral_addresses[num] = collateral_address
-
-        #2
-        print(f"Stopping node {hot_node_num}...")
-        stop_node(self.nodes[hot_node_num], hot_node_num)
-
-        #3
-        print(f"Creating masternode.conf for node {hot_node_num}...")
-        for num, key in cold_nodes.items():
-            mn_alias = f"mn{num}"
-            c_txid, c_vin = mn_ids[num].split('-')
-            print(f"{mn_alias}  127.0.0.1:{p2p_port(num)} {key} {c_txid} {c_vin}")
-            self.create_masternode_conf(mn_alias, hot_node_num, self.options.tmpdir, c_txid, c_vin, key, p2p_port(num))
-            mn_aliases[num] = mn_alias
-
-        #4
-        print(f"Starting node {hot_node_num}...")
-        self.nodes[hot_node_num]=start_node(hot_node_num, self.options.tmpdir, ["-debug=masternode", "-txindex=1", "-reindex"], timewait=900)
-        for i in range(num_of_nodes):
-            if i != hot_node_num:
-                connect_nodes_bi(self.nodes, hot_node_num, i)
-        
-        print("Waiting 90 seconds...")
-        time.sleep(90)
-        print(f"Checking sync status of node {hot_node_num}...")
-        assert_equal(self.nodes[hot_node_num].mnsync("status")["IsSynced"], True)
-        assert_equal(self.nodes[hot_node_num].mnsync("status")["IsFailed"], False)
-
-        #5
-        for mn_alias in mn_aliases.values():
-            print(f"Enabling MN {mn_alias}...")
-            res = self.nodes[hot_node_num].masternode("start-alias", mn_alias)
-            print(res)        
-            assert_equal(res["alias"], mn_alias)
-            assert_equal(res["result"], "successful")
-            time.sleep(1)
-        
-        print("Waiting for PRE_ENABLED...")
-        for ind, num in enumerate(mn_ids):
-            wait = 30 if ind == 0 else 0
-            self.wait_for_mn_state(wait, 10, "PRE_ENABLED", self.nodes[0:num_of_nodes], mn_ids[num])
-
-        print("Waiting for ENABLED...")
-        for ind, num in enumerate(mn_ids):
-            wait = 120 if ind == 0 else 0
-            self.wait_for_mn_state(wait, 20, "ENABLED", self.nodes[0:num_of_nodes], mn_ids[num])
-
-        return mn_ids, mn_aliases, mn_collateral_addresses
-
-
-    def reconnect_nodes(self, fromindex, toindex):
+    def reconnect_nodes(self, fromindex: int, toindex: int):
         for pair in itertools.combinations(range(fromindex, toindex), 2):
-            connect_nodes_bi(self.nodes, pair[0], pair[1])        
+            connect_nodes_bi(self.nodes, pair[0], pair[1])
 
+    def reconnect_all_nodes(self):
+        """ Reconnect all nodes.
+        """
+        self.reconnect_nodes(0, len(self.nodes))
 
-    def wait_for_mn_state(self, init_wait, more_wait, wait_for, node_list, mnId, repeatMore=1):
+    def reconnect_node(self, index: int):
+        """ Reconnect the node with the given index.
+
+        Args:
+            index (int): Node to reconnect to all other nodes
+        """
+        for i in range(len(self.nodes)):
+            if i != index:
+                connect_nodes_bi(self.nodes, index, i)
+    
+    def wait_for_mn_state(self, init_wait: int, more_wait: int, wait_for_state: str, mn_index: int, repeat_count: int = 1, node_list = None):
+        """Wait for the specific MN state.
+
+        Args:
+            init_wait (int): initial wait in secs
+            more_wait (int): additional wait in secs
+            wait_for_state (str): MN state to wait for
+            mn_index (int): MN index in self.mn_nodes to wait for the target state
+            repeat_count (int, optional): times to repeat wait in case state is not yet obtained. Defaults to 1.
+            node_list (list of nodes, optional): list of nodes to check MN's state on, if not defined - all nodes are checked
+        """
         debug = False
+        timer = Timer()
+        timer.start()
+        
         print(f'Waiting {init_wait} seconds...')
         time.sleep(init_wait)
 
-        for _ in range(repeatMore):
-            result = all(node.masternode("list").get(mnId, "") == wait_for for node in node_list)
+        if node_list is None:
+            node_list = self.nodes
+        mn = self.mn_nodes[mn_index]
+        collateral_id = mn.collateral_id
+        for no in range(repeat_count):
+            result = all(node.masternode("list").get(collateral_id, "") == wait_for_state for node in node_list)
             if not result:
                 if debug:
                     [print(node.masternode("list")) for node in node_list]
-                print(f'Waiting {more_wait} seconds more...')
+                print(f'Waiting {more_wait} seconds more [{no+1}/{repeat_count}]...')
                 time.sleep(more_wait)
             else:
+                print(f"Nodes [{','.join(str(node.index) for node in node_list)}] achieved {mn.alias} state '{wait_for_state}' in {int(timer.elapsed_time)} secs")
                 break
         if debug:
             [print(node.masternode("list")) for node in node_list]
-        [assert_equal(node.masternode("list").get(mnId, ""), wait_for) for node in node_list]
-
-
-    def create_masternode_conf(self, name, n, dirname, txid, vin, private_key, mn_port):
-        datadir = os.path.join(dirname, "node"+str(n))
-        if not os.path.isdir(datadir):
-            os.makedirs(datadir)    
-        regtestdir = os.path.join(datadir, "regtest")
-        if not os.path.isdir(regtestdir):
-            os.makedirs(regtestdir)    
-    
-        cfg_file = os.path.join(regtestdir, "masternode.conf")
-    
-        config = {}
-        if os.path.isfile(cfg_file):
-            with open(cfg_file) as json_file:  
-                config = json.load(json_file)
-
-        config[name] = {}
-        config[name]["mnAddress"] = "127.0.0.1:" + str(mn_port)
-        config[name]["mnPrivKey"] = str(private_key)
-        config[name]["txid"] = str(txid)
-        config[name]["outIndex"] = str(vin)
-        config[name]["extAddress"] = "127.0.0.1:" + str(random.randint(2000, 5000))
-        config[name]["extP2P"] = "127.0.0.1:" + str(random.randint(22000, 25000))
-        config[name]["extKey"] = ''.join(random.sample(private_key,len(private_key)))
-        config[name]["extCfg"] = {}
-        config[name]["extCfg"]["param1"] = str(random.randint(0, 9))
-        config[name]["extCfg"]["param2"] = str(random.randint(0, 9))
-
-        with open(cfg_file, 'w') as f:
-            json.dump(config, f, indent=4)
-        return datadir
+        [assert_equal(node.masternode("list").get(collateral_id, ""), wait_for_state) for node in node_list]

--- a/qa/rpc-tests/mn_messaging.py
+++ b/qa/rpc-tests/mn_messaging.py
@@ -1,26 +1,17 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018-2021 The Pastel Core developers
+# Copyright (c) 2018-2022 The Pastel Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-from test_framework.util import assert_equal, assert_greater_than, assert_true, initialize_chain_clean
-from mn_common import MasterNodeCommon
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 import time
-from test_framework.authproxy import JSONRPCException
-
 from decimal import getcontext
+
+from test_framework.util import assert_equal, initialize_chain_clean
+from mn_common import MasterNodeCommon
+
 getcontext().prec = 16
 
-# 4 Master Nodes
-private_keys_list = ["91sY9h4AQ62bAhNk1aJ7uJeSnQzSFtz7QmW5imrKmiACm7QJLXe",  # 0
-                     "923JtwGJqK6mwmzVkLiG6mbLkhk1ofKE1addiM8CYpCHFdHDNGo",  # 1
-                     "91wLgtFJxdSRLJGTtbzns5YQYFtyYLwHhqgj19qnrLCa1j5Hp5Z",  # 2
-                     "92XctTrjQbRwEAAMNEwKqbiSAJsBNuiR2B8vhkzDX4ZWQXrckZv"  # 3
-                     ]
-
-
 class MasterNodeMessagingTest(MasterNodeCommon):
-    number_of_master_nodes = len(private_keys_list)
+    number_of_master_nodes = 4
     number_of_simple_nodes = 3
     total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
 
@@ -40,14 +31,12 @@ class MasterNodeMessagingTest(MasterNodeCommon):
     def setup_network(self, split=False):
         self.nodes = []
         self.is_network_split = False
-        self.setup_masternodes_network(private_keys_list, self.number_of_simple_nodes)
+        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
+            self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
+        
 
     def run_test(self):
-        self.mining_enough(self.mining_node_num, self.number_of_master_nodes)
-        cold_nodes = {k: v for k, v in enumerate(private_keys_list)}
-        _, _, _ = self.start_mn(self.mining_node_num, self.hot_node_num, cold_nodes, self.total_number_of_nodes)
-
-        self.reconnect_nodes(0, self.number_of_master_nodes)
+        self.reconnect_all_nodes()
         self.sync_all()
 
         mns = self.nodes[0].masternodelist("pubkey")

--- a/qa/rpc-tests/mn_messaging.py
+++ b/qa/rpc-tests/mn_messaging.py
@@ -36,9 +36,6 @@ class MasterNodeMessagingTest(MasterNodeCommon):
         
 
     def run_test(self):
-        self.reconnect_all_nodes()
-        self.sync_all()
-
         mns = self.nodes[0].masternodelist("pubkey")
         for out in mns:
             print(mns[out])

--- a/qa/rpc-tests/mn_payment.py
+++ b/qa/rpc-tests/mn_payment.py
@@ -1,39 +1,21 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018-2021 The Pastel developers
+# Copyright (c) 2018-2022 The Pastel developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or httpa://www.opensource.org/licenses/mit-license.php.
+import time
+from decimal import getcontext
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, initialize_chain_clean, \
-    initialize_datadir, start_nodes, start_node, connect_nodes_bi, \
-    pasteld_processes, wait_and_assert_operationid_status, p2p_port, \
-    stop_node
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    initialize_chain_clean
+)
 from mn_common import MasterNodeCommon
 
-import os
-import sys
-import time
-
-from decimal import Decimal, getcontext
 getcontext().prec = 16
 
-# 12 Master Nodes
-private_keys_list = ["91sY9h4AQ62bAhNk1aJ7uJeSnQzSFtz7QmW5imrKmiACm7QJLXe", #0 
-                     "923JtwGJqK6mwmzVkLiG6mbLkhk1ofKE1addiM8CYpCHFdHDNGo", #1
-                     "91wLgtFJxdSRLJGTtbzns5YQYFtyYLwHhqgj19qnrLCa1j5Hp5Z", #2
-                     "92XctTrjQbRwEAAMNEwKqbiSAJsBNuiR2B8vhkzDX4ZWQXrckZv", #3
-                     "923JCnYet1pNehN6Dy4Ddta1cXnmpSiZSLbtB9sMRM1r85TWym6", #4
-                     "93BdbmxmGp6EtxFEX17FNqs2rQfLD5FMPWoN1W58KEQR24p8A6j", #5
-                     "92av9uhRBgwv5ugeNDrioyDJ6TADrM6SP7xoEqGMnRPn25nzviq", #6
-                     "91oHXFR2NVpUtBiJk37i8oBMChaQRbGjhnzWjN9KQ8LeAW7JBdN", #7
-                     "92MwGh67mKTcPPTCMpBA6tPkEE5AK3ydd87VPn8rNxtzCmYf9Yb", #8
-                     "92VSXXnFgArfsiQwuzxSAjSRuDkuirE1Vf7KvSX7JE51dExXtrc", #9
-                     "91hruvJfyRFjo7JMKnAPqCXAMiJqecSfzn9vKWBck2bKJ9CCRuo", #10
-                     "92sYv5JQHzn3UDU6sYe5kWdoSWEc6B98nyY5JN7FnTTreP8UNrq"  #11
-                    ]
-
 class MasterNodePaymentTest (MasterNodeCommon):
-    number_of_master_nodes = len(private_keys_list)
+    number_of_master_nodes = 12
     number_of_simple_nodes = 2
     total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
     mining_node_num = number_of_master_nodes
@@ -46,19 +28,19 @@ class MasterNodePaymentTest (MasterNodeCommon):
     def setup_network(self, split=False):
         self.nodes = []
         self.is_network_split = False
-        self.setup_masternodes_network(private_keys_list, self.number_of_simple_nodes)
+        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
+            self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
 
     def run_test (self):
-        self.mining_enough(self.mining_node_num, self.number_of_master_nodes)
-        cold_nodes = {k: v for k, v in enumerate(private_keys_list)}
-        _, _, mn_collateral_addresses = self.start_mn(self.mining_node_num, self.hot_node_num, cold_nodes, self.total_number_of_nodes)
-
+        self.reconnect_all_nodes()
+        self.sync_all()
+        
         start_block = self.nodes[0].getinfo()["blocks"]
         next_block = start_block + 11
 
         winners_counts = dict()
 
-        for ind in range (120):
+        for _ in range (120):
             self.nodes[self.mining_node_num].generate(1)
             self.sync_all()
             block_winners_str = self.nodes[0].masternode("winners")[str(next_block)]
@@ -73,17 +55,17 @@ class MasterNodePaymentTest (MasterNodeCommon):
             # winners_counts[block_winner] = winners_counts.get(block_winner, 0) + 1
         number_mn_payments = 0
         number_payed_nodes = 0
-        for item in mn_collateral_addresses.items():
+        for mn in self.mn_nodes:
             number_payed_nodes += 1
-            address = item[1]
+            address = mn.collateral_address
             mn_payments = winners_counts.get(address, 0)
-            print("{0} - {1}".format(address, mn_payments))
+            print(f"{address} - {mn_payments}")
             # test that MN was selected as winner at least 80% times (8 out of 10 in this case)
             assert_greater_than(mn_payments, 7)
             number_mn_payments += mn_payments
 
         assert_equal(number_mn_payments, 120)
-        assert_equal(number_payed_nodes, len(mn_collateral_addresses))
+        assert_equal(number_payed_nodes, self.number_of_master_nodes)
         assert_equal(number_payed_nodes, len(winners_counts))
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/mn_payment.py
+++ b/qa/rpc-tests/mn_payment.py
@@ -32,9 +32,6 @@ class MasterNodePaymentTest (MasterNodeCommon):
             self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
 
     def run_test (self):
-        self.reconnect_all_nodes()
-        self.sync_all()
-        
         start_block = self.nodes[0].getinfo()["blocks"]
         next_block = start_block + 11
 

--- a/qa/rpc-tests/mn_tickets_username_change.py
+++ b/qa/rpc-tests/mn_tickets_username_change.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2021-2022 The Pastel Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php.
+from decimal import getcontext
+
 from test_framework.util import (
     assert_equal,
     assert_true,
@@ -14,7 +16,6 @@ from test_framework.util import (
 from pastel_test_framework import PastelTestFramework
 import test_framework.rpc_consts as rpc
 
-from decimal import Decimal, getcontext
 getcontext().prec = 16
 
 class UserNameChangeTest(PastelTestFramework):

--- a/qa/rpc-tests/mn_tickets_validation.py
+++ b/qa/rpc-tests/mn_tickets_validation.py
@@ -4,11 +4,12 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php.
 import json
 import time
+
 from test_framework.util import (
     assert_equal,
-    assert_raises_rpc, 
-    assert_true, 
-    initialize_chain_clean, 
+    assert_raises_rpc,
+    assert_true,
+    initialize_chain_clean,
     str_to_b64str
 )
 import test_framework.rpc_consts as rpc
@@ -18,25 +19,9 @@ from test_framework.authproxy import JSONRPCException
 from decimal import getcontext
 getcontext().prec = 16
 
-# 12 Master Nodes
-private_keys_list = ["91sY9h4AQ62bAhNk1aJ7uJeSnQzSFtz7QmW5imrKmiACm7QJLXe",  # 0
-                     "923JtwGJqK6mwmzVkLiG6mbLkhk1ofKE1addiM8CYpCHFdHDNGo",  # 1
-                     "91wLgtFJxdSRLJGTtbzns5YQYFtyYLwHhqgj19qnrLCa1j5Hp5Z",  # 2
-                     "92XctTrjQbRwEAAMNEwKqbiSAJsBNuiR2B8vhkzDX4ZWQXrckZv",  # 3
-                     "923JCnYet1pNehN6Dy4Ddta1cXnmpSiZSLbtB9sMRM1r85TWym6",  # 4
-                     "93BdbmxmGp6EtxFEX17FNqs2rQfLD5FMPWoN1W58KEQR24p8A6j",  # 5
-                     "92av9uhRBgwv5ugeNDrioyDJ6TADrM6SP7xoEqGMnRPn25nzviq",  # 6
-                     "91oHXFR2NVpUtBiJk37i8oBMChaQRbGjhnzWjN9KQ8LeAW7JBdN",  # 7
-                     "92MwGh67mKTcPPTCMpBA6tPkEE5AK3ydd87VPn8rNxtzCmYf9Yb",  # 8
-                     "92VSXXnFgArfsiQwuzxSAjSRuDkuirE1Vf7KvSX7JE51dExXtrc",  # 9
-                     "91hruvJfyRFjo7JMKnAPqCXAMiJqecSfzn9vKWBck2bKJ9CCRuo",  # 10
-                     "92sYv5JQHzn3UDU6sYe5kWdoSWEc6B98nyY5JN7FnTTreP8UNrq",  # 11
-                     "92pfBHQaf5K2XBnFjhLaALjhCqV8Age3qUgJ8j8oDB5eESFErsM"   # 12
-                     ]
-
 
 class MasterNodeTicketsTest(MasterNodeCommon):
-    number_of_master_nodes = len(private_keys_list)
+    number_of_master_nodes = 13
     number_of_simple_nodes = 3
     total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
 
@@ -95,18 +80,15 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         initialize_chain_clean(self.options.tmpdir, self.total_number_of_nodes)
 
     def setup_network(self, split=False):
-        self.setup_masternodes_network(private_keys_list, self.number_of_simple_nodes)
+        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
+            self.mining_node_num, self.hot_node_num, self.number_of_master_nodes - 1,
+            "masternode,mnpayments,governance,compress")
 
     def run_test(self):
-
-        self.mining_enough(self.mining_node_num, self.number_of_master_nodes)
-        cold_nodes = {k: v for k, v in enumerate(private_keys_list)}  # all but last!!!
-        _, _, _ = self.start_mn(self.mining_node_num, self.hot_node_num, cold_nodes, self.total_number_of_nodes)
-
-        self.reconnect_nodes(0, self.number_of_master_nodes)
+        self.reconnect_all_nodes()
         self.sync_all()
 
-        self.mn0_address1 = self.nodes[0].getnewaddress()
+        self.mn0_address1 = self.mn_nodes[0].getnewaddress()
         self.nonmn3_address1 = self.nodes[self.non_mn3].getnewaddress()
 
         self.nodes[self.mining_node_num].sendtoaddress(self.mn0_address1, self.collateral, "", "", False)
@@ -216,7 +198,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         print(self.ticket)
 
         # create ticket signature
-        ticket_signature_nonmn1 = self.nodes[self.non_mn1].pastelid("sign", self.ticket, self.nonmn1_pastelid1, self.passphrase)["signature"]
+        self.nodes[self.non_mn1].pastelid("sign", self.ticket, self.nonmn1_pastelid1, self.passphrase)["signature"]
         ticket_signature_creator = self.nodes[self.non_mn3].pastelid("sign", self.ticket, self.creator_pastelid1, self.passphrase)["signature"]
         for n in range(0, 13):
             self.mn_ticket_signatures[n] = self.nodes[n].pastelid("sign", self.ticket, self.mn_pastelids[n], self.passphrase)["signature"]

--- a/qa/rpc-tests/pastel_test_framework.py
+++ b/qa/rpc-tests/pastel_test_framework.py
@@ -204,10 +204,10 @@ class PastelTestFramework (BitcoinTestFramework):
         super().__init__()
 
         # registered ticket counters
-        self._ticket_counters = dict()
-        self._offer_counters = dict()
-        self._accept_counters = dict()
-        self._transfer_counters = dict()
+        self._ticket_counters = {}
+        self._offer_counters = {}
+        self._accept_counters = {}
+        self._transfer_counters = {}
 
     def ticket_counter(self, ticket_type: TicketType) -> int:
         """Get counter for registered tickets of the given type.

--- a/qa/rpc-tests/pruning.py
+++ b/qa/rpc-tests/pruning.py
@@ -114,7 +114,7 @@ class PruneTest(BitcoinTestFramework):
             # Disconnect node 0 so it can mine a longer reorg chain without knowing about node 1's soon-to-be-stale chain
             # Node 2 stays connected, so it hears about the stale blocks and then reorg's when node0 reconnects
             # Stopping node 0 also clears its mempool, so it doesn't have node1's transactions to accidentally mine
-            stop_node(self.nodes[0],0)
+            stop_node(self.nodes[0])
             self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=999000", "-checkblocks=5"], timewait=900)
             # Mine 24 blocks in node 1
             self.utxo = self.nodes[1].listunspent()
@@ -141,7 +141,7 @@ class PruneTest(BitcoinTestFramework):
         # This will cause Node 2 to do a reorg requiring 288 blocks of undo data to the reorg_test chain
         # Reboot node 1 to clear its mempool (hopefully make the invalidate faster)
         # Lower the block max size so we don't keep mining all our big mempool transactions (from disconnected blocks)
-        stop_node(self.nodes[1],1)
+        stop_node(self.nodes[1])
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
         height = self.nodes[1].getblockcount()
@@ -164,7 +164,7 @@ class PruneTest(BitcoinTestFramework):
         print("New best height", self.nodes[1].getblockcount())
 
         # Reboot node1 to clear those giant tx's from mempool
-        stop_node(self.nodes[1],1)
+        stop_node(self.nodes[1])
         self.nodes[1]=start_node(1, self.options.tmpdir, ["-debug","-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
 
         print("Generating new longer chain of 300 more blocks")

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -30,7 +30,7 @@ class ReindexTest(BitcoinTestFramework):
 
     def run_test(self):
         self.nodes[0].generate(3)
-        stop_node(self.nodes[0], 0)
+        stop_node(self.nodes[0])
         wait_pastelds()
         self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug", "-reindex", "-checkblockindex=1"])
         assert_equal(self.nodes[0].getblockcount(), 3)

--- a/qa/rpc-tests/secure_container.py
+++ b/qa/rpc-tests/secure_container.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018-2021 The Pastel Core developers
+# Copyright (c) 2018-2022 The Pastel Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
-import math
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 import base64
+from decimal import getcontext
 
 from test_framework.util import (
-    assert_equal, 
+    assert_equal,
     assert_raises_rpc,
-    assert_true, 
-    assert_raises, 
+    assert_true,
+    assert_raises,
     assert_raises_message,
-    assert_shows_help, 
+    assert_shows_help,
     start_nodes,
     connect_nodes_bi
 )
@@ -19,7 +19,6 @@ from pastel_test_framework import PastelTestFramework
 from test_framework.authproxy import JSONRPCException
 import test_framework.rpc_consts as rpc
 
-from decimal import Decimal, getcontext
 getcontext().prec = 16
 
 class SecureContainerTest(PastelTestFramework):
@@ -44,7 +43,7 @@ class SecureContainerTest(PastelTestFramework):
         print(" -pastelid help")
         assert_shows_help(self.nodes[0].pastelid)
 
-        coinbase_addr1 = self.nodes[1].getnewaddress()
+        self.nodes[1].getnewaddress()
         taddr1 = self.nodes[1].getnewaddress()
 
         print(" -pastelid newkey")

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -111,9 +111,9 @@ class WalletBackupTest(BitcoinTestFramework):
         connect_nodes(self.nodes[2], 0)
 
     def stop_three(self):
-        stop_node(self.nodes[0], 0)
-        stop_node(self.nodes[1], 1)
-        stop_node(self.nodes[2], 2)
+        stop_node(self.nodes[0])
+        stop_node(self.nodes[1])
+        stop_node(self.nodes[2])
 
     def erase_three(self):
         os.remove(self.options.tmpdir + "/node0/regtest/wallet.dat")

--- a/src/gtest/test_prevector.cpp
+++ b/src/gtest/test_prevector.cpp
@@ -35,7 +35,7 @@ class prevector_tester {
              EXPECT_EQ(&(pre_vector[s]) , &*(pre_vector.begin() + s));
              EXPECT_EQ(&(pre_vector[s]) , &*((pre_vector.end() + s) - real_vector.size()));
         }
-        // BOOST_CHECK(realtype(pre_vector) == real_vector);
+
         EXPECT_EQ(pretype(real_vector.begin(), real_vector.end()) , pre_vector);
         EXPECT_EQ(pretype(pre_vector.begin(), pre_vector.end()) , pre_vector);
         size_t pos = 0;

--- a/src/gtest/test_raii_event.cpp
+++ b/src/gtest/test_raii_event.cpp
@@ -1,12 +1,11 @@
 // Copyright (c) 2016 The Bitcoin Core developers
-// Copyright (c) 2021 The Pastel developers
+// Copyright (c) 2021-2022 The Pastel developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <event2/event.h>
 
 #ifdef EVENT_SET_MEM_FUNCTIONS_IMPLEMENTED
-// It would probably be ideal to define dummy test(s) that report skipped, but boost::test doesn't seem to make that practical (at least not in versions available with common distros)
 
 #include <map>
 #include <stdlib.h>
@@ -14,7 +13,7 @@
 
 #include <gtest/gtest.h>
 
-#include "support/events.h"
+#include <support/events.h>
 
 using namespace std;
 using namespace testing;
@@ -42,7 +41,7 @@ TEST(test_raii_event, raii_event_creation)
 {
     event_set_mem_functions(tag_malloc, realloc, tag_free);
     
-    void* base_ptr = NULL;
+    void* base_ptr = nullptr;
     {
         auto base = obtain_event_base();
         base_ptr = (void*)base.get();
@@ -50,10 +49,10 @@ TEST(test_raii_event, raii_event_creation)
     }
     EXPECT_EQ(tags[base_ptr] , 0);
     
-    void* event_ptr = NULL;
+    void* event_ptr = nullptr;
     {
         auto base = obtain_event_base();
-        auto event = obtain_event(base.get(), -1, 0, NULL, NULL);
+        auto event = obtain_event(base.get(), -1, 0, nullptr, nullptr);
 
         base_ptr = (void*)base.get();
         event_ptr = (void*)event.get();
@@ -71,11 +70,11 @@ TEST(test_raii_event, raii_event_order)
 {
     event_set_mem_functions(tag_malloc, realloc, tag_free);
     
-    void* base_ptr = NULL;
-    void* event_ptr = NULL;
+    void* base_ptr = nullptr;
+    void* event_ptr = nullptr;
     {
         auto base = obtain_event_base();
-        auto event = obtain_event(base.get(), -1, 0, NULL, NULL);
+        auto event = obtain_event(base.get(), -1, 0, nullptr, nullptr);
 
         base_ptr = (void*)base.get();
         event_ptr = (void*)event.get();

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -309,7 +309,7 @@ static void http_reject_request_cb(struct evhttp_request* req, void*)
 /** Event dispatcher thread */
 static void ThreadHTTP(struct event_base* base, struct evhttp* http)
 {
-    RenameThread("pastel-http");
+    RenameThread("psl-http");
     LogPrint("http", "Entering http event loop\n");
     event_base_dispatch(base);
     // Event loop will be interrupted by InterruptHTTPServer()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -191,7 +191,7 @@ void Shutdown(CServiceThreadGroup& threadGroup, CScheduler &scheduler)
     /// for example if the data directory was found to be locked.
     /// Be sure that anything that writes files or flushes caches only does this if the respective
     /// module was initialized.
-    RenameThread("pastel-shutoff");
+    RenameThread("psl-shutoff");
     mempool.AddTransactionsUpdated(1);
 
     StopHTTPRPC();
@@ -624,7 +624,7 @@ void CleanupBlockRevFiles()
 
 void ThreadImport(std::vector<fs::path> vImportFiles)
 {
-    RenameThread("pastel-loadblk");
+    RenameThread("psl-loadblk");
     const auto& chainparams = Params();
     // -reindex
     if (fReindex) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -503,7 +503,7 @@ void static BitcoinMiner()
 {
     LogPrintf("PastelMiner started\n");
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
-    RenameThread("pastel-miner");
+    RenameThread("psl-miner");
 
 #ifdef ENABLE_WALLET
     // Each thread has its own key

--- a/src/mnode/mnode-active.cpp
+++ b/src/mnode/mnode-active.cpp
@@ -3,43 +3,49 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
-#include "protocol.h"
-#include "port_config.h"
+#include <util.h>
+#include <protocol.h>
+#include <port_config.h>
 
-#include "mnode/mnode-active.h"
-#include "mnode/mnode-masternode.h"
-#include "mnode/mnode-manager.h"
-#include "mnode/mnode-sync.h"
-#include "mnode/mnode-controller.h"
+#include <mnode/mnode-active.h>
+#include <mnode/mnode-masternode.h>
+#include <mnode/mnode-manager.h>
+#include <mnode/mnode-sync.h>
+#include <mnode/mnode-controller.h>
+#include <mnode/tickets/pastelid-reg.h>
 
 using namespace std;
 
 void CActiveMasternode::ManageState()
 {
-    LogPrint("masternode", "CActiveMasternode::ManageState -- Start\n");
-    if(!masterNodeCtrl.IsMasterNode()) {
-        LogPrint("masternode", "CActiveMasternode::ManageState -- Not a masternode, returning\n");
+    LogFnPrint("masternode", "Start");
+    if (!masterNodeCtrl.IsMasterNode())
+    {
+        LogFnPrint("masternode", "Not a masternode, returning");
         return;
     }
 
-    if(!Params().IsRegTest() && !masterNodeCtrl.masternodeSync.IsBlockchainSynced()) {
+    if (!Params().IsRegTest() && !masterNodeCtrl.masternodeSync.IsBlockchainSynced())
+    {
         nState = ActiveMasternodeState::SyncInProcess;
-        LogPrintf("CActiveMasternode::ManageState -- %s: %s\n", GetStateString(), GetStatus());
+        LogFnPrintf("%s: %s", GetStateString(), GetStatus());
         return;
     }
 
-    if(nState == ActiveMasternodeState::SyncInProcess) {
+    if (nState == ActiveMasternodeState::SyncInProcess)
+    {
         nState = ActiveMasternodeState::Initial;
     }
 
-    LogPrint("masternode", "CActiveMasternode::ManageState -- status = %s, type = %s, pinger enabled = %d\n", GetStatus(), GetTypeString(), fPingerEnabled);
+    LogFnPrint("masternode", "status = %s, type = %s, pinger enabled = %d", GetStatus(), GetTypeString(), fPingerEnabled);
 
-    if(mnType == MasternodeType::Unknown) {
+    if (mnType == MasternodeType::Unknown)
+    {
         ManageStateInitial();
     }
 
-    if(mnType == MasternodeType::Remote) {
+    if (mnType == MasternodeType::Remote)
+    {
         ManageStateRemote();
     }
 
@@ -53,6 +59,7 @@ string CActiveMasternode::GetStatus() const noexcept
         case ActiveMasternodeState::SyncInProcess:  return "Sync in progress. Must wait until sync is complete to start Masternode";
         case ActiveMasternodeState::InputTooNew:    return strprintf("Masternode input must have at least %d confirmations", masterNodeCtrl.nMasternodeMinimumConfirmations);
         case ActiveMasternodeState::NotCapable:     return "Not capable masternode: " + strNotCapableReason;
+        case ActiveMasternodeState::NeedMnId:       return "Masternode need to register Pastel ID (mnid)";
         case ActiveMasternodeState::Started:        return "Masternode successfully started";
         default:                                    return "Unknown";
     }
@@ -61,46 +68,52 @@ string CActiveMasternode::GetStatus() const noexcept
 string CActiveMasternode::GetTypeString() const noexcept
 {
     string strType;
-    switch(mnType) {
-    case MasternodeType::Remote:
-        strType = "REMOTE";
-        break;
-    default:
-        strType = "UNKNOWN";
-        break;
+    switch(mnType)
+    {
+        case MasternodeType::Remote:
+            strType = "REMOTE";
+            break;
+
+        default:
+            strType = "UNKNOWN";
+            break;
     }
     return strType;
 }
 
 bool CActiveMasternode::SendMasternodePing()
 {
-    if(!fPingerEnabled) {
-        LogPrint("masternode", "CActiveMasternode::SendMasternodePing -- %s: masternode ping service is disabled, skipping...\n", GetStateString());
+    if (!fPingerEnabled)
+    {
+        LogFnPrint("masternode", "%s: masternode ping service is disabled, skipping...", GetStateString());
         return false;
     }
 
-    if(!masterNodeCtrl.masternodeManager.Has(outpoint)) {
+    if (!masterNodeCtrl.masternodeManager.Has(outpoint))
+    {
         strNotCapableReason = "Masternode not in masternode list";
         nState = ActiveMasternodeState::NotCapable;
-        LogPrintf("CActiveMasternode::SendMasternodePing -- %s: %s\n", GetStateString(), strNotCapableReason);
+        LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
         return false;
     }
 
     CMasternodePing mnp(outpoint);
-    if(!mnp.Sign(keyMasternode, pubKeyMasternode)) {
-        LogPrintf("CActiveMasternode::SendMasternodePing -- ERROR: Couldn't sign Masternode Ping\n");
+    if (!mnp.Sign(keyMasternode, pubKeyMasternode))
+    {
+        LogFnPrintf("ERROR: Couldn't sign Masternode Ping");
         return false;
     }
 
     // Update lastPing for our masternode in Masternode list
-    if(masterNodeCtrl.masternodeManager.IsMasternodePingedWithin(outpoint, masterNodeCtrl.MasternodeMinMNPSeconds, mnp.sigTime)) {
-        LogPrintf("CActiveMasternode::SendMasternodePing -- Too early to send Masternode Ping\n");
+    if (masterNodeCtrl.masternodeManager.IsMasternodePingedWithin(outpoint, masterNodeCtrl.MasternodeMinMNPSeconds, mnp.sigTime))
+    {
+        LogFnPrintf("Too early to send Masternode Ping");
         return false;
     }
 
     masterNodeCtrl.masternodeManager.SetMasternodeLastPing(outpoint, mnp);
 
-    LogPrintf("CActiveMasternode::SendMasternodePing -- Relaying ping, collateral=%s\n", outpoint.ToStringShort());
+    LogFnPrintf("Relaying ping, collateral=%s", outpoint.ToStringShort());
 
     mnp.Relay();
 
@@ -109,21 +122,23 @@ bool CActiveMasternode::SendMasternodePing()
 
 void CActiveMasternode::ManageStateInitial()
 {
-    LogPrint("masternode", "CActiveMasternode::ManageStateInitial -- status = %s, type = %s, pinger enabled = %d\n", GetStatus(), GetTypeString(), fPingerEnabled);
+    LogFnPrint("masternode", "status = %s, type = %s, pinger enabled = %d", GetStatus(), GetTypeString(), fPingerEnabled);
 
     // Check that our local network configuration is correct
-    if (!fListen) {
+    if (!fListen)
+    {
         // listen option is probably overwritten by smth else, no good
         nState = ActiveMasternodeState::NotCapable;
         strNotCapableReason = "Masternode must accept connections from outside. Make sure listen configuration option is not overwritten by some another parameter.";
-        LogPrintf("CActiveMasternode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);
+        LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
         return;
     }
 
     // First try to find whatever local address is specified by externalip option
     const auto& chainparams = Params();
     bool fFoundLocal = chainparams.IsRegTest() || (GetLocal(service) && CMasternode::IsValidNetAddr(service));
-    if(!fFoundLocal) {
+    if (!fFoundLocal)
+    {
         bool empty = true;
         // If we have some peers, let's try to find our local address from one of them
         CNodeHelper::ForEachNodeContinueIf(CNodeHelper::AllNodes, [&fFoundLocal, &empty, this](CNode* pnode) {
@@ -137,7 +152,7 @@ void CActiveMasternode::ManageStateInitial()
         {
             nState = ActiveMasternodeState::NotCapable;
             strNotCapableReason = "Can't detect valid external address. Will retry when there are some connections available.";
-            LogPrintf("CActiveMasternode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);
+            LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
     }
@@ -146,7 +161,7 @@ void CActiveMasternode::ManageStateInitial()
     {
         nState = ActiveMasternodeState::NotCapable;
         strNotCapableReason = "Can't detect valid external address. Please consider using the externalip configuration option if problem persists. Make sure to use IPv4 address only.";
-        LogPrintf("CActiveMasternode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);
+        LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
         return;
     }
 
@@ -156,39 +171,61 @@ void CActiveMasternode::ManageStateInitial()
         {
             nState = ActiveMasternodeState::NotCapable;
             strNotCapableReason = strprintf("Invalid port: %hu - only %hu is supported on mainnet.", service.GetPort(), MAINNET_DEFAULT_PORT);
-            LogPrintf("CActiveMasternode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);
+            LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
     } else if (service.GetPort() == MAINNET_DEFAULT_PORT) {
         nState = ActiveMasternodeState::NotCapable;
         strNotCapableReason = strprintf("Invalid port: %hu is only supported on mainnet.", service.GetPort());
-        LogPrintf("CActiveMasternode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);
+        LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
         return;
     }
 
     if (!chainparams.IsRegTest())
     {
-        LogPrintf("CActiveMasternode::ManageStateInitial -- Checking inbound connection to '%s'\n", service.ToString());
+        LogFnPrintf("Checking inbound connection to '%s'", service.ToString());
 
-        if(!ConnectNode(CAddress(service, NODE_NETWORK), nullptr, true))
+        if (!ConnectNode(CAddress(service, NODE_NETWORK), nullptr, true))
         {
             nState = ActiveMasternodeState::NotCapable;
             strNotCapableReason = "Could not connect to " + service.ToString();
-            LogPrintf("CActiveMasternode::ManageStateInitial -- %s: %s\n", GetStateString(), strNotCapableReason);
+            LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
     }
 
-    // Default to REMOTE
+    // at this point it can be started remotely without registered mnid
     mnType = MasternodeType::Remote;
 
-    LogPrint("masternode", "CActiveMasternode::ManageStateInitial -- End status = %s, type = %s, pinger enabled = %d\n", GetStatus(), GetTypeString(), fPingerEnabled);
+    LogFnPrint("masternode", "End status = %s, type = %s, pinger enabled = %d", GetStatus(), GetTypeString(), fPingerEnabled);
+}
+
+/**
+ * Check for registered mnid.
+ * In case it is not registered - set status to ActiveMasternodeState::NeeMnId.
+ * 
+ * \param outPoint - use this outpoint to search for the registered mnid
+ * \return true if mnid is registered
+ */
+bool CActiveMasternode::CheckMnId(const COutPoint &outPoint)
+{
+    // check for registered mnid
+    // check that this MN has registered Pastel ID (mnid)
+    CPastelIDRegTicket mnidTicket;
+    mnidTicket.secondKey = outPoint.ToStringShort();
+    if (!masterNodeCtrl.masternodeTickets.FindTicketBySecondaryKey(mnidTicket))
+    {
+        LogFnPrintf("Masternode %s does not have registered Pastel ID", outPoint.ToStringShort());
+        nState = ActiveMasternodeState::NeedMnId;
+        return false;
+    }
+    return true;
 }
 
 void CActiveMasternode::ManageStateRemote()
 {
-    LogPrint("masternode", "CActiveMasternode::ManageStateRemote -- Start status = %s, type = %s, pinger enabled = %d, pubKeyMasternode.GetID() = %s\n", 
-             GetStatus(), GetTypeString(), fPingerEnabled, pubKeyMasternode.GetID().ToString());
+    LogFnPrint("masternode", "Start status = %s, type = %s, pinger enabled = %d, pubKeyMasternode.GetID() = %s", 
+        GetStatus(), GetTypeString(), fPingerEnabled, pubKeyMasternode.GetID().ToString());
 
     masterNodeCtrl.masternodeManager.CheckMasternode(pubKeyMasternode, true);
     masternode_info_t infoMn;
@@ -198,27 +235,32 @@ void CActiveMasternode::ManageStateRemote()
         {
             nState = ActiveMasternodeState::NotCapable;
             strNotCapableReason = strprintf("Invalid protocol version %d, required %d", infoMn.nProtocolVersion, PROTOCOL_VERSION);
-            LogPrintf("CActiveMasternode::ManageStateRemote -- %s: %s\n", GetStateString(), strNotCapableReason);
+            LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
         if (!Params().IsRegTest() && service != infoMn.addr)
         {
             nState = ActiveMasternodeState::NotCapable;
             strNotCapableReason = "Broadcasted IP doesn't match our external address. Make sure you issued a new broadcast if IP of this masternode changed recently.";
-            LogPrintf("CActiveMasternode::ManageStateRemote -- %s: %s\n", GetStateString(), strNotCapableReason);
+            LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
-        if (!CMasternode::IsValidStateForAutoStart(infoMn.nActiveState))
+        if (!CMasternode::IsValidStateForAutoStart(infoMn.GetActiveState()))
         {
             nState = ActiveMasternodeState::NotCapable;
-            strNotCapableReason = strprintf("Masternode in %s state", CMasternode::StateToString(infoMn.nActiveState));
-            LogPrintf("CActiveMasternode::ManageStateRemote -- %s: %s\n", GetStateString(), strNotCapableReason);
+            strNotCapableReason = strprintf("Masternode in %s state", MasternodeStateToString(infoMn.GetActiveState()));
+            LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
         if (!IsStarted())
         {
-            LogPrintf("CActiveMasternode::ManageStateRemote -- STARTED!\n");
+            // can assign outpoint - will be used to register mnid
             outpoint = infoMn.vin.prevout;
+
+            // mnid should be registered to  set 'Started' status
+            if (!CheckMnId(infoMn.vin.prevout))
+                return;
+            LogFnPrintf("STARTED!");
             service = infoMn.addr;
             fPingerEnabled = true;
             nState = ActiveMasternodeState::Started;
@@ -228,6 +270,6 @@ void CActiveMasternode::ManageStateRemote()
     {
         nState = ActiveMasternodeState::NotCapable;
         strNotCapableReason = "Masternode not in masternode list";
-        LogPrintf("CActiveMasternode::ManageStateRemote -- %s: %s\n", GetStateString(), strNotCapableReason);
+        LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
     }
 }

--- a/src/mnode/mnode-active.h
+++ b/src/mnode/mnode-active.h
@@ -6,11 +6,11 @@
 #include <string>
 #include <map>
 
-#include "chainparams.h"
-#include "net.h"
-#include "sync.h"
-#include "primitives/transaction.h"
-#include "key.h"
+#include <chainparams.h>
+#include <net.h>
+#include <sync.h>
+#include <primitives/transaction.h>
+#include <key.h>
 
 // Responsible for activating the Masternode and pinging the network
 class CActiveMasternode
@@ -25,11 +25,13 @@ public:
     enum class ActiveMasternodeState : uint8_t
     {
         Initial        = 0, // initial state
-        SyncInProcess  = 1,
-        InputTooNew    = 2,
-        NotCapable     = 3,
-        Started        = 4,
-        COUNT          = 5
+        SyncInProcess,
+        InputTooNew,
+        NotCapable,
+        NeedMnId,
+        Started,
+
+        COUNT
     };
 
     typedef struct _ActiveMNStateInfo
@@ -45,6 +47,7 @@ protected:
                { ActiveMasternodeState::SyncInProcess,   "SYNC_IN_PROCESS" },
                { ActiveMasternodeState::InputTooNew,     "INPUT_TOO_NEW" },
                { ActiveMasternodeState::NotCapable,      "NOT_CAPABLE" },
+               { ActiveMasternodeState::NeedMnId,        "NEED_MNID" },
                { ActiveMasternodeState::Started,         "STARTED" }
         }};
     
@@ -71,15 +74,10 @@ public:
     ActiveMasternodeState nState;
     std::string strNotCapableReason;
 
-
-    CActiveMasternode()
-        : mnType(MasternodeType::Unknown),
-          fPingerEnabled(false),
-          pubKeyMasternode(),
-          keyMasternode(),
-          outpoint(),
-          service(),
-          nState(ActiveMasternodeState::Initial)
+    CActiveMasternode() :
+        mnType(MasternodeType::Unknown),
+        fPingerEnabled(false),
+        nState(ActiveMasternodeState::Initial)
     {}
 
     /// Manage state of active Masternode
@@ -97,8 +95,11 @@ public:
     std::string GetStatus() const noexcept;
     std::string GetTypeString() const noexcept;
     bool IsStarted() const noexcept { return nState == ActiveMasternodeState::Started; }
+    bool NeedMnId() const noexcept { return nState == ActiveMasternodeState::NeedMnId; }
 
 private:
     void ManageStateInitial();
     void ManageStateRemote();
+    // check that mnid is registered
+    bool CheckMnId(const COutPoint &outPoint);
 };

--- a/src/mnode/mnode-config.h
+++ b/src/mnode/mnode-config.h
@@ -4,68 +4,69 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <vector>
-#include <map_types.h>
 #include <mutex>
 
+#include <map_types.h>
 #include <mnode/mnode-masternode.h>
 
 class CMasternodeConfig
 {
 public:
 
-    class CMasternodeEntry {
+    class CMasternodeEntry
+    {
+        private:
+            std::string alias;
+            std::string mnAddress;
+            std::string mnPrivKey;
+            std::string txHash;
+            std::string outputIndex;
+            std::string extAddress;
+            std::string extP2P;
+            std::string extKey;
+            std::string extCfg;
 
-    private:
-        std::string alias;
-        std::string mnAddress;
-        std::string mnPrivKey;
-        std::string txHash;
-        std::string outputIndex;
-        std::string extAddress;
-        std::string extP2P;
-        std::string extKey;
-        std::string extCfg;
+        public:
+            CMasternodeEntry() noexcept = default;
+            CMasternodeEntry(const std::string &alias, std::string &&mnAddress, std::string &&mnPrivKey, std::string &&txHash, 
+                std::string &&outputIndex, std::string &&extAddress, std::string &&extP2P, std::string &&extKey, std::string &&extCfg) noexcept
+            {
+                this->alias = alias;
+                this->mnAddress = std::move(mnAddress);
+                this->mnPrivKey = std::move(mnPrivKey);
+                this->txHash = std::move(txHash);
+                this->outputIndex = std::move(outputIndex);
+                this->extAddress = std::move(extAddress);
+                this->extP2P = std::move(extP2P);
+                this->extKey = std::move(extKey);
+                this->extCfg = std::move(extCfg);
+            }
 
-    public:
-        CMasternodeEntry(std::string alias, std::string mnAddress, std::string mnPrivKey, std::string txHash, std::string outputIndex,
-                         std::string extAddress, std::string extP2P, std::string extKey, std::string extCfg) noexcept
-        {
-            this->alias = alias;
-            this->mnAddress = mnAddress;
-            this->mnPrivKey = mnPrivKey;
-            this->txHash = txHash;
-            this->outputIndex = outputIndex;
-            this->extAddress = extAddress;
-            this->extP2P = extP2P;
-            this->extKey = extKey;
-            this->extCfg = extCfg;
-        }
+            const std::string& getAlias() const noexcept { return alias; }
+            const std::string& getIp() const noexcept { return mnAddress; }
+            const std::string& getPrivKey() const noexcept { return mnPrivKey; }
+            const std::string& getTxHash() const noexcept{ return txHash; }
+            const std::string& getOutputIndex() const noexcept { return outputIndex; }
+            const std::string& getExtIp() const noexcept { return extAddress; }
+            const std::string& getExtP2P() const noexcept { return extP2P; }
+            const std::string& getExtKey() const noexcept { return extKey; }
+            const std::string& getExtCfg() const noexcept { return extCfg; }
 
-        const std::string& getAlias() const noexcept { return alias; }
-        const std::string& getIp() const noexcept { return mnAddress; }
-        const std::string& getPrivKey() const noexcept { return mnPrivKey; }
-        const std::string& getTxHash() const noexcept{ return txHash; }
-        const std::string& getOutputIndex() const noexcept { return outputIndex; }
-        const std::string& getExtIp() const noexcept { return extAddress; }
-        const std::string& getExtP2P() const noexcept { return extP2P; }
-        const std::string& getExtKey() const noexcept { return extKey; }
-        const std::string& getExtCfg() const noexcept { return extCfg; }
-
-        COutPoint getOutPoint() const noexcept;
+            COutPoint getOutPoint() const noexcept;
     };
 
-    CMasternodeConfig() noexcept
-    {
-        entries = std::vector<CMasternodeEntry>();
-    }
+    CMasternodeConfig() noexcept = default;
 
-    bool read(std::string& strErr);
+    bool read(std::string& strErr, const bool bNewOnly = false);
 
-    std::vector<CMasternodeEntry>& getEntries() noexcept { return entries; }
+    std::unordered_map<std::string, CMasternodeEntry>& getEntries() noexcept { return m_CfgEntries; }
+    // get MN entry by alias
+    bool GetEntryByAlias(const std::string& alias, CMasternodeEntry &mne) const noexcept;
+    bool AliasExists(const std::string &alias) const noexcept;
     int getCount() const noexcept;
     std::string getAlias(const COutPoint &outpoint) const noexcept;
 
 private:
     mutable std::mutex m_mtx;
-    std::vector<CMasternodeEntry> entries;
+    std::unordered_map<std::string, CMasternodeEntry> m_CfgEntries;
 };

--- a/src/mnode/mnode-controller.h
+++ b/src/mnode/mnode-controller.h
@@ -100,13 +100,16 @@ public:
 
     bool IsMasterNode() const noexcept { return fMasterNode; }
     bool IsActiveMasterNode() const noexcept { return fMasterNode && activeMasternode.IsStarted(); }
+    bool CanRegisterMnId() const noexcept { return fMasterNode && (activeMasternode.IsStarted() || activeMasternode.NeedMnId()); }
     int GetSupportedProtocolVersion() const noexcept;
 
 #ifdef ENABLE_WALLET
     bool EnableMasterNode(std::ostringstream& strErrors, CServiceThreadGroup& threadGroup, CWallet* pwalletMain);
+    void LockMnOutpoints(CWallet* pWalletMain); // lock MN outpoints
 #else
     bool EnableMasterNode(std::ostringstream& strErrors, CServiceThreadGroup& threadGroup);
 #endif
+
     void StartMasterNode(CServiceThreadGroup& threadGroup);
     void StopMasterNode();
 

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -29,20 +29,20 @@ public:
 private:
     static const std::string SERIALIZATION_VERSION_STRING;
 
-    static const int DSEG_UPDATE_SECONDS        = 3 * 60 * 60;
+    static constexpr int DSEG_UPDATE_SECONDS        = 3 * 60 * 60;
 
-    static const int LAST_PAID_SCAN_BLOCKS      = 100;
+    static constexpr int LAST_PAID_SCAN_BLOCKS      = 100;
 
-    static const int MIN_POSE_PROTO_VERSION     = 70203;
-    static const int MAX_POSE_CONNECTIONS       = 10;
-    static const int MAX_POSE_RANK              = 10;
-    static const int MAX_POSE_BLOCKS            = 10;
+    static constexpr int MIN_POSE_PROTO_VERSION     = 70203;
+    static constexpr int MAX_POSE_CONNECTIONS       = 10;
+    static constexpr int MAX_POSE_RANK              = 10;
+    static constexpr int MAX_POSE_BLOCKS            = 10;
 
-    static const int MNB_RECOVERY_QUORUM_TOTAL      = 10;
-    static const int MNB_RECOVERY_QUORUM_REQUIRED   = 6;
-    static const int MNB_RECOVERY_MAX_ASK_ENTRIES   = 10;
-    static const int MNB_RECOVERY_WAIT_SECONDS      = 60;
-    static const int MNB_RECOVERY_RETRY_SECONDS     = 3 * 60 * 60;
+    static constexpr int MNB_RECOVERY_QUORUM_TOTAL      = 10;
+    static constexpr int MNB_RECOVERY_QUORUM_REQUIRED   = 6;
+    static constexpr int MNB_RECOVERY_MAX_ASK_ENTRIES   = 10;
+    static constexpr int MNB_RECOVERY_WAIT_SECONDS      = 60;
+    static constexpr int MNB_RECOVERY_RETRY_SECONDS     = 3 * 60 * 60;
 
 
     // critical section to protect the inner data structures
@@ -186,6 +186,7 @@ public:
 
     /// Return the number of (unique) Masternodes
     size_t size() const noexcept { return mapMasternodes.size(); }
+    bool empty() const noexcept { return mapMasternodes.empty(); }
 
     std::string ToString() const;
 
@@ -198,7 +199,7 @@ public:
     void UpdateLastPaid(const CBlockIndex* pindex);
 
     bool IsWatchdogActive();
-    void UpdateWatchdogVoteTime(const COutPoint& outpoint, uint64_t nVoteTime = 0);
+    void UpdateWatchdogVoteTime(const COutPoint& outpoint, const uint64_t nVoteTime = 0);
 
     void CheckMasternode(const CPubKey& pubKeyMasternode, bool fForce);
 

--- a/src/mnode/mnode-payments.cpp
+++ b/src/mnode/mnode-payments.cpp
@@ -40,12 +40,12 @@ void CMasternodePayments::FillMasterNodePayment(CMutableTransaction& txNew, int 
         masternode_info_t mnInfo;
         if(!masterNodeCtrl.masternodeManager.GetNextMasternodeInQueueForPayment(nBlockHeight, true, nCount, mnInfo)) {
             // ...and we can't calculate it on our own
-            LogPrintf("CMasternodePayments::FillMasterNodePayment -- Failed to detect masternode to pay\n");
+            LogFnPrintf("Failed to detect masternode to pay");
             return;
         }
         // fill scriptPubKey with locally calculated winner and hope for the best
         scriptPubKey = GetScriptForDestination(mnInfo.pubKeyCollateralAddress.GetID());
-        LogPrintf("CMasternodePayments::FillMasterNodePayment -- Locally calculated winner!!!\n");
+        LogFnPrintf("Locally calculated winner!!!");
     }
 
     CAmount masternodePayment = GetMasternodePayment(nBlockHeight, blockReward);
@@ -60,7 +60,7 @@ void CMasternodePayments::FillMasterNodePayment(CMutableTransaction& txNew, int 
     ExtractDestination(scriptPubKey, dest);
     string address = keyIO.EncodeDestination(dest);
 
-    LogPrintf("CMasternodePayments::FillMasterNodePayment -- Masternode payment %lld to %s\n", masternodePayment, address);
+    LogFnPrintf("Masternode payment %" PRId64 " to %s", masternodePayment, address);
 }
 
 string CMasternodePayments::GetRequiredPaymentsString(int nBlockHeight)
@@ -109,14 +109,14 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, string& strCommand, CData
 
         if(masterNodeCtrl.requestTracker.HasFulfilledRequest(pfrom->addr, NetMsgType::MASTERNODEPAYMENTSYNC)) {
             // Asking for the payments list multiple times in a short period of time is no good
-            LogPrintf("MASTERNODEPAYMENTSYNC -- peer already asked me for the list, peer=%d\n", pfrom->id);
+            LogFnPrintf("MASTERNODEPAYMENTSYNC -- peer already asked me for the list, peer=%d", pfrom->id);
             Misbehaving(pfrom->GetId(), 20);
             return;
         }
         masterNodeCtrl.requestTracker.AddFulfilledRequest(pfrom->addr, NetMsgType::MASTERNODEPAYMENTSYNC);
 
         Sync(pfrom);
-        LogPrintf("MASTERNODEPAYMENTSYNC -- Sent Masternode payment votes to peer %d\n", pfrom->id);
+        LogFnPrintf("MASTERNODEPAYMENTSYNC -- Sent Masternode payment votes to peer %d", pfrom->id);
 
     } else if (strCommand == NetMsgType::MASTERNODEPAYMENTVOTE) { // Masternode Payments Vote for the Winner
 
@@ -135,7 +135,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, string& strCommand, CData
         {
             LOCK(cs_mapMasternodePaymentVotes);
             if(mapMasternodePaymentVotes.count(nHash)) {
-                LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- hash=%s, nHeight=%d seen\n", nHash.ToString(), nCachedBlockHeight);
+                LogFnPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- hash=%s, nHeight=%d seen", nHash.ToString(), nCachedBlockHeight);
                 return;
             }
 
@@ -148,25 +148,25 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, string& strCommand, CData
 
         int nFirstBlock = nCachedBlockHeight - GetStorageLimit();
         if(vote.nBlockHeight < nFirstBlock || vote.nBlockHeight > nCachedBlockHeight+20) {
-            LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- vote out of range: nFirstBlock=%d, nBlockHeight=%d, nHeight=%d\n", nFirstBlock, vote.nBlockHeight, nCachedBlockHeight);
+            LogFnPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- vote out of range: nFirstBlock=%d, nBlockHeight=%d, nHeight=%d", nFirstBlock, vote.nBlockHeight, nCachedBlockHeight);
             return;
         }
 
         string strError;
         if(!vote.IsValid(pfrom, nCachedBlockHeight, strError)) {
-            LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- invalid message, error: %s\n", strError);
+            LogFnPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- invalid message, error: %s", strError);
             return;
         }
 
         if(!CanVote(vote.vinMasternode.prevout, vote.nBlockHeight)) {
-            LogPrintf("MASTERNODEPAYMENTVOTE -- masternode already voted, masternode=%s\n", vote.vinMasternode.prevout.ToStringShort());
+            LogFnPrintf("MASTERNODEPAYMENTVOTE -- masternode already voted, masternode=%s", vote.vinMasternode.prevout.ToStringShort());
             return;
         }
 
         masternode_info_t mnInfo;
         if(!masterNodeCtrl.masternodeManager.GetMasternodeInfo(vote.vinMasternode.prevout, mnInfo)) {
             // mn was not found, so we can't check vote, some info is probably missing
-            LogPrintf("MASTERNODEPAYMENTVOTE -- masternode is missing %s\n", vote.vinMasternode.prevout.ToStringShort());
+            LogFnPrintf("MASTERNODEPAYMENTVOTE -- masternode is missing %s", vote.vinMasternode.prevout.ToStringShort());
             masterNodeCtrl.masternodeManager.AskForMN(pfrom, vote.vinMasternode.prevout);
             return;
         }
@@ -174,11 +174,11 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, string& strCommand, CData
         int nDos = 0;
         if(!vote.CheckSignature(mnInfo.pubKeyMasternode, nCachedBlockHeight, nDos)) {
             if(nDos) {
-                LogPrintf("MASTERNODEPAYMENTVOTE -- ERROR: invalid signature\n");
+                LogFnPrintf("MASTERNODEPAYMENTVOTE -- ERROR: invalid signature");
                 Misbehaving(pfrom->GetId(), nDos);
             } else {
                 // only warn about anything non-critical (i.e. nDos == 0) in debug mode
-                LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- WARNING: invalid signature\n");
+                LogFnPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- WARNING: invalid signature");
             }
             // Either our info or vote info could be outdated.
             // In case our info is outdated, ask for an update,
@@ -193,7 +193,7 @@ void CMasternodePayments::ProcessMessage(CNode* pfrom, string& strCommand, CData
         ExtractDestination(vote.payee, dest);
         string address = keyIO.EncodeDestination(dest);
 
-        LogPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- vote: address=%s, nBlockHeight=%d, nHeight=%d, prevout=%s, hash=%s new\n",
+        LogFnPrint("mnpayments", "MASTERNODEPAYMENTVOTE -- vote: address=%s, nBlockHeight=%d, nHeight=%d, prevout=%s, hash=%s new",
                     address, vote.nBlockHeight, nCachedBlockHeight, vote.vinMasternode.prevout.ToStringShort(), nHash.ToString());
 
         if(AddPaymentVote(vote)){
@@ -211,12 +211,12 @@ bool CMasternodePaymentVote::Sign()
                 ScriptToAsmStr(payee);
 
     if(!CMessageSigner::SignMessage(strMessage, vchSig, masterNodeCtrl.activeMasternode.keyMasternode)) {
-        LogPrintf("CMasternodePaymentVote::Sign -- SignMessage() failed\n");
+        LogFnPrintf("SignMessage() failed");
         return false;
     }
 
     if(!CMessageSigner::VerifyMessage(masterNodeCtrl.activeMasternode.pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrintf("CMasternodePaymentVote::Sign -- VerifyMessage() failed, error: %s\n", strError);
+        LogFnPrintf("VerifyMessage() failed, error: %s", strError);
         return false;
     }
 
@@ -312,7 +312,7 @@ bool CMasternodeBlockPayees::GetBestPayee(CScript& payeeRet)
 
     if(vecPayees.empty())
     {
-        LogPrint("mnpayments", "CMasternodeBlockPayees::GetBestPayee -- ERROR: couldn't find any payee\n");
+        LogFnPrint("mnpayments", "ERROR: couldn't find any payee");
         return false;
     }
 
@@ -340,7 +340,7 @@ bool CMasternodeBlockPayees::HasPayeeWithVotes(const CScript& payeeIn, int nVote
         }
     }
 
-    LogPrint("mnpayments", "CMasternodeBlockPayees::HasPayeeWithVotes -- ERROR: couldn't find any payee with %d+ votes\n", nVotesReq);
+    LogFnPrint("mnpayments", "ERROR: couldn't find any payee with %d+ votes", nVotesReq);
     return false;
 }
 
@@ -381,13 +381,13 @@ bool CMasternodeBlockPayees::IsTransactionValid(const CTransaction& txNew) const
     // if we don't have at least MNPAYMENTS_SIGNATURES_REQUIRED signatures on a payee, approve whichever is the longest chain
     if (vOrderedPayee.empty())
     {
-        LogPrintf("CMasternodeBlockPayees::IsTransactionValid -- no scheduled MN payments, block - %d\n", nCurrentHeight);
+        LogFnPrintf("no scheduled MN payments, block - %d", nCurrentHeight);
         return true;
     }
     const auto nMaxVotes = vOrderedPayee.front().get().GetVoteCount();
     if (!bEnableFewVoteCheck && vOrderedPayee.front().get().GetVoteCount() < MNPAYMENTS_SIGNATURES_REQUIRED)
     {
-        LogPrintf("CMasternodeBlockPayees::IsTransactionValid -- extra vote check is not enabled AND we only have %zu signatures in the maximum vote, approve it anyway, block - %d\n", 
+        LogFnPrintf("extra vote check is not enabled AND we only have %zu signatures in the maximum vote, approve it anyway, block - %d", 
             nMaxVotes, nCurrentHeight);
         return true;
     }
@@ -409,7 +409,7 @@ bool CMasternodeBlockPayees::IsTransactionValid(const CTransaction& txNew) const
         {
             if (payee.GetPayee() == txout.scriptPubKey && nMasternodePayment == txout.nValue)
             {
-                LogPrint("mnpayments", "CMasternodeBlockPayees::IsTransactionValid -- Found required payment\n");
+                LogFnPrint("mnpayments", "Found required payment");
                 bFound = true;
                 break;
             }
@@ -427,7 +427,7 @@ bool CMasternodeBlockPayees::IsTransactionValid(const CTransaction& txNew) const
         bFound = true;
     if (!bFound)
     {
-        LogPrintf("CMasternodeBlockPayees::IsTransactionValid -- ERROR: Missing required payment, possible payees: '%s', amount: %" PRId64 " PSL\n",
+        LogFnPrintf("ERROR: Missing required payment, possible payees: '%s', amount: %" PRId64 " PSL",
             strPayeesPossible, nMasternodePayment);
         for (const auto& txout : txNew.vout)
         {
@@ -469,7 +469,7 @@ bool CMasternodePayments::IsTransactionValid(const CTransaction& txNew, int nBlo
     if(mapMasternodeBlockPayees.count(nBlockHeight))
         return mapMasternodeBlockPayees[nBlockHeight].IsTransactionValid(txNew);
     
-    LogPrint("mnpayments", "CMasternodePayments::IsTransactionValid -- no winner MN for block - %d\n", nBlockHeight);
+    LogFnPrint("mnpayments", "no winner MN for block - %d", nBlockHeight);
     return true;
 }
 
@@ -489,13 +489,13 @@ void CMasternodePayments::CheckAndRemove()
 
         if (nCachedBlockHeight - vote.nBlockHeight > nLimit)
         {
-            LogPrint("mnpayments", "CMasternodePayments::CheckAndRemove -- Removing old Masternode payment: nBlockHeight=%d\n", vote.nBlockHeight);
+            LogFnPrint("mnpayments", "Removing old Masternode payment: nBlockHeight=%d", vote.nBlockHeight);
             mapMasternodePaymentVotes.erase(it++);
             mapMasternodeBlockPayees.erase(vote.nBlockHeight);
         } else
             ++it;
     }
-    LogPrintf("CMasternodePayments::CheckAndRemove -- %s\n", ToString());
+    LogFnPrintf("%s", ToString());
 }
 
 bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, string& strError)
@@ -528,8 +528,7 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, string
     int nRank = -1;
 
     if(!masterNodeCtrl.masternodeManager.GetMasternodeRank(vinMasternode.prevout, nRank, nBlockHeight + masterNodeCtrl.nMasternodePaymentsVotersIndexDelta, nMinRequiredProtocol)) {
-        LogPrint("mnpayments", "CMasternodePaymentVote::IsValid -- Can't calculate rank for masternode %s\n",
-                    vinMasternode.prevout.ToStringShort());
+        LogFnPrint("mnpayments", "Can't calculate rank for masternode %s", vinMasternode.prevout.ToStringShort());
         return false;
     }
 
@@ -542,7 +541,7 @@ bool CMasternodePaymentVote::IsValid(CNode* pnode, int nValidationHeight, string
         if(nRank > MNPAYMENTS_SIGNATURES_TOTAL*2 && nBlockHeight > nValidationHeight)
         {
             strError = strprintf("Masternode is not in the top %d (%d)", MNPAYMENTS_SIGNATURES_TOTAL*2, nRank);
-            LogPrintf("CMasternodePaymentVote::IsValid -- Error: %s\n", strError);
+            LogFnPrintf("Error: %s", strError);
             Misbehaving(pnode->GetId(), 20);
         }
         // Still invalid however
@@ -569,20 +568,20 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
     if (!masterNodeCtrl.masternodeManager.GetMasternodeRank(masterNodeCtrl.activeMasternode.outpoint, nRank, nBlockHeight + masterNodeCtrl.nMasternodePaymentsVotersIndexDelta))
     {
-        LogPrint("mnpayments", "CMasternodePayments::ProcessBlock -- Unknown Masternode\n");
+        LogFnPrint("mnpayments", "Unknown Masternode");
         return false;
     }
 
     if (nRank > MNPAYMENTS_SIGNATURES_TOTAL)
     {
-        LogPrint("mnpayments", "CMasternodePayments::ProcessBlock -- Masternode not in the top %d (%d)\n", MNPAYMENTS_SIGNATURES_TOTAL, nRank);
+        LogFnPrint("mnpayments", "Masternode not in the top %zu (%d)", MNPAYMENTS_SIGNATURES_TOTAL, nRank);
         return false;
     }
 
 
     // LOCATE THE NEXT MASTERNODE WHICH SHOULD BE PAID
 
-    LogPrintf("CMasternodePayments::ProcessBlock -- Start: nBlockHeight=%d, masternode=%s\n", nBlockHeight, masterNodeCtrl.activeMasternode.outpoint.ToStringShort());
+    LogFnPrintf("Start: nBlockHeight=%d, masternode=%s", nBlockHeight, masterNodeCtrl.activeMasternode.outpoint.ToStringShort());
 
     // pay to the oldest MN that still had no payment but its input is old enough and it was active long enough
     uint32_t nCount = 0;
@@ -590,11 +589,11 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
     if (!masterNodeCtrl.masternodeManager.GetNextMasternodeInQueueForPayment(nBlockHeight, true, nCount, mnInfo))
     {
-        LogPrintf("CMasternodePayments::ProcessBlock -- ERROR: Failed to find masternode to pay\n");
+        LogFnPrintf("ERROR: Failed to find masternode to pay");
         return false;
     }
 
-    LogPrintf("CMasternodePayments::ProcessBlock -- Masternode found by GetNextMasternodeInQueueForPayment(): %s\n", mnInfo.vin.prevout.ToStringShort());
+    LogFnPrintf("Masternode found by GetNextMasternodeInQueueForPayment(): %s", mnInfo.vin.prevout.ToStringShort());
 
 
     CScript payee = GetScriptForDestination(mnInfo.pubKeyCollateralAddress.GetID());
@@ -606,14 +605,13 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     ExtractDestination(payee, dest);
     string address = keyIO.EncodeDestination(dest);
 
-    LogPrintf("CMasternodePayments::ProcessBlock -- vote: payee=%s, nBlockHeight=%d\n", address, nBlockHeight);
+    LogFnPrintf("vote: payee=%s, nBlockHeight=%d", address, nBlockHeight);
 
     // SIGN MESSAGE TO NETWORK WITH OUR MASTERNODE KEYS
-
-    LogPrintf("CMasternodePayments::ProcessBlock -- Signing vote\n");
+    LogFnPrintf("Signing vote");
     if (voteNew.Sign())
     {
-        LogPrintf("CMasternodePayments::ProcessBlock -- AddPaymentVote()\n");
+        LogFnPrintf("AddPaymentVote()");
 
         if (AddPaymentVote(voteNew))
         {
@@ -630,12 +628,12 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
     if (!masterNodeCtrl.masternodeSync.IsWinnersListSynced())
         return;
 
-    string debugStr = strprintf("CMasternodePayments::CheckPreviousBlockVotes -- nPrevBlockHeight=%d, expected voting MNs:\n", nPrevBlockHeight);
+    string debugStr = strprintf("CMasternodePayments::CheckPreviousBlockVotes -- nPrevBlockHeight=%d, expected voting MNs: ", nPrevBlockHeight);
 
     CMasternodeMan::rank_pair_vec_t mns;
     if (!masterNodeCtrl.masternodeManager.GetMasternodeRanks(mns, nPrevBlockHeight + masterNodeCtrl.nMasternodePaymentsVotersIndexDelta)) {
-        debugStr += "CMasternodePayments::CheckPreviousBlockVotes -- GetMasternodeRanks failed\n";
-        LogPrint("mnpayments", "%s", debugStr);
+        debugStr += "GetMasternodeRanks failed\n";
+        LogFnPrint("mnpayments", "%s", debugStr);
         return;
     }
 
@@ -655,8 +653,7 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
                 {
                     if (!mapMasternodePaymentVotes.count(voteHash))
                     {
-                        debugStr += strprintf("CMasternodePayments::CheckPreviousBlockVotes --   could not find vote %s\n",
-                                              voteHash.ToString());
+                        debugStr += strprintf("could not find vote %s; ", voteHash.ToString());
                         continue;
                     }
                     auto vote = mapMasternodePaymentVotes[voteHash];
@@ -672,8 +669,7 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
 
         if (!found)
         {
-            debugStr += strprintf("CMasternodePayments::CheckPreviousBlockVotes --   %s - no vote received\n",
-                                  mn.second.vin.prevout.ToStringShort());
+            debugStr += strprintf("%s - no vote received; ", mn.second.vin.prevout.ToStringShort());
             mapMasternodesDidNotVote[mn.second.vin.prevout]++;
             continue;
         }
@@ -683,12 +679,11 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
         ExtractDestination(payee, dest);
         string address = keyIO.EncodeDestination(dest);
 
-        debugStr += strprintf("CMasternodePayments::CheckPreviousBlockVotes --   %s - voted for %s\n",
-                              mn.second.vin.prevout.ToStringShort(), address);
+        debugStr += strprintf("%s - voted for %s; ", mn.second.vin.prevout.ToStringShort(), address);
     }
-    debugStr += "CMasternodePayments::CheckPreviousBlockVotes -- Masternodes which missed a vote in the past:\n";
-    for (auto it : mapMasternodesDidNotVote)
-        debugStr += strprintf("CMasternodePayments::CheckPreviousBlockVotes --   %s: %d\n", it.first.ToStringShort(), it.second);
+    debugStr += "Masternodes which missed a vote in the past:\n";
+    for (const auto &[outpoint, count] : mapMasternodesDidNotVote)
+        debugStr += strprintf("   %s: %d\n", outpoint.ToStringShort(), count);
 
     LogPrint("mnpayments", "%s", debugStr);
 }
@@ -698,7 +693,7 @@ void CMasternodePaymentVote::Relay()
     // Do not relay until fully synced
     if(!masterNodeCtrl.masternodeSync.IsSynced())
     {
-        LogPrint("mnpayments", "CMasternodePayments::Relay -- won't relay until fully synced\n");
+        LogFnPrint("mnpayments", "won't relay until fully synced");
         return;
     }
 
@@ -768,7 +763,7 @@ void CMasternodePayments::Sync(CNode* pnode)
         }
     }
 
-    LogPrintf("CMasternodePayments::Sync -- Sent %d votes to peer %d\n", nInvCount, pnode->id);
+    LogFnPrintf("Sent %d votes to peer %d", nInvCount, pnode->id);
     pnode->PushMessage(NetMsgType::SYNCSTATUSCOUNT, (int)CMasternodeSync::MasternodeSyncState::List, nInvCount);
 }
 
@@ -791,7 +786,7 @@ void CMasternodePayments::RequestLowDataPaymentBlocks(CNode* pnode)
             // We should not violate GETDATA rules
             if(vToFetch.size() == MAX_INV_SZ)
             {
-                LogPrintf("CMasternodePayments::SyncLowDataPaymentBlocks -- asking peer %d for %zu blocks\n", pnode->id, MAX_INV_SZ);
+                LogFnPrintf("asking peer %d for %zu blocks", pnode->id, MAX_INV_SZ);
                 pnode->PushMessage("getdata", vToFetch);
                 // Start filling new batch
                 vToFetch.clear();
@@ -844,7 +839,7 @@ void CMasternodePayments::RequestLowDataPaymentBlocks(CNode* pnode)
         // We should not violate GETDATA rules
         if (vToFetch.size() == MAX_INV_SZ)
         {
-            LogPrintf("CMasternodePayments::SyncLowDataPaymentBlocks -- asking peer %d for %zu payment blocks\n", pnode->id, MAX_INV_SZ);
+            LogFnPrintf("asking peer %d for %zu payment blocks", pnode->id, MAX_INV_SZ);
             pnode->PushMessage("getdata", vToFetch);
             // Start filling new batch
             vToFetch.clear();
@@ -854,7 +849,7 @@ void CMasternodePayments::RequestLowDataPaymentBlocks(CNode* pnode)
     // Ask for the rest of it
     if(!vToFetch.empty())
     {
-        LogPrintf("CMasternodePayments::SyncLowDataPaymentBlocks -- asking peer %d for %zu payment blocks\n", pnode->id, vToFetch.size());
+        LogFnPrintf("asking peer %d for %zu payment blocks", pnode->id, vToFetch.size());
         pnode->PushMessage("getdata", vToFetch);
     }
 }
@@ -887,7 +882,7 @@ void CMasternodePayments::UpdatedBlockTip(const CBlockIndex *pindex)
         return;
 
     nCachedBlockHeight = pindex->nHeight;
-    LogPrint("mnpayments", "CMasternodePayments::UpdatedBlockTip -- nCachedBlockHeight=%d\n", nCachedBlockHeight);
+    LogFnPrint("mnpayments", "nCachedBlockHeight=%d", nCachedBlockHeight);
 
     int nFutureBlock = nCachedBlockHeight + masterNodeCtrl.nMasternodePaymentsFeatureWinnerBlockIndexDelta;
 

--- a/src/mnode/mnode-validation.h
+++ b/src/mnode/mnode-validation.h
@@ -18,8 +18,8 @@ int GetUTXOConfirmations(const COutPoint& outpoint);
 void FillOtherBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, CTxOut& txoutMasternodeRet, CTxOut& txoutGovernanceRet);
 
 #ifdef ENABLE_WALLET
-    bool GetMasternodeOutpointAndKeys(CWallet* pwalletMain, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash, std::string strOutputIndex);
-    bool GetOutpointAndKeysFromOutput(CWallet* pwalletMain, const COutput& out, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet);
+    bool GetMasternodeOutpointAndKeys(CWallet* pwalletMain, std::string &error, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash, std::string strOutputIndex);
+    bool GetOutpointAndKeysFromOutput(CWallet* pwalletMain, std::string &error, const COutput& out, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet);
 #endif
 
 bool IsBlockValid(const Consensus::Params& consensusParams, 

--- a/src/mnode/rpc/tickets-find.cpp
+++ b/src/mnode/rpc/tickets-find.cpp
@@ -92,7 +92,8 @@ As json rpc
     switch (FIND.cmd()) {
     case RPC_CMD_FIND::id: {
         CPastelIDRegTicket ticket;
-        if (CPastelIDRegTicket::FindTicketInDb(key, ticket)) {
+        if (CPastelIDRegTicket::FindTicketInDb(key, ticket))
+        {
             UniValue obj(UniValue::VOBJ);
             obj.read(ticket.ToJSON());
             return obj;

--- a/src/mnode/rpc/tickets-register.cpp
+++ b/src/mnode/rpc/tickets-register.cpp
@@ -44,7 +44,7 @@ As json rpc:
 )" + HelpExampleRpc("tickets", R"("register", "mnid", "jXaShWhNtatHVPWRNPsvjoVHUYes2kA7T9EJVL9i9EKPdBNo5aTYp19niWemJb2EwgYYR68jymULPtmHdETf8M", "passphrase")")
 );
 
-    if (!masterNodeCtrl.IsActiveMasterNode())
+    if (!masterNodeCtrl.CanRegisterMnId())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "This is not an active masternode. Only active MN can register its Pastel ID");
 
     string pastelID = params[2].get_str();

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -135,7 +135,7 @@ void CPastelTicketProcessor::UpdatedBlockTip(const CBlockIndex* cBlockIndex, boo
     CBlock block;
     if (!ReadBlockFromDisk(block, cBlockIndex, Params().GetConsensus()))
     {
-        LogPrintf("CPastelTicket::UpdatedBlockTip -- ERROR: Can't read block from disk\n");
+        LogFnPrintf("ERROR: Can't read block from disk");
         return;
     }
 
@@ -184,7 +184,7 @@ bool CPastelTicketProcessor::UpdateDB(CPastelTicket &ticket, string& txid, const
     if (ticket.HasMVKeyThree())
         UpdateDB_MVK(ticket, ticket.MVKeyThree());
         
-    //LogPrintf("tickets", "CPastelTicketProcessor::UpdateDB -- Ticket added into DB with key %s (txid - %s)\n", ticket.KeyOne(), ticket.ticketTnx);
+    //LogFnPrintf("tickets", "Ticket added into DB with key %s (txid - %s)", ticket.KeyOne(), ticket.ticketTnx);
     return true;
 }
 
@@ -654,7 +654,7 @@ unique_ptr<CPastelTicket> CPastelTicketProcessor::GetTicket(const uint256 &txid)
     }
 
     if (!ticket)
-        LogPrintf("CPastelTicketProcessor::GetTicket -- Invalid ticket ['%s', txid=%s]. ERROR: %s\n", 
+        LogFnPrintf("Invalid ticket ['%s', txid=%s]. ERROR: %s", 
             GetTicketDescription(ticket_id), tx.GetHash().GetHex(), error_ret);
 
     return ticket;

--- a/src/mnode/tickets/pastelid-reg.cpp
+++ b/src/mnode/tickets/pastelid-reg.cpp
@@ -187,7 +187,7 @@ ticket_validation_t CPastelIDRegTicket::IsValid(const bool bPreReg, const uint32
                             outpoint.ToStringShort(), pastelID);
                         break;
                     }
-                    if (!mnInfo.IsEnabled())
+                    if (!mnInfo.IsEnabled() && !mnInfo.IsPreEnabled())
                     {
                         tv.errorMsg = strprintf(
                             "Not an active Masternode - [%s]. Pastel ID - [%s]", 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2435,7 +2435,7 @@ As a json rpc call
 
         o.pushKV("txid", outpt.hash.GetHex());
         o.pushKV("vout", (int)outpt.n);
-        ret.push_back(o);
+        ret.push_back(move(o));
     }
 
     return ret;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3645,36 +3645,36 @@ void CWallet::UpdatedTransaction(const uint256 &hashTx)
     }
 }
 
-void CWallet::LockCoin(COutPoint& output)
+void CWallet::LockCoin(const COutPoint& output)
 {
-    AssertLockHeld(cs_wallet); // setLockedCoins
-    setLockedCoins.insert(output);
+    AssertLockHeld(cs_wallet); // m_setLockedCoins
+    m_setLockedCoins.emplace(output);
 }
 
-void CWallet::UnlockCoin(COutPoint& output)
+void CWallet::UnlockCoin(const COutPoint& output)
 {
-    AssertLockHeld(cs_wallet); // setLockedCoins
-    setLockedCoins.erase(output);
+    AssertLockHeld(cs_wallet); // m_setLockedCoins
+    m_setLockedCoins.erase(output);
 }
 
 void CWallet::UnlockAllCoins()
 {
-    AssertLockHeld(cs_wallet); // setLockedCoins
-    setLockedCoins.clear();
+    AssertLockHeld(cs_wallet); // m_setLockedCoins
+    m_setLockedCoins.clear();
 }
 
 bool CWallet::IsLockedCoin(uint256 hash, unsigned int n) const
 {
-    AssertLockHeld(cs_wallet); // setLockedCoins
+    AssertLockHeld(cs_wallet); // m_setLockedCoins
     COutPoint outpt(hash, n);
 
-    return (setLockedCoins.count(outpt) > 0);
+    return (m_setLockedCoins.count(outpt) > 0);
 }
 
 void CWallet::ListLockedCoins(v_outpoints& vOutPoints)
 {
-    AssertLockHeld(cs_wallet); // setLockedCoins
-    for (const auto &outpoint : vOutPoints)
+    AssertLockHeld(cs_wallet); // m_setLockedCoins
+    for (const auto &outpoint : m_setLockedCoins)
         vOutPoints.emplace_back(outpoint);
 }
 
@@ -3683,31 +3683,31 @@ void CWallet::ListLockedCoins(v_outpoints& vOutPoints)
 void CWallet::LockNote(const SaplingOutPoint& output)
 {
     AssertLockHeld(cs_wallet);
-    setLockedSaplingNotes.insert(output);
+    m_setLockedSaplingNotes.emplace(output);
 }
 
 void CWallet::UnlockNote(const SaplingOutPoint& output)
 {
     AssertLockHeld(cs_wallet);
-    setLockedSaplingNotes.erase(output);
+    m_setLockedSaplingNotes.erase(output);
 }
 
 void CWallet::UnlockAllSaplingNotes()
 {
     AssertLockHeld(cs_wallet);
-    setLockedSaplingNotes.clear();
+    m_setLockedSaplingNotes.clear();
 }
 
 bool CWallet::IsLockedNote(const SaplingOutPoint& output) const
 {
     AssertLockHeld(cs_wallet);
-    return (setLockedSaplingNotes.count(output) > 0);
+    return (m_setLockedSaplingNotes.count(output) > 0);
 }
 
 vector<SaplingOutPoint> CWallet::ListLockedSaplingNotes()
 {
     AssertLockHeld(cs_wallet);
-    vector<SaplingOutPoint> vOutputs(setLockedSaplingNotes.begin(), setLockedSaplingNotes.end());
+    vector<SaplingOutPoint> vOutputs(m_setLockedSaplingNotes.cbegin(), m_setLockedSaplingNotes.cend());
     return vOutputs;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -852,8 +852,8 @@ public:
 
     CPubKey vchDefaultKey;
 
-    std::set<COutPoint> setLockedCoins;
-    std::set<SaplingOutPoint> setLockedSaplingNotes;
+    std::set<COutPoint> m_setLockedCoins;
+    std::set<SaplingOutPoint> m_setLockedSaplingNotes;
 
     int64_t nTimeFirstKey;
 
@@ -884,8 +884,8 @@ public:
     bool IsSaplingSpent(const uint256& nullifier) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const;
-    void LockCoin(COutPoint& output);
-    void UnlockCoin(COutPoint& output);
+    void LockCoin(const COutPoint& output);
+    void UnlockCoin(const COutPoint& output);
     void UnlockAllCoins();
     void ListLockedCoins(v_outpoints& vOutPoints);
 


### PR DESCRIPTION
Added requirement for MN to have registered mind in ENABLED state:
 - introduced new state for active MN: ActiveMasternodeState::NeedMnId. State is not serialized/deserialized, so it is just local code change. When node is started with -masternode option: CActiveMasternode is initialized, but MN is in ActiveMasternodeState::NotCapable state until outpoint is defined. Hot/Cold mode works fine with that new check for registered mnid. After MN config is created on cold node and start-alias is issued for the new mn - hot node receives masternode broadcast with the new mn info (including outpoint). At that moment hot node searches for the registered MNID by outpoint (in ID DB by secondary key). If it finds it - node sets state to ActiveMasternodeState::Started and enables pinger. If not - it sets state ActiveMasternodeState::NeedMnId. Also the check for the registered MNID is added in CMasterNode class, where MN manager validates all MNs and sets their states. Search is the same - by outpoint in Pastel ID DB by secondary key. Added also check in CMasterNode class for the local MN - Pastel ID should exist locally (stored in a secure container). If MN does not have registered mnid - it stays in PRE_ENABLED state. "tickets register mnid" condition relaxed to work also in ActiveMasternodeState::NeedMnId state. mnid ticket IsValid() also passes when MN is in PRE_ENABLED state (in addition to ENABLED state). Need to check: old nodes will set ENABLED status for MNs without registered MNID, this may cause inconsistent top MNs list across MNs and affect MN payments logic.

Some other code improvements:
 - changed storage for MNs from vector to unordered_map with MN alias (lowercased) as a key. This allows fast search for the specific MN config by alias.
 - read new MN configs from masternode.conf on "masternode start-alias|start-all" to avoid node restart after adding new MN config. We can simply add new MN config on cold node and use "start-alias" to start it (no need to restart the node).
 - Added mutex to protect access to mn configs storage.
 - Log improvements:
   - added new macro __METHOD_NAME__ that returns ClassName::function_name, specific implementations for gcc/clang and msvc.
   - added LogFnPrintf/LogFnPrint to log automatically function name
   - changed many logs in mnode classes which used classname::function_name in a log message. Simplifies/unifies logging a lot + avoids copy&paste errors when logs are copied from one function to another.
 - fixed locking collateral outpoint on mn start, added same locking call when called start-alias or start-all

Fixed all python tests to work with the new MN network startup:
 - added new class MasterNode to represent masternode
 - rewritten setup_masternodes_network to work with new MNID registration logic