### PR TITLE
[PSL-433] Write API on pasteld to handle score update

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -113,6 +113,7 @@ declare -a testScriptsMN=(
     'mn_messaging.py'
     'mn_payment.py'
     'mn_bugs.py'
+    'mn_expiration.py'
 )
 
 declare -a testScriptsMNslow=(

--- a/qa/rpc-tests/mn_bugs.py
+++ b/qa/rpc-tests/mn_bugs.py
@@ -22,25 +22,30 @@ getcontext().prec = 16
 TEST_CASE_EXEC_NR = 40300409; # ExtP2P address-change tests
 
 class MasterNodeGovernanceTest (MasterNodeCommon):
-    number_of_master_nodes = 12
-    number_of_simple_nodes = 2
-    total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
-    mining_node_num = number_of_master_nodes
-    hot_node_num = number_of_master_nodes+1
-    Test_func_dictionary = {
-        40104615: "test_40104615",
-        40104682: "test_40104682"
-    } 
+    
+    def __init__(self):
+        super().__init__()
+        
+        self.number_of_master_nodes = 12
+        self.number_of_simple_nodes = 2
+        self.number_of_cold_nodes = self.number_of_master_nodes 
+        self.mining_node_num = self.number_of_master_nodes
+        self.hot_node_num = self.number_of_master_nodes + 1
+        self.Test_func_dictionary = {
+            40104615: "test_40104615",
+            40104682: "test_40104682"
+        } 
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, self.total_number_of_nodes)
 
+
     def setup_network(self, split=False):
         self.nodes = []
         self.is_network_split = False
-        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
-            self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
+        self.setup_masternodes_network(self.mining_node_num, self.hot_node_num)
+
 
     def run_test (self):
         print("Run freedcamp ID specific test")

--- a/qa/rpc-tests/mn_common.py
+++ b/qa/rpc-tests/mn_common.py
@@ -7,17 +7,23 @@ import time
 import itertools
 import json
 import random
+import string
 from decimal import getcontext
 
-from pastel_test_framework import PastelTestFramework
 from test_framework.util import (
     assert_true,
     assert_equal,
     start_node,
     connect_nodes_bi,
     p2p_port,
+    str_to_b64str,
     Timer
 )
+from pastel_test_framework import (
+    PastelTestFramework,
+    TicketType
+)
+
 getcontext().prec = 16
 
 class TicketData:
@@ -156,17 +162,67 @@ class MasterNodeCommon (PastelTestFramework):
     def __init__(self):
         super().__init__()
 
+        # this will be redefined in a child class
+        self.number_of_master_nodes = 1
+        self.number_of_cold_nodes = self.number_of_master_nodes
+        self.number_of_simple_nodes = 2
+
         # list of master nodes (MasterNode)
         self.mn_nodes = []
         self.collateral = int(1000)
         # flag to use new "masternode init" API
         self.use_masternode_init = False
+        
+        # dict for fast search of the MN by outpoint (txid-index)
+        self.mn_outpoints = {}
+        
+        # list of 3 TopMNs
+        self.top_mns = [TopMN(i) for i in range(3)]
+        
+        self.signatures_dict = None
+        self.same_mns_signatures_dict = None
+        self.not_top_mns_signatures_dict = None
+        # dict of all principal signatures for validation: 'principal Pastel ID' -> 'signature'
+        self.principal_signatures_dict = {}
+        
+        self.royalty = 0.075                        # default royalty fee 7.5%
+        self.is_green = True                        # is green fee payment?
+        self.green_address = "tPj5BfCrLfLpuviSJrD3B1yyWp3XkgtFjb6"
+
+        # storage for all ticket types used in tests
+        self.tickets = {}
+        for _, member in TicketType.__members__.items():
+            self.tickets[member] = TicketData()
+            self.tickets[member].ticket_price = member.ticket_price
+            print(f"{member.description} ticket price: {member.ticket_price}")
 
 
-    def setup_masternodes_network(self, mn_count:int = 1, non_mn_count: int = 2,
-                                  mining_node_num:int = 1, hot_node_num:int = 2,
-                                  cold_node_count: int = None,
-                                  debug_flags: str = ""):
+    @property
+    def total_number_of_nodes(self) -> int:
+        """ Returns total number of nodes: masternodes + simple nodes
+
+        Returns:
+            int: total number of nodes
+        """
+        return self.number_of_master_nodes + self.number_of_simple_nodes
+    
+
+    def get_mnid(self, mn_no: int) -> str:
+        """ Get mnid (Pastel ID of the MasterNode).
+
+        Args:
+            mn_no (int): mn index in self.mn_nodes
+
+        Returns:
+            str: mnid if mn found by index, None - otherwise
+        """
+        if mn_no >= len(self.mn_nodes):
+            return None
+        mn = self.mn_nodes[mn_no]
+        return mn.mnid
+
+
+    def setup_masternodes_network(self, mining_node_num:int = 1, hot_node_num:int = 2, debug_flags: str = ""):
         """ Setup MasterNode network using hot/cold method.
             Hot node keeps all collaterals for all MNs (cold nodes).
             Network initialization steps:
@@ -193,12 +249,10 @@ class MasterNodeCommon (PastelTestFramework):
         timer = Timer()
         timer.start()
         
-        if cold_node_count is None:
-            cold_node_count = mn_count
         # create list of mns
         # start only non-mn nodes
-        for index in range(mn_count + non_mn_count):
-            if index < mn_count:
+        for index in range(self.total_number_of_nodes):
+            if index < self.number_of_master_nodes:
                 mn = self.MasterNode(index, self.passphrase)
                 self.mn_nodes.append(mn)
                 self.nodes.append(None) # add dummy node for now
@@ -207,17 +261,17 @@ class MasterNodeCommon (PastelTestFramework):
                 self.nodes.append(start_node(index, self.options.tmpdir, [f"-debug={debug_flags}"]))
 
         # connect non-mn nodes
-        for pair in itertools.combinations(range(mn_count, mn_count + non_mn_count), 2):
+        for pair in itertools.combinations(range(self.number_of_master_nodes, self.total_number_of_nodes), 2):
             connect_nodes_bi(self.nodes, pair[0], pair[1])
 
         # mining enough coins for collateral for mn_count nodes
-        self.mining_enough(mining_node_num, mn_count)
+        self.mining_enough(mining_node_num, self.number_of_master_nodes)
 
         # hot node will keep all collateral amounts in its wallet to activate all master nodes
         for mn in self.mn_nodes:
             # create collateral address for each MN
             # number of nodes to activate is defined by cold_node_count
-            if mn.index >= cold_node_count:
+            if mn.index >= self.number_of_cold_nodes:
                 continue
             mn.collateral_address = self.nodes[hot_node_num].getnewaddress()
             # send coins to the collateral addresses on hot node
@@ -225,14 +279,14 @@ class MasterNodeCommon (PastelTestFramework):
             mn.collateral_txid = self.nodes[mining_node_num].sendtoaddress(mn.collateral_address, self.collateral, "", "", False)
 
         self.generate_and_sync_inc(1, mining_node_num)
-        assert_equal(self.nodes[hot_node_num].getbalance(), self.collateral * cold_node_count)
+        assert_equal(self.nodes[hot_node_num].getbalance(), self.collateral * self.number_of_cold_nodes)
 
         # prepare parameters and create masternode.conf for all masternodes
         outputs = self.nodes[hot_node_num].masternode("outputs")
         print(f"hot node{hot_node_num} collateral outputs\n{outputs}")
         for mn in self.mn_nodes:
             # get the collateral outpoint indexes
-            if mn.index < cold_node_count:
+            if mn.index < self.number_of_cold_nodes:
                 mn.collateral_index = int(outputs[mn.collateral_txid])
             if self.use_masternode_init:
                 # generate info for masternodes (masternode init)
@@ -254,7 +308,7 @@ class MasterNodeCommon (PastelTestFramework):
             self.nodes[mn.index] = start_node(mn.index, self.options.tmpdir, [f"-debug={debug_flags}", "-masternode", "-txindex=1", "-reindex", f"-masternodeprivkey={mn.privKey}"])
 
         # connect nodes (non-mn nodes already interconnected)
-        for pair in itertools.combinations(range(mn_count + non_mn_count), 2):
+        for pair in itertools.combinations(range(self.total_number_of_nodes), 2):
             connect_nodes_bi(self.nodes, pair[0], pair[1])
 
         self.sync_all()
@@ -270,7 +324,7 @@ class MasterNodeCommon (PastelTestFramework):
             # create & register mnid
             for mn in self.mn_nodes:
                 mn.mnid, mn.lrKey = self.create_pastelid(mn.index)
-                if mn.index >= cold_node_count:
+                if mn.index >= self.number_of_cold_nodes:
                     continue
                 # get new address and send some coins for mnid registration
                 mn.mnid_reg_address = self.nodes[mn.index].getnewaddress()
@@ -279,7 +333,7 @@ class MasterNodeCommon (PastelTestFramework):
             self.generate_and_sync_inc(1, mining_node_num)
 
             for mn in self.mn_nodes:
-                if mn.index >= cold_node_count:
+                if mn.index >= self.number_of_cold_nodes:
                     continue
                 print(f"Enabling master node: {mn.alias}...")
                 res = self.nodes[hot_node_num].masternode("start-alias", mn.alias)
@@ -290,14 +344,14 @@ class MasterNodeCommon (PastelTestFramework):
             print("Waiting for PRE_ENABLED status...")
             initial_wait = 10
             for mn in self.mn_nodes:
-                if mn.index >= cold_node_count:
+                if mn.index >= self.number_of_cold_nodes:
                     continue
                 self.wait_for_mn_state(initial_wait, 10, "PRE_ENABLED", mn.index, 3)
                 initial_wait = 0
                 
             # register mnids
             for mn in self.mn_nodes:
-                if mn.index >= cold_node_count:
+                if mn.index >= self.number_of_cold_nodes:
                     continue
                 result = self.nodes[mn.index].tickets("register", "mnid", mn.mnid,
                     self.passphrase, mn.mnid_reg_address)
@@ -313,16 +367,30 @@ class MasterNodeCommon (PastelTestFramework):
             print("Waiting for ENABLED status...")
             initial_wait = 15
             for mn in self.mn_nodes:
-                if mn.index >= cold_node_count:
+                if mn.index >= self.number_of_cold_nodes:
                     continue
                 self.wait_for_mn_state(initial_wait, 10, "ENABLED", mn.index, 10)
                 initial_wait = 0
+
+
+        # create dict for fast search of the MN by outpoint (txid-index)
+        for mn in self.mn_nodes:
+            self.mn_outpoints[mn.collateral_id] = mn.index
 
         self.reconnect_all_nodes()
         self.sync_all()
         timer.stop()
         print(f"<<<< MasterNode network INITIALIZED in {timer.elapsed_time} secs >>>>")
+        self.list_masternode_info()      
 
+
+    def list_masternode_info(self):
+        """List info for all masternodes.
+        """
+        print(f'MasterNodes [{len(self.mn_nodes)}], (outpoint, mnid, address)):')
+        for mn in self.mn_nodes:
+            print(f"  {mn.index}) {mn.collateral_id}, {mn.mnid_reg_address}, {mn.mnid}")
+        
 
     def mining_enough(self, mining_node_num, nodes_to_start):
         min_blocks_to_mine = nodes_to_start*self.collateral/self._reward
@@ -395,3 +463,263 @@ class MasterNodeCommon (PastelTestFramework):
         if debug:
             [print(node.masternode("list")) for node in node_list]
         [assert_equal(node.masternode("list").get(collateral_id, ""), wait_for_state) for node in node_list]
+
+
+    def update_mn_indexes(self, node_num = 0, height = -1):
+        """Get historical information about top MNs at given height.
+
+        Args:
+            nodeNum (int, optional): Use this node to get info. Defaults to 0 (mn0).
+            height (int, optional): Get historical info at this height. Defaults to -1 (current blockchain height).
+
+        Returns:
+            list(): list of top mn indexes
+        """
+        # Get current top MNs on given node
+        if height == -1:
+            creator_height = self.nodes[node_num].getblockcount()
+        else:
+            creator_height = height
+        top_masternodes = self.nodes[node_num].masternode("top", creator_height)[str(creator_height)]
+        print(f"top_masternodes ({creator_height}) - {top_masternodes}")
+
+        top_mns_indexes = []
+        for mn in top_masternodes:
+            index = self.mn_outpoints[mn["outpoint"]]
+            top_mns_indexes.append(index)
+
+        for i in range(3):
+            idx = top_mns_indexes[i]
+            self.top_mns[i] = TopMN(idx, self.get_mnid(idx))
+            print(f"TopMN[{i}]: {self.top_mns[i]!r}")
+
+        return top_mns_indexes
+
+
+    # ===============================================================================================================
+    def create_signatures(self, item_type: TicketType, principal_node_num: int, make_bad_signatures_dicts = False):
+        """Create ticket signatures
+
+        Args:
+            principal_node_num (int): node# for principal signer
+            make_bad_signatures_dicts (bool): if True - create invalid signatures
+        """
+        ticket = self.tickets[item_type]
+        principal_pastelid = ticket.reg_pastelid
+
+        mn_ticket_signatures = {}
+        principal_signature = self.nodes[principal_node_num].pastelid("sign", ticket.reg_ticket, principal_pastelid, self.passphrase)["signature"]
+        assert_true(principal_signature, f"Principal signer {principal_pastelid} failed to sign ticket")
+        # save this principal signature for validation
+        self.principal_signatures_dict[principal_pastelid] = principal_signature
+
+        for n in range(self.number_of_cold_nodes):
+            mnid = self.get_mnid(n)
+            mn_ticket_signatures[n] = self.nodes[n].pastelid("sign", ticket.reg_ticket, mnid, self.passphrase)["signature"]
+            assert_true(mn_ticket_signatures[n], f"MN{n} signer {mnid} failed to sign ticket")
+        print(f"principal ticket signer - {principal_signature}")
+        print(f"mn_ticket_signatures - {mn_ticket_signatures}")
+
+        # update top master nodes used for signing
+        top_mns_indexes = self.update_mn_indexes()
+
+        # update top mn signatures
+        for i in range(3):
+            top_mn = self.top_mns[i]
+            idx = top_mn.index
+            top_mn.signature = mn_ticket_signatures[idx]
+
+        self.signatures_dict = dict(
+            {
+                "principal": {principal_pastelid: principal_signature},
+                "mn2": {self.top_mns[1].pastelid: self.top_mns[1].signature},
+                "mn3": {self.top_mns[2].pastelid: self.top_mns[2].signature},
+            }
+        )
+        print(f"signatures_dict - {self.signatures_dict!r}")
+
+        if make_bad_signatures_dicts:
+            self.same_mns_signatures_dict = dict(
+                {
+                    "principal": {principal_pastelid: principal_signature},
+                    "mn2": {self.top_mns[0].pastelid: self.top_mns[0].signature},
+                    "mn3": {self.top_mns[0].pastelid: self.top_mns[0].signature},
+                }
+            )
+            print(f"same_mns_signatures_dict - {self.same_mns_signatures_dict!r}")
+
+            not_top_mns_indexes = set(self.mn_outpoints.values()) ^ set(top_mns_indexes)
+            print(not_top_mns_indexes)
+
+            not_top_mns_index1 = list(not_top_mns_indexes)[0]
+            not_top_mns_index2 = list(not_top_mns_indexes)[1]
+            not_top_mn_pastelid1 = self.get_mnid(not_top_mns_index1)
+            not_top_mn_pastelid2 = self.get_mnid(not_top_mns_index2)
+            not_top_mn_ticket_signature1 = mn_ticket_signatures[not_top_mns_index1]
+            not_top_mn_ticket_signature2 = mn_ticket_signatures[not_top_mns_index2]
+            self.not_top_mns_signatures_dict = dict(
+                {
+                    "principal": {principal_pastelid: principal_signature},
+                    "mn2": {not_top_mn_pastelid1: not_top_mn_ticket_signature1},
+                    "mn3": {not_top_mn_pastelid2: not_top_mn_ticket_signature2},
+                }
+            )
+            print(f"not_top_mns_signatures_dict - {self.not_top_mns_signatures_dict!r}")
+
+
+    # ===============================================================================================================
+    def generate_nft_app_ticket_details(self):
+        # app_ticket structure
+        # {
+        #     "creator_name": string,
+        #     "nft_title": string,
+        #     "nft_series_name": string,
+        #     "nft_keyword_set": string,
+        #     "creator_website": string,
+        #     "creator_written_statement": string,
+        #     "nft_creation_video_youtube_url": string,
+        #
+        #     "preview_hash": bytes,        //hash of the preview thumbnail !!!!SHA3-256!!!!
+        #     "thumbnail1_hash": bytes,     //hash of the thumbnail !!!!SHA3-256!!!!
+        #     "thumbnail2_hash": bytes,     //hash of the thumbnail !!!!SHA3-256!!!!
+        #     "data_hash": bytes,           //hash of the image that this ticket represents !!!!SHA3-256!!!!
+        #
+        #     "fingerprints_hash": bytes,       //hash of the fingerprint !!!!SHA3-256!!!!
+        #     "fingerprints_signature": bytes,  //signature on raw image fingerprint
+        #
+        #     "rq_ids": [list of strings],      //raptorq symbol identifiers -  !!!!SHA3-256 of symbol block!!!!
+        #     "rq_oti": [array of 12 bytes],    //raptorq CommonOTI and SchemeSpecificOTI
+        #
+        #     "dupe_detection_system_version": string,  //
+        #     "pastel_rareness_score": float,            // 0 to 1
+        #
+        #     "internet_rareness_score": 0,
+        #     "matches_found_on_first_page": integer,
+        #     "number_of_pages_of_results": integer,
+        #     "url_of_first_match_in_page": string,
+        #
+        #     "open_nsfw_score": float,                     // 0 to 1
+        #     "alternate_nsfw_scores": {
+        #           "drawing": float,                       // 0 to 1
+        #           "hentai": float,                        // 0 to 1
+        #           "neutral": float,                       // 0 to 1
+        #           "porn": float,                          // 0 to 1
+        #           "sexy": float,                          // 0 to 1
+        #     },
+        #
+        #     "image_hashes": {
+        #         "pdq_hash": bytes,
+        #         "perceptual_hash": bytes,
+        #         "average_hash": bytes,
+        #         "difference_hash": bytes
+        #     },
+        # }
+        # Data for nft-ticket generation
+        creator_first_names=('John', 'Andy', 'Joe', 'Jennifer', 'August', 'Dave', 'Blanca', 'Diana', 'Tia', 'Michael')
+        creator_last_names=('Johnson', 'Smith', 'Williams', 'Ecclestone', 'Schumacher', 'Faye', 'Counts', 'Wesley')
+        letters = string.ascii_letters
+
+        rq_ids = []
+        for _ in range(5):
+            rq_ids.insert(1, self.get_random_mock_hash())
+
+        nft_ticket_json = {
+            "creator_name": "".join(random.choice(creator_first_names)+" "+random.choice(creator_last_names)),
+            "nft_title": self.get_rand_testdata(letters, 10),
+            "nft_series_name": self.get_rand_testdata(letters, 10),
+            "nft_keyword_set": self.get_rand_testdata(letters, 10),
+            "creator_website": self.get_rand_testdata(letters, 10),
+            "creator_written_statement": self.get_rand_testdata(letters, 10),
+            "nft_creation_video_youtube_url": self.get_rand_testdata(letters, 10),
+
+            "preview_hash": self.get_random_mock_hash(),
+            "thumbnail_hash": self.get_random_mock_hash(),
+            "thumbnail1_hash": self.get_random_mock_hash(),
+            "thumbnail2_hash": self.get_random_mock_hash(),
+            "data_hash": self.get_random_mock_hash(),
+
+            "fingerprints_hash": self.get_random_mock_hash(),
+            "fingerprints_signature": self.get_rand_testdata(letters, 20),
+
+            "rq_ids": rq_ids,
+            "rq_oti": self.get_rand_testdata(letters, 12),
+
+            "dupe_detection_system_version": "1",
+            "pastel_rareness_score": round(random.random(), 2),
+
+            "rareness_score": random.randint(0, 1000),
+            "internet_rareness_score": round(random.random(), 2),
+            "matches_found_on_first_page": random.randint(1, 5),
+            "number_of_pages_of_results": random.randint(1, 50),
+            "url_of_first_match_in_page": self.get_rand_testdata(letters, 10),
+
+            "open_nsfw_score": round(random.random(), 2),
+            "nsfw_score": random.randint(0, 1000),
+            "alternate_nsfw_scores": {
+                  "drawing": round(random.random(), 2),
+                  "hentai": round(random.random(), 2),
+                  "neutral": round(random.random(), 2),
+            },
+
+            "image_hashes": {
+                "pdq_hash": self.get_random_mock_hash(),
+                "perceptual_hash": self.get_random_mock_hash(),
+                "average_hash": self.get_random_mock_hash(),
+                "difference_hash": self.get_random_mock_hash()
+            },
+        }
+
+        return nft_ticket_json
+
+
+    # ===============================================================================================================
+    def create_nft_ticket_v1(self, creator_node_num: int, total_copies: int,
+        royalty: float, green: bool, make_bad_signatures_dicts = False):
+        """Create NFT ticket v1 and signatures
+
+        Args:
+            creator_node_num (int): node that creates NFT ticket and signatures
+            total_copies (int): [number of copies]
+            royalty (float): [royalty fee, how much creator should get on all future resales]
+            green (bool): [is there Green NFT payment or not]
+            make_bad_signatures_dicts (bool): [create bad signatures]
+        """
+        # Get current height
+        ticket = self.tickets[TicketType.NFT]
+        ticket.reg_height = self.nodes[0].getblockcount()
+        ticket.reg_pastelid = self.creator_pastelid1
+        ticket.pastelid_node_id = self.non_mn3
+        print(f"creator_ticket_height - {ticket.reg_height}")
+
+        # nft_ticket - v1
+        # {
+        #   "nft_ticket_version": integer  // 1
+        #   "author": bytes,               // Pastel ID of the author (creator)
+        #   "blocknum": integer,           // block number when the ticket was created - this is to map the ticket to the MNs that should process it
+        #   "block_hash": bytes            // hash of the top block when the ticket was created - this is to map the ticket to the MNs that should process it
+        #   "copies": integer,             // number of copies
+        #   "royalty": float,              // how much creator should get on all future resales
+        #   "green": bool,                 // is green payment
+        #   "app_ticket": ...
+        # }
+
+        block_hash = self.nodes[creator_node_num].getblock(str(ticket.reg_height))["hash"]
+        app_ticket_json = self.generate_nft_app_ticket_details()
+        app_ticket = str_to_b64str(json.dumps(app_ticket_json))
+
+        json_ticket = {
+            "nft_ticket_version": 1,
+            "author": ticket.reg_pastelid,
+            "blocknum": ticket.reg_height,
+            "block_hash": block_hash,
+            "copies": total_copies,
+            "royalty": royalty,
+            "green": green,
+            "app_ticket": app_ticket
+        }
+        nft_ticket_str = json.dumps(json_ticket, indent=4)
+        ticket.reg_ticket = str_to_b64str(nft_ticket_str)
+        print(f"nft_ticket v1 - {nft_ticket_str}")
+        print(f"nft_ticket v1 (base64) - {ticket.reg_ticket}")
+
+        self.create_signatures(TicketType.NFT, creator_node_num, make_bad_signatures_dicts)

--- a/qa/rpc-tests/mn_expiration.py
+++ b/qa/rpc-tests/mn_expiration.py
@@ -1,73 +1,54 @@
 #!/usr/bin/env python3
 # Copyright (c) 2018-2022 The Pastel Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 import math
 import json
 import time
-import random
-import string
 from decimal import getcontext
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc,
     assert_true,
-    initialize_chain_clean,
-    str_to_b64str
+    assert_false,
+    assert_greater_than,
+    initialize_chain_clean
 )
-from test_framework.authproxy import JSONRPCException
 import test_framework.rpc_consts as rpc
-from mn_common import MasterNodeCommon
+from pastel_test_framework import (
+    TicketType
+)
+from mn_common import (
+    MasterNodeCommon
+)
 
 getcontext().prec = 16
 
-# 12 Master Nodes
-private_keys_list = ["91sY9h4AQ62bAhNk1aJ7uJeSnQzSFtz7QmW5imrKmiACm7QJLXe",  # 0
-                     "923JtwGJqK6mwmzVkLiG6mbLkhk1ofKE1addiM8CYpCHFdHDNGo",  # 1
-                     "91wLgtFJxdSRLJGTtbzns5YQYFtyYLwHhqgj19qnrLCa1j5Hp5Z",  # 2
-                     "92XctTrjQbRwEAAMNEwKqbiSAJsBNuiR2B8vhkzDX4ZWQXrckZv",  # 3
-                     "923JCnYet1pNehN6Dy4Ddta1cXnmpSiZSLbtB9sMRM1r85TWym6",  # 4
-                     "93BdbmxmGp6EtxFEX17FNqs2rQfLD5FMPWoN1W58KEQR24p8A6j",  # 5
-                     "92av9uhRBgwv5ugeNDrioyDJ6TADrM6SP7xoEqGMnRPn25nzviq",  # 6
-                     "91oHXFR2NVpUtBiJk37i8oBMChaQRbGjhnzWjN9KQ8LeAW7JBdN",  # 7
-                     "92MwGh67mKTcPPTCMpBA6tPkEE5AK3ydd87VPn8rNxtzCmYf9Yb",  # 8
-                     "92VSXXnFgArfsiQwuzxSAjSRuDkuirE1Vf7KvSX7JE51dExXtrc",  # 9
-                     "91hruvJfyRFjo7JMKnAPqCXAMiJqecSfzn9vKWBck2bKJ9CCRuo",  # 10
-                     "92sYv5JQHzn3UDU6sYe5kWdoSWEc6B98nyY5JN7FnTTreP8UNrq",  # 11
-                     "92pfBHQaf5K2XBnFjhLaALjhCqV8Age3qUgJ8j8oDB5eESFErsM"   # 12
-                     ]
-
-
 class MasterNodeTicketsTest(MasterNodeCommon):
-    number_of_master_nodes = len(private_keys_list)
-    number_of_simple_nodes = 6
-    total_number_of_nodes = number_of_master_nodes + number_of_simple_nodes
-
-    non_active_mn = number_of_master_nodes - 1
-
-    non_mn1 = number_of_master_nodes           # mining node - will have coins #13
-    non_mn2 = number_of_master_nodes + 1       # hot node - will have collateral for all active MN #14
-    non_mn3 = number_of_master_nodes + 2       # will not have coins by default #15
-    non_mn4 = number_of_master_nodes + 3       # will not have coins by default #16
-    non_mn5 = number_of_master_nodes + 4       # will not have coins by default #17
-    non_mn6 = number_of_master_nodes + 5       # will not have coins by default #18
-
-    mining_node_num = number_of_master_nodes   # same as non_mn1
-    hot_node_num = number_of_master_nodes + 1  # same as non_mn2
 
     def __init__(self):
+        super().__init__()
+        
+        self.number_of_master_nodes = 12
+        self.number_of_cold_nodes = self.number_of_master_nodes - 1
+        self.number_of_simple_nodes = 6
+
+        self.non_active_mn = self.number_of_master_nodes - 1
+
+        self.non_mn1 = self.number_of_master_nodes           # mining node - will have coins #13
+        self.non_mn2 = self.number_of_master_nodes + 1       # hot node - will have collateral for all active MN #14
+        self.non_mn3 = self.number_of_master_nodes + 2       # will not have coins by default #15
+        self.non_mn4 = self.number_of_master_nodes + 3       # will not have coins by default #16
+        self.non_mn5 = self.number_of_master_nodes + 4       # will not have coins by default #17
+        self.non_mn6 = self.number_of_master_nodes + 5       # will not have coins by default #18
+
+        self.mining_node_num = self.number_of_master_nodes   # same as non_mn1
+        self.hot_node_num = self.number_of_master_nodes + 1  # same as non_mn2
+        
         self.errorString = ""
         self.is_network_split = False
         self.nodes = []
         self.storage_fee = 100
-
-        self.mn_addresses = {}
-        self.mn_pastelids = {}
-        self.mn_outpoints = {}
-        self.ticket = None
-        self.signatures_dict = None
-        self.same_mns_signatures_dict = None
-        self.not_top_mns_signatures_dict = None
 
         self.nonmn3_pastelid1 = None
         self.nonmn4_pastelid1 = None
@@ -79,198 +60,37 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.nonmn5_address1 = None
         self.nonmn6_address1 = None
         self.creator_pastelid1 = None
-        self.creator_ticket_height = None
         self.ticket_principal_signature = None
-        self.top_mns_index0 = None
-        self.top_mns_index1 = None
-        self.top_mns_index2 = None
-        self.top_mn_pastelid0 = None
-        self.top_mn_pastelid1 = None
-        self.top_mn_pastelid2 = None
-        self.top_mn_ticket_signature0 = None
-        self.top_mn_ticket_signature1 = None
-        self.top_mn_ticket_signature2 = None
 
         self.total_copies = 2
-        self.nft_copy_price = 1000
-        self.id_ticket_price = 10
-        self.nft_ticket_price = 10
-        self.act_ticket_price = 10
-        self.transfer_ticket_price = 10
+        self.tickets[TicketType.NFT].item_price = 1000
 
-        self.royalty = 0.075                # default royalty fee
-        self.is_green = True                # is green fee payment?
 
     def setup_chain(self):
         print(f"Initializing test directory {self.options.tmpdir}")
         initialize_chain_clean(self.options.tmpdir, self.total_number_of_nodes)
 
+
     def setup_network(self, split=False):
-        self.setup_masternodes_network(private_keys_list, self.number_of_simple_nodes)
+        self.setup_masternodes_network(self.mining_node_num, self.hot_node_num, "masternode,mnpayments,governance,compress")
+        self.inc_ticket_counter(TicketType.MNID, self.number_of_cold_nodes)
+
 
     def run_test(self):
-        print("starting MNs for the first time - no shift")
-
-        self.mining_enough(self.mining_node_num, self.number_of_master_nodes)
-        cold_nodes = {k: v for k, v in enumerate(private_keys_list[:-1])}  # all but last!!!
-        _, _, _ = self.start_mn(self.mining_node_num, self.hot_node_num, cold_nodes, self.total_number_of_nodes)
-
-        self.reconnect_nodes(0, self.number_of_master_nodes)
-        self.sync_all()
-
-        offer_ticket2_txid = None
-
         self.initialize()
 
-        nft_ticket_txid = self.register_nft_reg_ticket("nft-label")
-        self.__wait_for_confirmation(self.non_mn3)
-
-        act_ticket_txid = self.register_nft_act_ticket(nft_ticket_txid)
-        self.__wait_for_confirmation(self.non_mn3)
-
-        offer_ticket1_txid = self.register_offer_ticket(act_ticket_txid)
-        offer_ticket_txid = offer_ticket1_txid
-        print(f"offer ticket 1 txid {offer_ticket1_txid}")
-        self.__wait_for_confirmation(self.non_mn3)
-
-        if (self.total_copies == 1):
-            # fail if not enough copies to offer
-            assert_raises_rpc(rpc.RPC_MISC_ERROR, 
-                "Invalid Offer ticket - copy number [2] cannot exceed the total number of available copies [1] or be 0",
-                self.register_offer_ticket, act_ticket_txid)
-
-        # fail as the replace copy can be created after 5 days
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, 
-            f"Can only replace Offer ticket after 5 days, txid - [{offer_ticket1_txid}] copyNumber [1]",
-            self.register_offer_ticket, act_ticket_txid, 1)
-
-        print("Generate 3000 blocks that is > 5 days. 1 chunk is 10 blocks")
-        for ind in range (300):
-            print(f"chunk - {ind + 1}")
-            self.nodes[self.mining_node_num].generate(10)
-            time.sleep(2)
-
-        print("Waiting 300 seconds")
-        time.sleep(300)
-        self.__wait_for_sync_all()
-
-        offer_ticket2_txid = self.register_offer_ticket(act_ticket_txid, 1)
-        offer_ticket_txid = offer_ticket2_txid
-        print(f"offer ticket 2 txid {offer_ticket2_txid}")
-
-        offer_ticket3_txid = None
-        if (self.total_copies > 1):
-            offer_ticket3_txid = self.register_offer_ticket(act_ticket_txid)
-            print(f"offer ticket 3 txid {offer_ticket3_txid}")
-
-            offer_ticket1_1 = self.nodes[self.non_mn3].tickets("find", "offer", act_ticket_txid+":2")
-            assert_equal(offer_ticket1_1['ticket']['type'], "offer")
-            assert_equal(offer_ticket1_1['ticket']['item_txid'], act_ticket_txid)
-            assert_equal(offer_ticket1_1["ticket"]["copy_number"], 2)
-
-            offer_ticket1_2 = self.nodes[self.non_mn3].tickets("get", offer_ticket3_txid)
-            assert_equal(offer_ticket1_2["ticket"]["item_txid"], offer_ticket1_1["ticket"]["item_txid"])
-            assert_equal(offer_ticket1_2["ticket"]["copy_number"], offer_ticket1_1["ticket"]["copy_number"])
-
-        self.__send_coins_to_accept(self.non_mn4, self.nonmn4_address1, 5)
-
-        if offer_ticket2_txid:
-            # fail if old offer ticket has been replaced
-            assert_raises_rpc(rpc.RPC_MISC_ERROR,
-               f"This Offer ticket has been replaced with another ticket, txid - [{offer_ticket2_txid}], copyNumber [1]",
-               self.register_accept_ticket, self.non_mn4, self.nonmn4_pastelid1, offer_ticket1_txid)
-
-        accept_ticket1_txid = self.register_accept_ticket(self.non_mn4, self.nonmn4_pastelid1, offer_ticket_txid)
-        accept_ticket_txid = accept_ticket1_txid
-
-        # fail if there is another Accept ticket1 created < 1 hour ago
-        assert_raises_rpc(rpc.RPC_MISC_ERROR,
-            f"Accept ticket [{accept_ticket1_txid}] already exists and is not yet 1h old for this Offer ticket [{offer_ticket_txid}]",
-            self.register_accept_ticket, self.non_mn4, self.nonmn4_pastelid1, offer_ticket_txid)
-
-        print("Generate 30 blocks that is > 1 hour. 1 chunk is 10 blocks")
-        for ind in range (3):
-            print(f"chunk - {ind + 1}")
-            self.nodes[self.mining_node_num].generate(10)
-            time.sleep(2)
-
-        print("Waiting 180 seconds")
-        time.sleep(180)
-        self.__wait_for_sync_all()
-
-        accept_ticket2_txid = self.register_accept_ticket(self.non_mn4, self.nonmn4_pastelid1, offer_ticket_txid)
-        accept_ticket_txid = accept_ticket2_txid
-
-        # fail if there is another Accept ticket2 created < 1 hour ago
-        assert_raises_rpc(rpc.RPC_MISC_ERROR,
-            f"Accept ticket [{accept_ticket2_txid}]  already exists and is not yet 1h old for this Offer ticket [{offer_ticket_txid}]",
-            self.register_accept_ticket, self.non_mn4, self.nonmn4_pastelid1, offer_ticket_txid)
-
-        print("Generate 30 blocks that is > 1 hour. 1 chunk is 10 blocks")
-        for ind in range (3):
-            print(f"chunk - {ind + 1}")
-            self.nodes[self.mining_node_num].generate(10)
-            time.sleep(2)
-
-        print("Waiting 180 seconds")
-        time.sleep(180)
-        self.__wait_for_sync_all()
-
-        accept_ticket3_txid = self.register_accept_ticket(self.non_mn4, self.nonmn4_pastelid1, offer_ticket_txid)
-        accept_ticket_txid = accept_ticket3_txid
-
-        # fail if old accept ticket1 has been replaced
-        assert_raises_rpc(rpc.RPC_MISC_ERROR,
-            f"This Accept ticket has been replaced with another ticket, txid - [{accept_ticket_txid}]",
-            self.register_transfer_ticket, 
-            self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1, offer_ticket_txid, accept_ticket1_txid)
-
-        # fail if old accept ticket2 has been replaced
-        assert_raises_rpc(rpc.RPC_MISC_ERROR,
-            f"This Accept ticket has been replaced with another ticket, txid - [{accept_ticket_txid}]",
-            self.register_transfer_ticket, 
-            self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1, offer_ticket_txid, accept_ticket2_txid)
-
-        transfer_ticket1_txid = self.register_transfer_ticket(
-            self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1,
-            offer_ticket_txid, accept_ticket_txid)
-
-        # fail if there is another Transfer ticket referring to that offer ticket
-        assert_raises_rpc(rpc.RPC_MISC_ERROR,
-            "Transfer ticket already exists for the Offer ticket with this txid [{offer_ticket_txid}]",
-            self.register_transfer_ticket,
-            self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1, offer_ticket_txid, accept_ticket_txid)
-
-        if self.total_copies == 1:
-            assert_raises_rpc(rpc.RPC_MISC_ERROR,
-                f"The NFT you are trying to offer - from NFT Registration ticket [{act_ticket_txid}]"
-                " - is already offered - there are already [1] offered copies, "
-                "but only [1] copies were available",
-                self.register_offer_ticket, act_ticket_txid, 1)
-        elif self.total_copies == 2:
-            # fail if not enough copies to offer
-            assert_raises_rpc(rpc.RPC_MISC_ERROR,
-                "Invalid Offer ticket - copy number [3] cannot exceed the total number of available copies [2] or be 0",
-                self.register_offer_ticket, act_ticket_txid)
-
-            assert_raises_rpc(rpc.RPC_MISC_ERROR,
-                f"Cannot replace Offer ticket - it has been already transferred, txid - [{offer_ticket_txid}] copyNumber [1]",
-                self.register_offer_ticket, act_ticket_txid, 1)
-
-            # fail as the replace copy can be created after 5 days
-            assert_raises_rpc(rpc.RPC_MISC_ERROR,
-                f"Can only replace Offer ticket after 5 days, txid - [{offer_ticket3_txid}] copyNumber [2]",
-                self.register_offer_ticket, act_ticket_txid, 2)
-
+        self.pose_ban_tests()
+        self.ticket_expiration_tests()
 
     # ===============================================================================================================
     def initialize(self):
         print("== Initialize nodes ==")
 
-        self.nodes[self.mining_node_num].generate(10)
+        self.generate_and_sync_inc(10, self.mining_node_num)
 
         # generate pastelIDs & send coins
         self.creator_pastelid1 = self.create_pastelid(self.non_mn3)[0]
+        print(f'Creator Pastel ID: {self.creator_pastelid1}')
         self.nonmn3_pastelid1 = self.create_pastelid(self.non_mn3)[0]
         self.nonmn3_address1 = self.nodes[self.non_mn3].getnewaddress()
         self.nodes[self.mining_node_num].sendtoaddress(self.nonmn3_address1, 1000, "", "", False)
@@ -282,386 +102,317 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.nonmn5_pastelid1 = self.create_pastelid(self.non_mn5)[0]
         self.nonmn5_address1 = self.nodes[self.non_mn5].getnewaddress()
         self.nodes[self.mining_node_num].sendtoaddress(self.nonmn5_address1, 100, "", "", False)
+        self.generate_and_sync_inc(1, self.mining_node_num)
 
-        for n in range(0, 12):
-            self.mn_addresses[n] = self.nodes[n].getnewaddress()
-            self.nodes[self.mining_node_num].sendtoaddress(self.mn_addresses[n], 1000, "", "", False)
-            self.mn_pastelids[n] = self.create_pastelid(n)[0]
-            self.mn_outpoints[self.nodes[n].masternode("status")["outpoint"]] = n
-
-        print(f"mn_addresses - {self.mn_addresses}")
-        print(f"mn_pastelids - {self.mn_pastelids}")
-        print(f"mn_outpoints - {self.mn_outpoints}")
-
-        self.__wait_for_sync_all()
-
-        # register pastelIDs
-        self.nodes[self.non_mn3].tickets("register", "id", self.creator_pastelid1, self.passphrase, self.nonmn3_address1)
-        self.nodes[self.non_mn3].tickets("register", "id", self.nonmn3_pastelid1, self.passphrase, self.nonmn3_address1)
-        self.nodes[self.non_mn4].tickets("register", "id", self.nonmn4_pastelid1, self.passphrase, self.nonmn4_address1)
-        self.nodes[self.non_mn5].tickets("register", "id", self.nonmn5_pastelid1, self.passphrase, self.nonmn5_address1)
-        for n in range(0, 12):
-            self.nodes[n].tickets("register", "mnid", self.mn_pastelids[n], self.passphrase)
-
-        self.__wait_for_sync_all(5)
+        # register Pastel IDs
+        register_ids = [
+            ( self.non_mn3, self.creator_pastelid1, self.nonmn3_address1 ),
+            ( self.non_mn3, self.nonmn3_pastelid1, self.nonmn3_address1 ),
+            ( self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1 ),
+            ( self.non_mn5, self.nonmn5_pastelid1, self.nonmn5_address1 )
+        ]
+        for idreg_info in register_ids:
+            self.nodes[idreg_info[0]].tickets("register", "id", idreg_info[1], self.passphrase, idreg_info[2])
+            self.generate_and_sync_inc(1, self.mining_node_num)
+        self.inc_ticket_counter(TicketType.ID, len(register_ids))
+        self.__wait_for_ticket_tnx(5)
 
 
-    # ===============================================================================================================
-    def generate_nft_app_ticket_details(self):
-        # app_ticket structure
-        # {
-        #     "creator_name": string,
-        #     "nft_title": string,
-        #     "nft_series_name": string,
-        #     "nft_keyword_set": string,
-        #     "creator_website": string,
-        #     "creator_written_statement": string,
-        #     "nft_creation_video_youtube_url": string,
-        #
-        #     "preview_hash": bytes,        //hash of the preview thumbnail !!!!SHA3-256!!!!
-        #     "thumbnail1_hash": bytes,     //hash of the thumbnail !!!!SHA3-256!!!!
-        #     "thumbnail2_hash": bytes,     //hash of the thumbnail !!!!SHA3-256!!!!
-        #     "data_hash": bytes,           //hash of the image that this ticket represents !!!!SHA3-256!!!!
-        #
-        #     "fingerprints_hash": bytes,       //hash of the fingerprint !!!!SHA3-256!!!!
-        #     "fingerprints_signature": bytes,  //signature on raw image fingerprint
-        #
-        #     "rq_ids": [list of strings],      //raptorq symbol identifiers -  !!!!SHA3-256 of symbol block!!!!
-        #     "rq_oti": [array of 12 bytes],    //raptorq CommonOTI and SchemeSpecificOTI
-        #
-        #     "dupe_detection_system_version": string,  //
-        #     "pastel_rareness_score": float,            // 0 to 1
-        #
-        #     "internet_rareness_score": 0,
-        #     "matches_found_on_first_page": integer,
-        #     "number_of_pages_of_results": integer,
-        #     "url_of_first_match_in_page": string,
-        #
-        #     "open_nsfw_score": float,                     // 0 to 1
-        #     "alternate_nsfw_scores": {
-        #           "drawing": float,                       // 0 to 1
-        #           "hentai": float,                        // 0 to 1
-        #           "neutral": float,                       // 0 to 1
-        #           "porn": float,                          // 0 to 1
-        #           "sexy": float,                          // 0 to 1
-        #     },
-        #
-        #     "image_hashes": {
-        #         "pdq_hash": bytes,
-        #         "perceptual_hash": bytes,
-        #         "average_hash": bytes,
-        #         "difference_hash": bytes
-        #     },
-        # }
-        # Data for nft-ticket generation
-        creator_first_names=('John', 'Andy', 'Joe', 'Jennifer', 'August', 'Dave', 'Blanca', 'Diana', 'Tia', 'Michael')
-        creator_last_names=('Johnson', 'Smith', 'Williams', 'Ecclestone', 'Schumacher', 'Faye', 'Counts', 'Wesley')
-        letters = string.ascii_letters
-
-        rq_ids = []
-        for _ in range(5):
-            rq_ids.insert(1, self.get_random_mock_hash())
-
-        nft_ticket_json = {
-            "creator_name": "".join(random.choice(creator_first_names)+" "+random.choice(creator_last_names)),
-            "nft_title": self.get_rand_testdata(letters, 10),
-            "nft_series_name": self.get_rand_testdata(letters, 10),
-            "nft_keyword_set": self.get_rand_testdata(letters, 10),
-            "creator_website": self.get_rand_testdata(letters, 10),
-            "creator_written_statement": self.get_rand_testdata(letters, 10),
-            "nft_creation_video_youtube_url": self.get_rand_testdata(letters, 10),
-
-            "preview_hash": self.get_random_mock_hash(),
-            "thumbnail_hash": self.get_random_mock_hash(),
-            "thumbnail1_hash": self.get_random_mock_hash(),
-            "thumbnail2_hash": self.get_random_mock_hash(),
-            "data_hash": self.get_random_mock_hash(),
-
-            "fingerprints_hash": self.get_random_mock_hash(),
-            "fingerprints_signature": self.get_rand_testdata(letters, 20),
-
-            "rq_ids": rq_ids,
-            "rq_oti": self.get_rand_testdata(letters, 12),
-
-            "dupe_detection_system_version": "1",
-            "pastel_rareness_score": round(random.random(), 2),
-
-            "rareness_score": random.randint(0, 1000),
-            "internet_rareness_score": round(random.random(), 2),
-            "matches_found_on_first_page": random.randint(1, 5),
-            "number_of_pages_of_results": random.randint(1, 50),
-            "url_of_first_match_in_page": self.get_rand_testdata(letters, 10),
-
-            "open_nsfw_score": round(random.random(), 2),
-            "nsfw_score": random.randint(0, 1000),
-            "alternate_nsfw_scores": {
-                  "drawing": round(random.random(), 2),
-                  "hentai": round(random.random(), 2),
-                  "neutral": round(random.random(), 2),
-            },
-
-            "image_hashes": {
-                "pdq_hash": self.get_random_mock_hash(),
-                "perceptual_hash": self.get_random_mock_hash(),
-                "average_hash": self.get_random_mock_hash(),
-                "difference_hash": self.get_random_mock_hash()
-            },
-        }
-
-        return nft_ticket_json
-
-    def update_mn_indexes(self, nodeNum = 0, height = -1):
-        """Get historical information about top MNs at given height.
-
-        Args:
-            nodeNum (int, optional): Use this node to get info. Defaults to 0 (mn0).
-            height (int, optional): Get historical info at this height. Defaults to -1 (current blockchain height).
-
-        Returns:
-            list(): list of top mn indexes
+    def pose_ban_tests(self):
+        """ Test PoSe (Proof-of-Service) API.
+            Use this API on mn2 to ban mn5.
         """
-        # Get current top MNs on given node 
-        if height == -1:
-            creator_height = self.nodes[nodeNum].getblockcount()
-        else:
-            creator_height = height
-        top_masternodes = self.nodes[nodeNum].masternode("top", creator_height)[str(creator_height)]
-        print(f"top_masternodes ({creator_height}) - {top_masternodes}")
+        print("Test PoSe ban score API")
+        # get current PoSe ban score
+        mn2 = self.mn_nodes[2]
+        mn5 = self.mn_nodes[5]
+        out = self.nodes[mn2.index].masternode("pose-ban-score", "get", mn5.collateral_txid, mn5.collateral_index)
+        pose_ban_score = out["pose-ban-score"]
+        assert_equal(0, pose_ban_score)
+        assert_false(out["pose-banned"])
+        
+        current_height = self.nodes[mn2.index].getblockcount()
+        print(f"current height - {current_height}")
+        # now increment PoSe ban score 5 times for mn5
+        pose_ban_height = 0
+        for i in range(5):
+            out = self.nodes[mn2.index].masternode("pose-ban-score", "increment", mn5.collateral_txid, mn5.collateral_index)
+            pose_ban_score = out["pose-ban-score"]
+            print(f"mn5 PoSe ban score: {pose_ban_score}")
+            assert_equal(i + 1, pose_ban_score)
+            if i == 4:
+                assert_true(out["pose-banned"])
+                pose_ban_height = out["pose-ban-height"]
+                print(f"mn5 banned by PoSe until height {pose_ban_height}")
+            else:
+                assert_false(out["pose-banned"])
+        assert_greater_than(pose_ban_height, current_height)
+        for _ in range(current_height, pose_ban_height + 1):
+            self.generate_and_sync_inc(1, self.mining_node_num)
+            time.sleep(2)
+        time.sleep(10)
+        # check PoSe ban score again
+        out = self.nodes[mn2.index].masternode("pose-ban-score", "get", mn5.collateral_txid, mn5.collateral_index)
+        pose_ban_score = out["pose-ban-score"]
+        assert_equal(4, pose_ban_score)
+        assert_false(out["pose-banned"])
+            
 
-        top_mns_indexes = list()
-        for mn in top_masternodes:
-            index = self.mn_outpoints[mn["outpoint"]]
-            top_mns_indexes.append(index)
+    def ticket_expiration_tests(self):
+        self.register_nft_reg_ticket("nft-label")
+        self.__wait_for_confirmation(self.non_mn3)
 
-        self.top_mns_index0 = top_mns_indexes[0]
-        self.top_mns_index1 = top_mns_indexes[1]
-        self.top_mns_index2 = top_mns_indexes[2]
-        self.top_mn_pastelid0 = self.mn_pastelids[self.top_mns_index0]
-        self.top_mn_pastelid1 = self.mn_pastelids[self.top_mns_index1]
-        self.top_mn_pastelid2 = self.mn_pastelids[self.top_mns_index2]
+        self.register_nft_act_ticket()
+        self.__wait_for_confirmation(self.non_mn3)
 
-        print(f"top_mns_indexes - {top_mns_indexes}")
-        print(f"top_mns_pastelids - {self.top_mn_pastelid0},{self.top_mn_pastelid1},{self.top_mn_pastelid2}")
-        return top_mns_indexes
+        ticket = self.tickets[TicketType.NFT]
+        self.register_offer_ticket()
+        offer_ticket1_txid = ticket.offer_txid
+        print(f"offer ticket 1 txid {offer_ticket1_txid}")
+        self.__wait_for_confirmation(self.non_mn3)
 
+        if (self.total_copies == 1):
+            # fail if not enough copies to offer
+            assert_raises_rpc(rpc.RPC_MISC_ERROR,
+                "Invalid Offer ticket - copy number [2] cannot exceed the total number of available copies [1] or be 0",
+                self.register_offer_ticket)
 
-    # ===============================================================================================================
-    def create_signatures(self, principal_node_num, make_bad_signatures_dicts = False):
-        """Create ticket signatures
+        # fail as the replace copy can be created after 5 days
+        assert_raises_rpc(rpc.RPC_MISC_ERROR,
+            f"Can only replace Offer ticket after 5 days, txid - [{offer_ticket1_txid}] copyNumber [1]",
+            self.register_offer_ticket, 1)
+        
+        chunk_size = 10
+        chunk_count = int(300/chunk_size)
+        print(f"Generate 300 blocks that is > 5 days. 1 chunk is {chunk_size} blocks, total {chunk_count} chunks")
+        for ind in range(chunk_count):
+            print(f"chunk - {ind + 1}")
+            self.generate_and_sync_inc(chunk_size, self.mining_node_num)
+            time.sleep(5)
 
-        Args:
-            principal_node_num (int): node# for principal signer
-            make_bad_signatures_dicts (bool): if True - create invalid signatures
-        """
+        self.register_offer_ticket(1)
+        offer_ticket2_txid = ticket.offer_txid
+        print(f"offer ticket 2 txid {offer_ticket2_txid}")
 
-        mn_ticket_signatures = {}
-        principal_pastelid = self.creator_pastelid1
-        self.ticket_principal_signature = self.nodes[principal_node_num].pastelid("sign", self.ticket, principal_pastelid, self.passphrase)["signature"]
-        for n in range(0, 12):
-            mn_ticket_signatures[n] = self.nodes[n].pastelid("sign", self.ticket, self.mn_pastelids[n], self.passphrase)["signature"]
-        print(f"principal ticket signer - {self.ticket_principal_signature}")
-        print(f"mn_ticket_signatures - {mn_ticket_signatures}")
+        offer_ticket3_txid = None
+        if self.total_copies > 1:
+            self.register_offer_ticket()
+            offer_ticket3_txid = ticket.offer_txid
+            print(f"offer ticket 3 txid {offer_ticket3_txid}")
 
-        # update top master nodes used for signing
-        top_mns_indexes = self.update_mn_indexes()
+            offer_ticket1_1 = self.nodes[self.non_mn3].tickets("find", "offer", ticket.act_txid + ":2")
+            assert_equal(offer_ticket1_1['ticket']['type'], "offer")
+            assert_equal(offer_ticket1_1['ticket']['item_txid'], ticket.act_txid)
+            assert_equal(offer_ticket1_1["ticket"]["copy_number"], 2)
 
-        self.top_mn_ticket_signature0 = mn_ticket_signatures[self.top_mns_index0]
-        self.top_mn_ticket_signature1 = mn_ticket_signatures[self.top_mns_index1]
-        self.top_mn_ticket_signature2 = mn_ticket_signatures[self.top_mns_index2]
+            offer_ticket1_2 = self.nodes[self.non_mn3].tickets("get", offer_ticket3_txid)
+            assert_equal(offer_ticket1_2["ticket"]["item_txid"], offer_ticket1_1["ticket"]["item_txid"])
+            assert_equal(offer_ticket1_2["ticket"]["copy_number"], offer_ticket1_1["ticket"]["copy_number"])
 
-        self.signatures_dict = dict(
-            {
-                "principal": {principal_pastelid: self.ticket_principal_signature},
-                "mn2": {self.top_mn_pastelid1: self.top_mn_ticket_signature1},
-                "mn3": {self.top_mn_pastelid2: self.top_mn_ticket_signature2},
-            }
-        )
-        print(f"signatures_dict - {self.signatures_dict!r}")
+        self.__send_coins_to_accept(self.non_mn4, self.nonmn4_address1, 5)
 
-        if make_bad_signatures_dicts:
-            self.same_mns_signatures_dict = dict(
-                {
-                    "principal": {principal_pastelid: self.ticket_principal_signature},
-                    "mn2": {self.top_mn_pastelid0: self.top_mn_ticket_signature0},
-                    "mn3": {self.top_mn_pastelid0: self.top_mn_ticket_signature0},
-                }
-            )
-            print(f"same_mns_signatures_dict - {self.same_mns_signatures_dict!r}")
+        if offer_ticket2_txid:
+            # fail if old offer ticket has been replaced
+            ticket.offer_txid = offer_ticket1_txid
+            assert_raises_rpc(rpc.RPC_MISC_ERROR,
+               f"This Offer ticket has been replaced with another ticket, txid - [{offer_ticket2_txid}], copyNumber [1]",
+               self.register_accept_ticket, self.non_mn4, self.nonmn4_pastelid1)
 
-            not_top_mns_indexes = set(self.mn_outpoints.values()) ^ set(top_mns_indexes)
-            print(not_top_mns_indexes)
+        ticket.offer_txid = offer_ticket2_txid
+        self.register_accept_ticket(self.non_mn4, self.nonmn4_pastelid1)
+        accept_ticket1_txid = ticket.accept_txid
 
-            not_top_mns_index1 = list(not_top_mns_indexes)[0]
-            not_top_mns_index2 = list(not_top_mns_indexes)[1]
-            not_top_mn_pastelid1 = self.mn_pastelids[not_top_mns_index1]
-            not_top_mn_pastelid2 = self.mn_pastelids[not_top_mns_index2]
-            not_top_mn_ticket_signature1 = mn_ticket_signatures[not_top_mns_index1]
-            not_top_mn_ticket_signature2 = mn_ticket_signatures[not_top_mns_index2]
-            self.not_top_mns_signatures_dict = dict(
-                {
-                    "principal": {principal_pastelid: self.ticket_principal_signature},
-                    "mn2": {not_top_mn_pastelid1: not_top_mn_ticket_signature1},
-                    "mn3": {not_top_mn_pastelid2: not_top_mn_ticket_signature2},
-                }
-            )
-            print(f"not_top_mns_signatures_dict - {self.not_top_mns_signatures_dict!r}")
+        # fail if there is another Accept ticket1 created < 1 hour ago
+        ticket.offer_txid = offer_ticket2_txid
+        assert_raises_rpc(rpc.RPC_MISC_ERROR,
+            f"Accept ticket [{accept_ticket1_txid}] already exists and is not yet 1h old for this Offer ticket [{offer_ticket2_txid}]",
+            self.register_accept_ticket, self.non_mn4, self.nonmn4_pastelid1)
 
-    # ===============================================================================================================
-    def create_nft_ticket_v1(self, creator_node_num, total_copies, royalty, green, make_bad_signatures_dicts = False):
-        """Create NFT ticket v1 and signatures
+        print("Generate 30 blocks that is > 1 hour. 1 chunk is 10 blocks")
+        for ind in range(3):
+            print(f"chunk - {ind + 1}")
+            self.generate_and_sync_inc(10, self.mining_node_num)
+            time.sleep(5)
 
-        Args:
-            creator_node_num (int): node that creates NFT ticket and signatures
-            total_copies (int): [number of copies]
-            royalty (int): [royalty fee, how much creator should get on all future resales]
-            green (bool): [is there Green NFT payment or not]
-            make_bad_signatures_dicts (bool): [create bad signatures]
-        """
-        # Get current height
-        self.creator_ticket_height = self.nodes[0].getinfo()["blocks"]
-        print(f"creator_ticket_height - {self.creator_ticket_height}")
+        self.register_accept_ticket(self.non_mn4, self.nonmn4_pastelid1)
+        accept_ticket2_txid = ticket.accept_txid
 
-        # nft_ticket - v1
-        # {
-        #   "nft_ticket_version": integer  // 1
-        #   "author": bytes,               // Pastel ID of the author (creator)
-        #   "blocknum": integer,           // block number when the ticket was created - this is to map the ticket to the MNs that should process it
-        #   "block_hash": bytes            // hash of the top block when the ticket was created - this is to map the ticket to the MNs that should process it
-        #   "copies": integer,             // number of copies
-        #   "royalty": float,              // how much creator should get on all future resales
-        #   "green": bool,                 // is green payment
-        #   "app_ticket": ...
-        # }
+        # fail if there is another Accept ticket2 created < 1 hour ago
+        assert_raises_rpc(rpc.RPC_MISC_ERROR,
+            f"Accept ticket [{accept_ticket2_txid}] already exists and is not yet 1h old for this Offer ticket [{offer_ticket2_txid}]",
+            self.register_accept_ticket, self.non_mn4, self.nonmn4_pastelid1)
 
-        block_hash = self.nodes[creator_node_num].getblock(str(self.creator_ticket_height))["hash"]
-        app_ticket_json = self.generate_nft_app_ticket_details()
-        app_ticket = str_to_b64str(json.dumps(app_ticket_json))
+        print("Generate 30 blocks that is > 1 hour. 1 chunk is 10 blocks")
+        for ind in range (3):
+            print(f"chunk - {ind + 1}")
+            self.generate_and_sync_inc(10, self.mining_node_num)
+            time.sleep(5)
 
-        json_ticket = {
-            "nft_ticket_version": 1,
-            "author": self.creator_pastelid1,
-            "blocknum": self.creator_ticket_height,
-            "block_hash": block_hash,
-            "copies": total_copies,
-            "royalty": royalty,
-            "green": green,
-            "app_ticket": app_ticket
-        }
-        nft_ticket_str = json.dumps(json_ticket, indent=4)
-        self.ticket = str_to_b64str(nft_ticket_str)
-        print(f"nft_ticket v1 - {nft_ticket_str}")
-        print(f"nft_ticket v1 (base64) - {self.ticket}")
+        self.register_accept_ticket(self.non_mn4, self.nonmn4_pastelid1)
+        accept_ticket3_txid = ticket.accept_txid
 
-        self.create_signatures(creator_node_num, make_bad_signatures_dicts)
+        # fail if old accept ticket1 has been replaced
+        ticket.offer_txid = offer_ticket2_txid
+        ticket.accept_txid = accept_ticket1_txid
+        assert_raises_rpc(rpc.RPC_MISC_ERROR,
+            f"This Accept ticket has been replaced with another ticket, txid - [{accept_ticket3_txid}]",
+            self.register_transfer_ticket,
+            self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1)
+
+        # fail if old accept ticket2 has been replaced
+        ticket.offer_txid = offer_ticket2_txid
+        ticket.accept_txid = accept_ticket2_txid
+        assert_raises_rpc(rpc.RPC_MISC_ERROR,
+            f"This Accept ticket has been replaced with another ticket, txid - [{accept_ticket3_txid}]",
+            self.register_transfer_ticket, 
+            self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1)
+
+        ticket.offer_txid = offer_ticket2_txid
+        ticket.accept_txid = accept_ticket3_txid
+        self.register_transfer_ticket(self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1)
+
+        # fail if there is another Transfer ticket referring to that offer ticket
+        assert_raises_rpc(rpc.RPC_MISC_ERROR,
+            "Transfer ticket already exists for the Offer ticket with this txid [{offer_ticket_txid}]",
+            self.register_transfer_ticket,
+            self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1)
+
+        if self.total_copies == 1:
+            assert_raises_rpc(rpc.RPC_MISC_ERROR,
+                f"The NFT you are trying to offer - from NFT Registration ticket [{ticket.act_txid}]"
+                " - is already offered - there are already [1] offered copies, "
+                "but only [1] copies were available",
+                self.register_offer_ticket, ticket.act_txid, 1)
+        elif self.total_copies == 2:
+            # fail if not enough copies to offer
+            assert_raises_rpc(rpc.RPC_MISC_ERROR,
+                "Invalid Offer ticket - copy number [3] cannot exceed the total number of available copies [2] or be 0",
+                self.register_offer_ticket, ticket.act_txid)
+
+            assert_raises_rpc(rpc.RPC_MISC_ERROR,
+                f"Cannot replace Offer ticket - it has been already transferred, txid - [{ticket.offer_txid}] copyNumber [1]",
+                self.register_offer_ticket, ticket.act_txid, 1)
+
+            # fail as the replace copy can be created after 5 days
+            assert_raises_rpc(rpc.RPC_MISC_ERROR,
+                f"Can only replace Offer ticket after 5 days, txid - [{offer_ticket3_txid}] copyNumber [2]",
+                self.register_offer_ticket, ticket.act_txid, 2)
 
 
     def register_nft_reg_ticket(self, label):
         print("== Create the NFT registration ticket ==")
 
         self.create_nft_ticket_v1(self.non_mn3, self.total_copies, self.royalty, self.is_green)
-        nft_ticket_txid = self.nodes[self.top_mns_index0].tickets("register", "nft",
-            self.ticket, json.dumps(self.signatures_dict), self.top_mn_pastelid0, self.passphrase,
+        ticket = self.tickets[TicketType.NFT]
+        
+        top_mn_node = self.nodes[self.top_mns[0].index]
+        ticket.reg_txid = top_mn_node.tickets("register", "nft",
+            ticket.reg_ticket, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase,
             label, str(self.storage_fee))["txid"]
-        print(nft_ticket_txid)
-        assert_true(nft_ticket_txid, "No NFT registration ticket was created")
+        print(ticket.reg_txid)
+        assert_true(ticket.reg_txid, "No NFT registration ticket was created")
 
         self.__wait_for_ticket_tnx()
-        print(self.nodes[self.top_mns_index0].getblockcount())
+        print(top_mn_node.getblockcount())
 
-        return nft_ticket_txid
 
     # ===============================================================================================================
-    def register_nft_act_ticket(self, nft_ticket_txid):
+    def register_nft_act_ticket(self):
         print("== Create the nft activation ticket ==")
 
-        act_ticket_txid = self.nodes[self.non_mn3].tickets("register", "act", nft_ticket_txid,
-                                             str(self.creator_ticket_height), str(self.storage_fee),
+        ticket = self.tickets[TicketType.NFT]
+        ticket.act_txid = self.nodes[self.non_mn3].tickets("register", "act", ticket.reg_txid,
+                                             str(ticket.reg_height), str(self.storage_fee),
                                              self.creator_pastelid1, self.passphrase)["txid"]
-        assert_true(act_ticket_txid, "No NFT Registration ticket was created")
+        assert_true(ticket.act_txid, "No NFT Registration ticket was created")
         self.__wait_for_ticket_tnx()
 
-        return act_ticket_txid
 
     # ===============================================================================================================
-    def register_offer_ticket(self, act_ticket_txid, copyNumber = 0):
-        print("== Create Offer ticket ==")
+    def register_offer_ticket(self, copy_number: int = 0):
+        print(f"== Create Offer ticket (copy number: {copy_number})==")
 
-        offer_ticket_txid = self.nodes[self.non_mn3].tickets("register", "offer", act_ticket_txid, str(self.nft_copy_price),
-                                             self.creator_pastelid1, self.passphrase, 0, 0, copyNumber)["txid"]
-        assert_true(offer_ticket_txid, "No Offer ticket was created")
+        ticket = self.tickets[TicketType.NFT]
+        ticket.offer_txid = self.nodes[self.non_mn3].tickets("register", "offer", ticket.act_txid, str(ticket.item_price),
+                                             ticket.reg_pastelid, self.passphrase, 0, 0, copy_number)["txid"]
+        assert_true(ticket.offer_txid, "No Offer ticket was created")
         self.__wait_for_ticket_tnx()
 
-        return offer_ticket_txid
 
     # ===============================================================================================================
     def __send_coins_to_accept(self, node, address, num):
-        cover_price = self.nft_copy_price + max(10, int(self.nft_copy_price / 100)) + 5
+        nft_price = self.tickets[TicketType.NFT].item_price
+        cover_price = nft_price + max(10, int(nft_price / 100)) + 5
 
         self.nodes[self.mining_node_num].sendtoaddress(address, num * cover_price, "", "", False)
         self.__wait_for_confirmation(node)
 
-    def register_accept_ticket(self, acceptor_node, acceptor_pastelid1, offer_ticket_txid):
+
+    def register_accept_ticket(self, acceptor_node, acceptor_pastelid1):
         print("== Create Accept ticket ==")
 
-        accept_ticket_txid = self.nodes[acceptor_node].tickets("register", "accept", offer_ticket_txid, str(self.nft_copy_price),
+        ticket = self.tickets[TicketType.NFT]
+        ticket.accept_txid = self.nodes[acceptor_node].tickets("register", "accept", ticket.offer_txid, str(ticket.item_price),
                                            acceptor_pastelid1, self.passphrase)["txid"]
-        assert_true(accept_ticket_txid, "No Accept ticket was created")
+        assert_true(ticket.accept_txid, "No Accept ticket was created")
         self.__wait_for_ticket_tnx()
 
-        return accept_ticket_txid
 
     # ===============================================================================================================
-    def register_transfer_ticket(self, offerer_node, acceptor_node, acceptor_pastelid1, acceptor_address1,
-                                  offer_ticket_txid, accept_ticket_txid):
+    def register_transfer_ticket(self, offerer_node, acceptor_node, acceptor_pastelid1, acceptor_address1):
         print("== Create Transfer ticket ==")
 
-        cover_price = self.nft_copy_price + 10
+        ticket = self.tickets[TicketType.NFT]
+        transfer_ticket = self.tickets[TicketType.TRANSFER]
+        nft_price = ticket.item_price
+        cover_price = nft_price + 10
 
         # sends coins back, keep 1 PSL to cover transaction fee
         self.__send_coins_back(self.non_mn4)
         self.__wait_for_sync_all10()
 
-        coins_before = self.nodes[acceptor_node].getbalance()
-        print(coins_before)
-        assert_true(coins_before > 0 and coins_before < 1)
+        acceptor_coins_before = self.nodes[acceptor_node].getbalance()
+        print(acceptor_coins_before)
+        assert_true(acceptor_coins_before > 0 and acceptor_coins_before < 1)
 
         self.nodes[self.mining_node_num].sendtoaddress(acceptor_address1, cover_price, "", "", False)
         self.__wait_for_confirmation(acceptor_node)
 
-        coins_before = self.nodes[acceptor_node].getbalance()
-        print(coins_before)
+        acceptor_coins_before = self.nodes[acceptor_node].getbalance()
+        print(acceptor_coins_before)
 
-        offerer_pastel_id = self.nodes[offerer_node].tickets("get", offer_ticket_txid)["ticket"]["pastelID"]
+        offerer_pastel_id = self.nodes[offerer_node].tickets("get", ticket.offer_txid)["ticket"]["pastelID"]
         print(offerer_pastel_id)
         offerer_address = self.nodes[offerer_node].tickets("find", "id", offerer_pastel_id)["ticket"]["address"]
         print(offerer_address)
-        creators_coins_before = self.nodes[offerer_node].getreceivedbyaddress(offerer_address)
+        offerer_coins_before = self.nodes[offerer_node].getreceivedbyaddress(offerer_address)
 
         # consolidate funds into single address
         consaddress = self.nodes[acceptor_node].getnewaddress()
-        self.nodes[acceptor_node].sendtoaddress(consaddress, coins_before, "", "", True)
+        self.nodes[acceptor_node].sendtoaddress(consaddress, acceptor_coins_before, "", "", True)
 
-        transfer_ticket_txid = self.nodes[acceptor_node].tickets("register", "transfer", offer_ticket_txid, accept_ticket_txid,
+        ticket.transfer_txid = self.nodes[acceptor_node].tickets("register", "transfer", ticket.offer_txid, ticket.accept_txid,
                                            acceptor_pastelid1, self.passphrase)["txid"]
-        assert_true(transfer_ticket_txid, "No Transfer ticket was created")
-        self.__wait_for_ticket_tnx()
+        assert_true(ticket.transfer_txid, "No Transfer ticket was created")
+        self.__wait_for_ticket_tnx(10)
 
         # check correct amount of change and correct amount spent
-        coins_after = self.nodes[acceptor_node].getbalance()
-        print(coins_before)
-        print(coins_after)
-        # ticket cost is Transfer ticket price, NFT cost is nft_copy_price
-        assert_true(math.isclose(coins_after, coins_before - self.transfer_ticket_price - self.nft_copy_price, rel_tol=0.005))
+        acceptor_coins_after = self.nodes[acceptor_node].getbalance()
+        print(f"acceptor: {acceptor_coins_before} -> {acceptor_coins_after}")
+        # ticket cost is Transfer ticket price, NFT cost is nft_price
+        assert_true(math.isclose(acceptor_coins_after, acceptor_coins_before - transfer_ticket.ticket_price - nft_price, rel_tol=0.005))
 
-        # check current owner gets correct amount
-        creators_coins_after = self.nodes[self.non_mn3].getreceivedbyaddress(offerer_address)
-        print(creators_coins_before)
-        print(creators_coins_after)
-        assert_true(math.isclose(creators_coins_after - creators_coins_before, self.nft_copy_price, rel_tol=0.005))
+        # check that current owner gets correct amount
+        offerer_coins_after = self.nodes[offerer_node].getreceivedbyaddress(offerer_address)
+        print(f"offerer: {offerer_coins_before} -> {offerer_coins_after}")
+        offerer_coins_expected_to_receive = nft_price
+        if self.is_green: # green fee is 2% of item price
+            offerer_coins_expected_to_receive -= round(nft_price / 50)
+        assert_true(math.isclose(offerer_coins_after - offerer_coins_before, offerer_coins_expected_to_receive, rel_tol=0.005))
 
         # from another node - get ticket transaction and check
-        #   - there is 1 posiible output to current owner
-        transfer_ticket_hash = self.nodes[0].getrawtransaction(transfer_ticket_txid)
+        #   - there is 1 possible output to current owner
+        transfer_ticket_hash = self.nodes[0].getrawtransaction(ticket.transfer_txid)
         transfer_ticket_tx = self.nodes[0].decoderawtransaction(transfer_ticket_hash)
         offerer_amount = 0
         multi_fee = 0
@@ -671,15 +422,14 @@ class MasterNodeTicketsTest(MasterNodeCommon):
                 multi_fee += v["value"]
             if v["scriptPubKey"]["type"] == "pubkeyhash":
                 amount = v["value"]
-                print(f"transfer transiction pubkeyhash vout - {amount}")
+                print(f"transfer transaction pubkeyhash vout - {amount}")
                 if v["scriptPubKey"]["addresses"][0] == offerer_address:
                     offerer_amount = amount
                     print(f"transfer transaction to current owner's address - {amount}")
-        print(f"transfer transiction multisig fee_amount - {multi_fee}")
-        assert_true(math.isclose(offerer_amount, self.nft_copy_price))
-        assert_equal(multi_fee, self.id_ticket_price)
+        print(f"transfer transaction multisig fee_amount - {multi_fee}")
+        assert_true(math.isclose(offerer_amount, offerer_coins_expected_to_receive))
+        assert_equal(multi_fee, self.tickets[TicketType.ID].ticket_price)
 
-        return transfer_ticket_txid
 
     def __send_coins_back(self, node):
         coins_after = self.nodes[node].getbalance()
@@ -687,12 +437,14 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             mining_node_address1 = self.nodes[self.mining_node_num].getnewaddress()
             self.nodes[node].sendtoaddress(mining_node_address1, coins_after - 1, "", "", False)
 
-    def __wait_for_ticket_tnx(self):
+
+    def __wait_for_ticket_tnx(self, blocks: int = 5):
         time.sleep(10)
-        for x in range(5):
+        for _ in range(blocks):
             self.nodes[self.mining_node_num].generate(1)
             self.sync_all(10, 3)
         self.sync_all(10, 30)
+
 
     def __wait_for_sync_all(self, g = 1):
         time.sleep(2)
@@ -700,19 +452,21 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.nodes[self.mining_node_num].generate(g)
         self.sync_all()
 
-    def __wait_for_sync_all10(self):    
+
+    def __wait_for_sync_all10(self):
         time.sleep(2)
         self.sync_all(10, 30)
         self.nodes[self.mining_node_num].generate(1)
         self.sync_all(10, 30)
 
+
     def __wait_for_confirmation(self, node):
         print(f"block count - {self.nodes[node].getblockcount()}")
         time.sleep(2)
-        self.nodes[self.mining_node_num].generate(10)
+        self.generate_and_sync_inc(10, self.mining_node_num)
         time.sleep(2)
-        self.nodes[self.mining_node_num].generate(10)
         print(f"block count - {self.nodes[node].getblockcount()}")
+
 
 if __name__ == '__main__':
     MasterNodeTicketsTest().main()

--- a/qa/rpc-tests/mn_expiration.py
+++ b/qa/rpc-tests/mn_expiration.py
@@ -273,7 +273,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
         # fail if there is another Transfer ticket referring to that offer ticket
         assert_raises_rpc(rpc.RPC_MISC_ERROR,
-            "Transfer ticket already exists for the Offer ticket with this txid [{offer_ticket_txid}]",
+            f"Transfer ticket already exists for the Offer ticket with this txid [{offer_ticket2_txid}]",
             self.register_transfer_ticket,
             self.non_mn3, self.non_mn4, self.nonmn4_pastelid1, self.nonmn4_address1)
 
@@ -282,21 +282,21 @@ class MasterNodeTicketsTest(MasterNodeCommon):
                 f"The NFT you are trying to offer - from NFT Registration ticket [{ticket.act_txid}]"
                 " - is already offered - there are already [1] offered copies, "
                 "but only [1] copies were available",
-                self.register_offer_ticket, ticket.act_txid, 1)
+                self.register_offer_ticket, 1)
         elif self.total_copies == 2:
             # fail if not enough copies to offer
             assert_raises_rpc(rpc.RPC_MISC_ERROR,
                 "Invalid Offer ticket - copy number [3] cannot exceed the total number of available copies [2] or be 0",
-                self.register_offer_ticket, ticket.act_txid)
+                self.register_offer_ticket)
 
             assert_raises_rpc(rpc.RPC_MISC_ERROR,
-                f"Cannot replace Offer ticket - it has been already transferred, txid - [{ticket.offer_txid}] copyNumber [1]",
-                self.register_offer_ticket, ticket.act_txid, 1)
+                f"Cannot replace Offer ticket - it has been already transferred, txid - [{ticket.offer_txid}], copyNumber [1]",
+                self.register_offer_ticket, 1)
 
             # fail as the replace copy can be created after 5 days
             assert_raises_rpc(rpc.RPC_MISC_ERROR,
                 f"Can only replace Offer ticket after 5 days, txid - [{offer_ticket3_txid}] copyNumber [2]",
-                self.register_offer_ticket, ticket.act_txid, 2)
+                self.register_offer_ticket, 2)
 
 
     def register_nft_reg_ticket(self, label):
@@ -424,7 +424,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
                 amount = v["value"]
                 print(f"transfer transaction pubkeyhash vout - {amount}")
                 if v["scriptPubKey"]["addresses"][0] == offerer_address:
-                    offerer_amount = amount
+                    offerer_amount += amount
                     print(f"transfer transaction to current owner's address - {amount}")
         print(f"transfer transaction multisig fee_amount - {multi_fee}")
         assert_true(math.isclose(offerer_amount, offerer_coins_expected_to_receive))

--- a/qa/rpc-tests/mn_expiration.py
+++ b/qa/rpc-tests/mn_expiration.py
@@ -408,10 +408,11 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         offerer_coins_expected_to_receive = nft_price
         if self.is_green: # green fee is 2% of item price
             offerer_coins_expected_to_receive -= round(nft_price / 50)
+        print(f"Current owner is expected to receive {offerer_coins_expected_to_receive} PSL")
         assert_true(math.isclose(offerer_coins_after - offerer_coins_before, offerer_coins_expected_to_receive, rel_tol=0.005))
 
         # from another node - get ticket transaction and check
-        #   - there is 1 possible output to current owner
+        #   - there are 2 possible outputs to current owner
         transfer_ticket_hash = self.nodes[0].getrawtransaction(ticket.transfer_txid)
         transfer_ticket_tx = self.nodes[0].decoderawtransaction(transfer_ticket_hash)
         offerer_amount = 0
@@ -427,7 +428,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
                     offerer_amount += amount
                     print(f"transfer transaction to current owner's address - {amount}")
         print(f"transfer transaction multisig fee_amount - {multi_fee}")
-        assert_true(math.isclose(offerer_amount, offerer_coins_expected_to_receive))
+        assert_true(math.isclose(offerer_amount, offerer_coins_expected_to_receive, rel_tol=0.005))
         assert_equal(multi_fee, self.tickets[TicketType.ID].ticket_price)
 
 

--- a/qa/rpc-tests/mn_main.py
+++ b/qa/rpc-tests/mn_main.py
@@ -21,14 +21,17 @@ import test_framework.rpc_consts as rpc
 
 getcontext().prec = 16
 
-
 class MasterNodeMainTest (MasterNodeCommon):
-    number_of_master_nodes = 1
-    number_of_simple_nodes = 2
-    total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
-    cold_node_num = 0       # master node
-    mining_node_num = 1     # mining node
-    hot_node_num = 2        # keeps all collateral for MNs
+
+    def __init__(self):
+        super().__init__()
+
+        self.number_of_master_nodes = 1
+        self.number_of_simple_nodes = 2
+        self.number_of_cold_nodes = self.number_of_master_nodes
+        self.cold_node_num = 0       # master node
+        self.mining_node_num = 1     # mining node
+        self.hot_node_num = 2        # keeps all collateral for MNs
 
     def setup_chain(self):
         print(f"Initializing test directory {self.options.tmpdir}")
@@ -37,8 +40,7 @@ class MasterNodeMainTest (MasterNodeCommon):
     def setup_network(self, split=False):
         self.nodes = []
         self.is_network_split = False
-        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
-            self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
+        self.setup_masternodes_network(self.mining_node_num, self.hot_node_num)
 
 
     def storagefee_tests (self):

--- a/qa/rpc-tests/mn_messaging.py
+++ b/qa/rpc-tests/mn_messaging.py
@@ -11,18 +11,22 @@ from mn_common import MasterNodeCommon
 getcontext().prec = 16
 
 class MasterNodeMessagingTest(MasterNodeCommon):
-    number_of_master_nodes = 4
-    number_of_simple_nodes = 3
-    total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
 
-    non_active_mn = number_of_master_nodes-1
+    def __init__(self):
+        super().__init__()
+        self.number_of_master_nodes = 4
+        self.number_of_simple_nodes = 3
+        self.number_of_cold_nodes = self.number_of_master_nodes
 
-    non_mn1 = number_of_master_nodes        # mining node - will have coins #13
-    non_mn2 = number_of_master_nodes+1      # hot node - will have collateral for all active MN #14
-    non_mn3 = number_of_master_nodes+2      # will not have coins by default #15
+        self.non_active_mn = self.number_of_master_nodes - 1
 
-    mining_node_num = number_of_master_nodes    # same as non_mn1
-    hot_node_num = number_of_master_nodes+1     # same as non_mn2
+        self.non_mn1 = self.number_of_master_nodes          # mining node - will have coins #13
+        self.non_mn2 = self.number_of_master_nodes+1        # hot node - will have collateral for all active MN #14
+        self.non_mn3 = self.number_of_master_nodes+2        # will not have coins by default #15
+
+        self.mining_node_num = self.number_of_master_nodes  # same as non_mn1
+        self.hot_node_num = self.number_of_master_nodes+1   # same as non_mn2
+
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -31,8 +35,7 @@ class MasterNodeMessagingTest(MasterNodeCommon):
     def setup_network(self, split=False):
         self.nodes = []
         self.is_network_split = False
-        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
-            self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
+        self.setup_masternodes_network(self.mining_node_num, self.hot_node_num)
         
 
     def run_test(self):

--- a/qa/rpc-tests/mn_payment.py
+++ b/qa/rpc-tests/mn_payment.py
@@ -15,11 +15,16 @@ from mn_common import MasterNodeCommon
 getcontext().prec = 16
 
 class MasterNodePaymentTest (MasterNodeCommon):
-    number_of_master_nodes = 12
-    number_of_simple_nodes = 2
-    total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
-    mining_node_num = number_of_master_nodes
-    hot_node_num = number_of_master_nodes+1
+
+    def __init__(self):
+        super().__init__()
+
+        self.number_of_master_nodes = 12
+        self.number_of_simple_nodes = 2
+        self.number_of_cold_nodes = self.number_of_master_nodes
+        self.mining_node_num = self.number_of_master_nodes
+        self.hot_node_num = self.number_of_master_nodes + 1
+
 
     def setup_chain(self):
         print("Initializing test directory "+self.options.tmpdir)
@@ -28,8 +33,7 @@ class MasterNodePaymentTest (MasterNodeCommon):
     def setup_network(self, split=False):
         self.nodes = []
         self.is_network_split = False
-        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
-            self.mining_node_num, self.hot_node_num, self.number_of_master_nodes)
+        self.setup_masternodes_network(self.mining_node_num, self.hot_node_num)
 
     def run_test (self):
         start_block = self.nodes[0].getinfo()["blocks"]

--- a/qa/rpc-tests/mn_tickets_validation.py
+++ b/qa/rpc-tests/mn_tickets_validation.py
@@ -25,20 +25,21 @@ getcontext().prec = 16
 
 
 class MasterNodeTicketsTest(MasterNodeCommon):
-    number_of_master_nodes = 12
-    number_of_simple_nodes = 3
-    total_number_of_nodes = number_of_master_nodes+number_of_simple_nodes
-
-    non_mn1 = number_of_master_nodes        # mining node - will have coins #12
-    non_mn2 = number_of_master_nodes+1      # hot node - will have collateral for all active MN #13
-    non_mn3 = number_of_master_nodes+2      # will not have coins by default #1
-
-    mining_node_num = number_of_master_nodes    # same as non_mn1
-    hot_node_num = number_of_master_nodes+1     # same as non_mn2
 
     def __init__(self):
         super().__init__()
         
+        self.number_of_master_nodes = 12
+        self.number_of_simple_nodes = 3
+        self.number_of_cold_nodes = self.number_of_master_nodes
+
+        self.non_mn1 = self.number_of_master_nodes        # mining node - will have coins #12
+        self.non_mn2 = self.number_of_master_nodes+1      # hot node - will have collateral for all active MN #13
+        self.non_mn3 = self.number_of_master_nodes+2      # will not have coins by default #1
+
+        self.mining_node_num = self.number_of_master_nodes    # same as non_mn1
+        self.hot_node_num = self.number_of_master_nodes+1     # same as non_mn2
+
         self.errorString = ""
         self.is_network_split = False
         self.nodes = []
@@ -46,8 +47,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.storage_fee90percent = self.storage_fee*9/10
 
         self.mn_ticket_signatures = {}
-        self.mn_outpoints = {}
-
+ 
         self.nonmn1_pastelid1 = None
         self.creator_pastelid1 = None
         self.non_mn1_pastelid_txid = None
@@ -56,9 +56,6 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.top_mns = [TopMN(i) for i in range(3)]
         # list of 3 non-TopMNs
         self.non_top_mns = [TopMN(i) for i in range(3)]
-
-        self.signatures_dict = None
-        self.not_top_mns_signatures_dict = None
 
         self.ticket = None
         self.creator_ticket_height = None
@@ -69,12 +66,10 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         print(f"Initializing test directory {self.options.tmpdir}")
         initialize_chain_clean(self.options.tmpdir, self.total_number_of_nodes)
 
+
     def setup_network(self, split=False):
-        self.setup_masternodes_network(self.number_of_master_nodes, self.number_of_simple_nodes,
-            self.mining_node_num, self.hot_node_num)
-        for n in range(self.number_of_master_nodes):
-            mn = self.mn_nodes[n]
-            self.mn_outpoints[mn.collateral_id] = n
+        self.setup_masternodes_network(self.mining_node_num, self.hot_node_num)
+
 
     def run_test(self):
         self.mn0_address1 = self.nodes[0].getnewaddress()

--- a/qa/rpc-tests/pastel_test_framework.py
+++ b/qa/rpc-tests/pastel_test_framework.py
@@ -209,6 +209,7 @@ class PastelTestFramework (BitcoinTestFramework):
         self._accept_counters = {}
         self._transfer_counters = {}
 
+
     def ticket_counter(self, ticket_type: TicketType) -> int:
         """Get counter for registered tickets of the given type.
 
@@ -223,6 +224,7 @@ class PastelTestFramework (BitcoinTestFramework):
         else:
             return 0
 
+
     def _get_add_counter(self, ticket_type: TicketType):
         counters = None
         if ticket_type == TicketType.OFFER:
@@ -232,6 +234,7 @@ class PastelTestFramework (BitcoinTestFramework):
         elif ticket_type == TicketType.TRANSFER:
             counters = self._transfer_counters
         return counters
+
 
     def offer_counter(self, item_type: TicketType) -> int:
         """Get number of offers for the given item type.
@@ -247,6 +250,7 @@ class PastelTestFramework (BitcoinTestFramework):
         else:
             return 0
 
+
     def accept_counter(self, item_type: TicketType) -> int:
         """Get number of accepts for the given item type.
 
@@ -261,6 +265,7 @@ class PastelTestFramework (BitcoinTestFramework):
         else:
             return 0
 
+
     def transfer_counter(self, item_type: TicketType) -> int:
         """Get number of transfers for the given item type.
 
@@ -274,6 +279,7 @@ class PastelTestFramework (BitcoinTestFramework):
             return self._transfer_counters[item_type]
         else:
             return 0
+
 
     def inc_ticket_counter(self, ticket_type: TicketType, count: int = 1, item_type: TicketType = None):
         """Increase counter for the given ticket type.
@@ -297,6 +303,7 @@ class PastelTestFramework (BitcoinTestFramework):
             else:
                 counters[item_type] = count
             print(f"{ticket_type} tickets for {item_type.description}: {counters[item_type]}")
+
 
     def list_all_ticket_counters(self):
         """List all ticket counters.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -353,7 +353,8 @@ public:
         pchMessageStart[3] = 0xfc;
         vAlertPubKey = ParseHex("0441f3821b035bc418b8fbe8e912005112826a5c51fdcf5fbac6d7dd2ab545183049e51c3f2ed2a70b1e48a59b4c3367c15d30fbff461afc6b83932fefedfe5d41");
         nDefaultPort = MAINNET_DEFAULT_PORT;
-        nPruneAfterHeight = 100'000;
+        m_nPruneAfterHeight = 100'000;
+        m_nOfferReplacementAllowedBlocks = 2'880;
         const size_t N = 200, K = 9;
         static_assert(equihash_parameters_acceptable(N, K));
         consensus.nEquihashN = N;
@@ -461,7 +462,8 @@ public:
         pchMessageStart[3] = 0x64;
         vAlertPubKey = ParseHex("0429aff40718031ed61f0166f3e33b5dfb256c78cdbfa916bf6cc9869a40ce1d66ca35b92fe874bd18b69457ecef27bc3a0f089b737b03fb889dc1420b6a6e70cb");
         nDefaultPort = TESTNET_DEFAULT_PORT;
-        nPruneAfterHeight = 1000;
+        m_nPruneAfterHeight = 1000;
+        m_nOfferReplacementAllowedBlocks = 2'880;
         const size_t N = 200, K = 9;
         static_assert(equihash_parameters_acceptable(N, K));
         consensus.nEquihashN = N;
@@ -565,7 +567,8 @@ public:
         //vAlertPubKey = ParseHex("04b985ccafe6d17ac5d84cb8c06a69cefad733ee96b4b93bcf5ef0897778c227ee7e74e7680cc219236e4c6a609dbcdeb5bf65cea9c2576c2a0fbef590657c8e7a");
         vAlertPubKey = ParseHex("04d8a5b9bf6ef2396204fc879d370c85b3ccd665b6a06b9600165ceed4233ca38d27010abd3b6e607b46663ce21e8473df0e30f1bf7e425a3bdd58d2a6d1bb2049");
         nDefaultPort = REGTEST_DEFAULT_PORT;
-        nPruneAfterHeight = 1000;
+        m_nPruneAfterHeight = 1000;
+        m_nOfferReplacementAllowedBlocks = 288;
         const size_t N = 48, K = 5;
         static_assert(equihash_parameters_acceptable(N, K));
         consensus.nEquihashN = N;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -78,7 +78,8 @@ public:
     bool DefaultConsistencyChecks() const noexcept { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
     bool RequireStandard() const noexcept { return fRequireStandard; }
-    int64_t PruneAfterHeight() const noexcept { return nPruneAfterHeight; }
+    int64_t PruneAfterHeight() const noexcept { return m_nPruneAfterHeight; }
+    uint32_t getOfferReplacementAllowedBlocks() const noexcept { return m_nOfferReplacementAllowedBlocks; }
     std::string CurrencyUnits() const noexcept { return strCurrencyUnits; }
     uint32_t BIP44CoinType() const noexcept { return bip44CoinType; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
@@ -113,7 +114,8 @@ protected:
     //! Raw pub key bytes for the broadcast alert signing key.
     v_uint8 vAlertPubKey;
     int nDefaultPort = 0;
-    uint64_t nPruneAfterHeight = 0;
+    uint64_t m_nPruneAfterHeight = 0;
+    uint32_t m_nOfferReplacementAllowedBlocks = 0;
     std::vector<CDNSSeedData> vSeeds;
     std::string strNetworkID;
     std::string strCurrencyUnits;

--- a/src/mnode/mnode-active.cpp
+++ b/src/mnode/mnode-active.cpp
@@ -97,7 +97,7 @@ bool CActiveMasternode::SendMasternodePing()
         return false;
     }
 
-    CMasternodePing mnp(outpoint);
+    CMasterNodePing mnp(outpoint);
     if (!mnp.Sign(keyMasternode, pubKeyMasternode))
     {
         LogFnPrintf("ERROR: Couldn't sign Masternode Ping");
@@ -105,7 +105,7 @@ bool CActiveMasternode::SendMasternodePing()
     }
 
     // Update lastPing for our masternode in Masternode list
-    if (masterNodeCtrl.masternodeManager.IsMasternodePingedWithin(outpoint, masterNodeCtrl.MasternodeMinMNPSeconds, mnp.sigTime))
+    if (masterNodeCtrl.masternodeManager.IsMasternodePingedWithin(outpoint, masterNodeCtrl.MasternodeMinMNPSeconds, mnp.getSigTime()))
     {
         LogFnPrintf("Too early to send Masternode Ping");
         return false;

--- a/src/mnode/mnode-config.h
+++ b/src/mnode/mnode-config.h
@@ -55,7 +55,7 @@ public:
             COutPoint getOutPoint() const noexcept;
     };
 
-    CMasternodeConfig() noexcept = default;
+    CMasternodeConfig() noexcept {}
 
     bool read(std::string& strErr, const bool bNewOnly = false);
 

--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -53,7 +53,7 @@ void CMasterNodeController::InvalidateParameters()
     MasternodeNewStartRequiredSeconds = 0;
     MNStartRequiredExpirationTime = 0;
 
-    MasternodePOSEBanMaxScore = 0;
+    m_nMasternodePOSEBanMaxScore = 0;
     nMasterNodeMaximumOutboundConnections = 0;
 
     nMasternodePaymentsVotersIndexDelta = 0;
@@ -101,7 +101,9 @@ void CMasterNodeController::SetParameters()
     MasternodeNewStartRequiredSeconds   = 180 * 60;
     MNStartRequiredExpirationTime             = 7 * 24 * 60 * 60;
 
-    MasternodePOSEBanMaxScore           = 5;
+    // MasterNode PoSe (Proof of Service) Max Ban Score
+    m_nMasternodePOSEBanMaxScore           = 5;
+
     nMasterNodeMaximumOutboundConnections = 20;
 
     nMasternodePaymentsVotersIndexDelta = -101;
@@ -262,16 +264,16 @@ bool CMasterNodeController::EnableMasterNode(ostringstream& strErrors, CServiceT
     }
 
     // NOTE: Masternode should have no wallet
-    fMasterNode = GetBoolArg("-masternode", false);
+    m_fMasterNode = GetBoolArg("-masternode", false);
 
-    if ((fMasterNode || masternodeConfig.getCount() > 0) && !fTxIndex)
+    if ((m_fMasterNode || masternodeConfig.getCount() > 0) && !fTxIndex)
     {
         strErrors << _("Enabling Masternode support requires turning on transaction indexing.")
                 << _("Please add txindex=1 to your configuration and start with -reindex");
         return false;
     }
 
-    if (fMasterNode)
+    if (m_fMasterNode)
     {
         LogPrintf("MASTERNODE:\n");
 
@@ -589,7 +591,7 @@ fs::path CMasterNodeController::GetMasternodeConfigFile()
 CAmount CMasterNodeController::GetNetworkFeePerMB() const noexcept
 {
     CAmount nFee = masterNodeCtrl.MasternodeFeePerMBDefault;
-    if (fMasterNode)
+    if (m_fMasterNode)
     {
         // COutPoint => CMasternode
         const auto mapMasternodes = masternodeManager.GetFullMasternodeMap();
@@ -608,7 +610,7 @@ CAmount CMasterNodeController::GetNetworkFeePerMB() const noexcept
 
 CAmount CMasterNodeController::GetNFTTicketFeePerKB() const noexcept
 {
-    if (fMasterNode)
+    if (m_fMasterNode)
     {
         CAmount nFee = 0;
         // COutPoint => CMasternode

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -81,7 +81,7 @@ public:
     // Keep track of all broadcasts I've seen
     std::map<uint256, std::pair<int64_t, CMasternodeBroadcast> > mapSeenMasternodeBroadcast;
     // Keep track of all pings I've seen
-    std::map<uint256, CMasternodePing> mapSeenMasternodePing;
+    std::map<uint256, CMasterNodePing> mapSeenMasternodePing;
     // Keep track of all verifications I've seen
     std::map<uint256, CMasternodeVerification> mapSeenMasternodeVerification;
 
@@ -204,9 +204,10 @@ public:
     void CheckMasternode(const CPubKey& pubKeyMasternode, bool fForce);
 
     bool IsMasternodePingedWithin(const COutPoint& outpoint, int nSeconds, int64_t nTimeToCheckAt = -1);
-    void SetMasternodeLastPing(const COutPoint& outpoint, const CMasternodePing& mnp);
+    void SetMasternodeLastPing(const COutPoint& outpoint, const CMasterNodePing& mnp);
 
     void SetMasternodeFee(const COutPoint& outpoint, const CAmount newFee);
+    void IncrementMasterNodePoSeBanScore(const COutPoint& outpoint);
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
     

--- a/src/mnode/mnode-payments.cpp
+++ b/src/mnode/mnode-payments.cpp
@@ -593,7 +593,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
         return false;
     }
 
-    LogFnPrintf("Masternode found by GetNextMasternodeInQueueForPayment(): %s", mnInfo.vin.prevout.ToStringShort());
+    LogFnPrintf("Masternode found by GetNextMasternodeInQueueForPayment(): %s", mnInfo.GetDesc());
 
 
     CScript payee = GetScriptForDestination(mnInfo.pubKeyCollateralAddress.GetID());
@@ -669,7 +669,7 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
 
         if (!found)
         {
-            debugStr += strprintf("%s - no vote received; ", mn.second.vin.prevout.ToStringShort());
+            debugStr += strprintf("%s - no vote received; ", mn.second.GetDesc());
             mapMasternodesDidNotVote[mn.second.vin.prevout]++;
             continue;
         }
@@ -679,7 +679,7 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
         ExtractDestination(payee, dest);
         string address = keyIO.EncodeDestination(dest);
 
-        debugStr += strprintf("%s - voted for %s; ", mn.second.vin.prevout.ToStringShort(), address);
+        debugStr += strprintf("%s - voted for %s; ", mn.second.GetDesc(), address);
     }
     debugStr += "Masternodes which missed a vote in the past:\n";
     for (const auto &[outpoint, count] : mapMasternodesDidNotVote)

--- a/src/mnode/mnode-validation.h
+++ b/src/mnode/mnode-validation.h
@@ -18,8 +18,8 @@ int GetUTXOConfirmations(const COutPoint& outpoint);
 void FillOtherBlockPayments(CMutableTransaction& txNew, int nBlockHeight, CAmount blockReward, CTxOut& txoutMasternodeRet, CTxOut& txoutGovernanceRet);
 
 #ifdef ENABLE_WALLET
-    bool GetMasternodeOutpointAndKeys(CWallet* pwalletMain, std::string &error, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash, std::string strOutputIndex);
-    bool GetOutpointAndKeysFromOutput(CWallet* pwalletMain, std::string &error, const COutput& out, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet);
+bool GetMasternodeOutpointAndKeys(CWallet* pwalletMain, std::string &error, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash, std::string strOutputIndex);
+bool GetOutpointAndKeysFromOutput(CWallet* pwalletMain, std::string &error, const COutput& out, COutPoint& outpointRet, CPubKey& pubKeyRet, CKey& keyRet);
 #endif
 
 bool IsBlockValid(const Consensus::Params& consensusParams, 

--- a/src/mnode/rpc/masternodebroadcast.cpp
+++ b/src/mnode/rpc/masternodebroadcast.cpp
@@ -196,7 +196,7 @@ Examples:
 
             if (mnb.CheckSignature(nDos)) {
                 nSuccessful++;
-                resultObj.pushKV("outpoint", mnb.vin.prevout.ToStringShort());
+                resultObj.pushKV("outpoint", mnb.GetDesc());
                 resultObj.pushKV("addr", mnb.addr.ToString());
 
                 CTxDestination dest1 = mnb.pubKeyCollateralAddress.GetID();
@@ -212,10 +212,11 @@ Examples:
                 resultObj.pushKV("protocolVersion", mnb.nProtocolVersion);
 
                 UniValue lastPingObj(UniValue::VOBJ);
-                lastPingObj.pushKV("outpoint", mnb.lastPing.vin.prevout.ToStringShort());
-                lastPingObj.pushKV("blockHash", mnb.lastPing.blockHash.ToString());
-                lastPingObj.pushKV("sigTime", mnb.lastPing.sigTime);
-                lastPingObj.pushKV("vchSig", EncodeBase64(&mnb.lastPing.vchSig[0], mnb.lastPing.vchSig.size()));
+                const auto& lastPing = mnb.getLastPing();
+                lastPingObj.pushKV("outpoint", lastPing.GetDesc());
+                lastPingObj.pushKV("blockHash", lastPing.getBlockHashString());
+                lastPingObj.pushKV("sigTime", lastPing.getSigTime());
+                lastPingObj.pushKV("vchSig", lastPing.getEncodedBase64Signature());
 
                 resultObj.pushKV("lastPing", lastPingObj);
             } else {
@@ -255,7 +256,7 @@ Arguments:
         for (auto& mnb : vecMnb) {
             UniValue resultObj(UniValue::VOBJ);
 
-            resultObj.pushKV("outpoint", mnb.vin.prevout.ToStringShort());
+            resultObj.pushKV("outpoint", mnb.GetDesc());
             resultObj.pushKV("addr", mnb.addr.ToString());
 
             int nDos = 0;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -237,6 +237,7 @@ public:
     {}
 
     std::string ToString() const;
+    // returns outpoint in short form txid-index
     std::string ToStringShort() const;
 };
 

--- a/src/rpc/rpc_parser.h
+++ b/src/rpc/rpc_parser.h
@@ -36,6 +36,8 @@ public:
 
     // returns rpc command (enumeration type)
     RPC_CMD_ENUM cmd() const noexcept { return m_Cmd; }
+    // returns string representation of the rpc command 
+    std::string getCmdStr() const noexcept { return m_sCmd; }
     // returns true if command is supported
     bool IsCmdSupported() const noexcept { return m_Cmd != RPC_CMD_ENUM::unknown; }
     // returns true if cmd was passed

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -4,12 +4,13 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <cinttypes>
 
-#include "timedata.h"
-#include "netbase.h"
-#include "sync.h"
-#include "ui_interface.h"
-#include "util.h"
-#include "utilstrencodings.h"
+#include <timedata.h>
+#include <netbase.h>
+#include <sync.h>
+#include <ui_interface.h>
+#include <util.h>
+#include <utilstrencodings.h>
+
 using namespace std;
 
 static CCriticalSection cs_nTimeOffset;
@@ -38,20 +39,20 @@ static int64_t abs64(int64_t n)
     return (n >= 0 ? n : -n);
 }
 
-#define BITCOIN_TIMEDATA_MAX_SAMPLES 200
+constexpr size_t PASTEL_TIMEDATA_MAX_SAMPLES = 200;
 
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
 {
     LOCK(cs_nTimeOffset);
     // Ignore duplicates
     static set<CNetAddr> setKnown;
-    if (setKnown.size() == BITCOIN_TIMEDATA_MAX_SAMPLES)
+    if (setKnown.size() == PASTEL_TIMEDATA_MAX_SAMPLES)
         return;
     if (!setKnown.insert(ip).second)
         return;
 
     // Add data
-    static CMedianFilter<int64_t> vTimeOffsets(BITCOIN_TIMEDATA_MAX_SAMPLES, 0);
+    static CMedianFilter<int64_t> vTimeOffsets(PASTEL_TIMEDATA_MAX_SAMPLES, 0);
     vTimeOffsets.input(nOffsetSample);
     LogPrintf("Added time data, samples %zu, offset %+" PRId64 " (%+" PRId64 " minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
 

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -67,7 +67,7 @@ void base_blob<BITS>::SetHex(const string& str)
 template <unsigned int BITS>
 string base_blob<BITS>::ToString() const
 {
-    return (GetHex());
+    return GetHex();
 }
 
 // Explicit instantiations for base_blob<160>


### PR DESCRIPTION
Added new API for PoSe (Proof-of-Service) Ban score management:
    masternode pose-ban-score [get|increment] "txid" index
RPC API parameters validations:
  - txid is valid and can be converted to uint256
  - index is valid integer
  - MN with the given outpoint exists
  - exception handling Changed mn_expiration.py:
 - use new MasterNode, TopMN classes and new MasterNode initialization with mnid registration
 - moved some functions from mn_expiration.py & mn_tickets.py to mn_common.py to get rid of duplicate code
 - fixed amounts calculation for NFT transfers (royalty, green fees)
 - found and fixed an issue in pasteld with offer ticket replacement validation
 - use different number of blocks to allow offer ticket replacement for regtest (288), mainnet, testnet (2880, 5 days)
 - added tests for the new PoSe ban score APIs:
    - get score
    - increment ban score till mn is banned - check that mn will be unbanned after pose-ban-height is reached
 - added mn_expiration.py to the MN tests group to test it in CircleCI build - won't increase total build time because test groups now run in parallel