### PR TITLE
[PSL-450] Use MN's collateral outpoint to find MN Pastel ID

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -114,11 +114,7 @@ declare -a testScriptsMN=(
     'mn_payment.py'
     'mn_bugs.py'
     'mn_expiration.py'
-)
-
-declare -a testScriptsMNslow=(
     'mn_main.py'
-    'mn_tickets.py'
 )
 
 declare -a testScriptsMNdisabled=(

--- a/qa/rpc-tests/mn_common.py
+++ b/qa/rpc-tests/mn_common.py
@@ -13,6 +13,7 @@ from decimal import getcontext
 from test_framework.util import (
     assert_true,
     assert_equal,
+    assert_greater_than,
     start_node,
     connect_nodes_bi,
     p2p_port,
@@ -177,6 +178,7 @@ class MasterNodeCommon (PastelTestFramework):
         
         # list of 3 TopMNs
         self.top_mns = [TopMN(i) for i in range(3)]
+        self.non_top_mns = []
         
         self.signatures_dict = None
         self.same_mns_signatures_dict = None
@@ -282,7 +284,7 @@ class MasterNodeCommon (PastelTestFramework):
 
         # prepare parameters and create masternode.conf for all masternodes
         outputs = self.nodes[hot_node_num].masternode("outputs")
-        print(f"hot node{hot_node_num} collateral outputs\n{outputs}")
+        print(f"hot node{hot_node_num} collateral outputs\n{json.dumps(outputs, indent=4)}")
         for mn in self.mn_nodes:
             # get the collateral outpoint indexes
             if mn.index < self.number_of_cold_nodes:
@@ -465,12 +467,13 @@ class MasterNodeCommon (PastelTestFramework):
         [assert_equal(node.masternode("list").get(collateral_id, ""), wait_for_state) for node in node_list]
 
 
-    def update_mn_indexes(self, node_num = 0, height = -1):
+    def update_mn_indexes(self, node_num: int = 0, height: int = -1, number_of_top_mns: int = 3):
         """Get historical information about top MNs at given height.
 
         Args:
             nodeNum (int, optional): Use this node to get info. Defaults to 0 (mn0).
             height (int, optional): Get historical info at this height. Defaults to -1 (current blockchain height).
+            number_of_top_mns (int, optional): Number of top mns to return. Defaults to 3.
 
         Returns:
             list(): list of top mn indexes
@@ -481,17 +484,20 @@ class MasterNodeCommon (PastelTestFramework):
         else:
             creator_height = height
         top_masternodes = self.nodes[node_num].masternode("top", creator_height)[str(creator_height)]
-        print(f"top_masternodes ({creator_height}) - {top_masternodes}")
+        print(f"top masternodes for height {creator_height}:\n{json.dumps(top_masternodes, indent=4)}")
+        assert_greater_than(len(top_masternodes), number_of_top_mns)
 
         top_mns_indexes = []
         for mn in top_masternodes:
             index = self.mn_outpoints[mn["outpoint"]]
             top_mns_indexes.append(index)
 
-        for i in range(3):
+        self.top_mns = []
+        for i in range(number_of_top_mns):
             idx = top_mns_indexes[i]
-            self.top_mns[i] = TopMN(idx, self.get_mnid(idx))
-            print(f"TopMN[{i}]: {self.top_mns[i]!r}")
+            top_mn = TopMN(idx, self.get_mnid(idx))
+            self.top_mns.append(top_mn)
+            print(f"TopMN[{i}]: {top_mn!r}")
 
         return top_mns_indexes
 

--- a/qa/rpc-tests/mn_common.py
+++ b/qa/rpc-tests/mn_common.py
@@ -148,7 +148,6 @@ class MasterNodeCommon (PastelTestFramework):
             config[name]["outIndex"] = str(self.collateral_index)
             config[name]["extAddress"] = f"127.0.0.1:{random.randint(2000, 5000)}"
             config[name]["extP2P"] = f"127.0.0.1:{random.randint(22000, 25000)}"
-            config[name]["extKey"] = self.mnid if self.mnid else ""
             config[name]["extCfg"] = {}
             config[name]["extCfg"]["param1"] = str(random.randint(0, 9))
             config[name]["extCfg"]["param2"] = str(random.randint(0, 9))
@@ -332,6 +331,7 @@ class MasterNodeCommon (PastelTestFramework):
                 mn.create_masternode_conf(self.options.tmpdir, hot_node_num)
             self.generate_and_sync_inc(1, mining_node_num)
 
+            # send "masternode start-alias <alias>" for all cold nodes
             for mn in self.mn_nodes:
                 if mn.index >= self.number_of_cold_nodes:
                     continue
@@ -381,7 +381,7 @@ class MasterNodeCommon (PastelTestFramework):
         self.sync_all()
         timer.stop()
         print(f"<<<< MasterNode network INITIALIZED in {timer.elapsed_time} secs >>>>")
-        self.list_masternode_info()      
+        self.list_masternode_info()
 
 
     def list_masternode_info(self):

--- a/qa/rpc-tests/mn_main.py
+++ b/qa/rpc-tests/mn_main.py
@@ -120,7 +120,6 @@ class MasterNodeMainTest (MasterNodeCommon):
             print(f"Starting node {new_node_no}...")
             self.nodes.append(start_node(new_node_no, self.options.tmpdir, ["-debug=masternode"]))
             self.reconnect_node(new_node_no)
-            self.total_number_of_nodes = len(self.nodes)
             self.sync_all()
 
             print(f"Waiting for {mn.alias} ENABLED state...")

--- a/qa/rpc-tests/mn_tickets_validation.py
+++ b/qa/rpc-tests/mn_tickets_validation.py
@@ -52,11 +52,6 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         self.creator_pastelid1 = None
         self.non_mn1_pastelid_txid = None
 
-        # list of 3 TopMNs
-        self.top_mns = [TopMN(i) for i in range(3)]
-        # list of 3 non-TopMNs
-        self.non_top_mns = [TopMN(i) for i in range(3)]
-
         self.ticket = None
         self.creator_ticket_height = None
         self.nft_ticket1_txid = None
@@ -172,31 +167,20 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         print(self.ticket)
 
         # create ticket signature
-        self.nodes[self.non_mn1].pastelid("sign", self.ticket, self.nonmn1_pastelid1, self.passphrase)["signature"]
         ticket_signature_creator = self.nodes[self.non_mn3].pastelid("sign", self.ticket, self.creator_pastelid1, self.passphrase)["signature"]
         for n in range(self.number_of_master_nodes):
             mn = self.mn_nodes[n]
             self.mn_ticket_signatures[n] = self.nodes[n].pastelid("sign", self.ticket, mn.mnid, self.passphrase)["signature"]
 
-        top_mns_indexes = set()
-        for top_mn in top_masternodes:
-            index = self.mn_outpoints[top_mn["outpoint"]]
-            top_mns_indexes.add(index)
-        print(f"top_mns_indexes: {top_mns_indexes}")
-            
-        for i in range(3):
-            idx = top_mns_indexes.pop()
-            top_mn = TopMN(idx, self.mn_nodes[idx].mnid)
-            self.top_mns[i] = top_mn
-            top_mn.signature = self.mn_ticket_signatures[idx]
-            print(f"TopMN[{i}]: {top_mn!r}")
-            
-        for i in range(3):
-            idx = top_mns_indexes.pop()
-            non_top_mn = TopMN(idx, self.mn_nodes[idx].mnid)
-            self.non_top_mns[i] = non_top_mn
-            non_top_mn.signature = self.mn_ticket_signatures[idx]
-            print(f"NonTopMN[{i}]: {non_top_mn!r}")
+        self.update_mn_indexes(0, -1, 6)
+        # define signatures
+        for top_mn in self.top_mns:
+            top_mn.signature = self.mn_ticket_signatures[top_mn.index]
+        # slice top_mns into 2 lists:
+        #   1) top_mns[0, 1, 2]
+        #   2) non_top_mns[3, 4, 5]
+        self.non_top_mns = self.top_mns[3:6]
+        self.top_mns = self.top_mns[0:3]
 
         self.signatures_dict = dict(
             {

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -329,7 +329,7 @@ int printMetrics(size_t cols, bool mining)
         {
             LOCK2(cs_main, cs_metrics);
             boost::strict_lock_ptr<list<uint256>> u = trackedBlocks.synchronize();
-            auto consensusParams = Params().GetConsensus();
+            const auto &consensusParams = Params().GetConsensus();
             auto tipHeight = chainActive.Height();
 
             // Update orphans and calculate subsidies

--- a/src/mnode/mnode-active.cpp
+++ b/src/mnode/mnode-active.cpp
@@ -238,7 +238,7 @@ void CActiveMasternode::ManageStateRemote()
             LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
-        if (!Params().IsRegTest() && service != infoMn.addr)
+        if (!Params().IsRegTest() && service != infoMn.get_addr())
         {
             nState = ActiveMasternodeState::NotCapable;
             strNotCapableReason = "Broadcasted IP doesn't match our external address. Make sure you issued a new broadcast if IP of this masternode changed recently.";
@@ -255,13 +255,13 @@ void CActiveMasternode::ManageStateRemote()
         if (!IsStarted())
         {
             // can assign outpoint - will be used to register mnid
-            outpoint = infoMn.vin.prevout;
+            outpoint = infoMn.getOutPoint();
 
             // mnid should be registered to  set 'Started' status
-            if (!CheckMnId(infoMn.vin.prevout))
+            if (!CheckMnId(infoMn.getOutPoint()))
                 return;
             LogFnPrintf("STARTED!");
-            service = infoMn.addr;
+            service = infoMn.get_addr();
             fPingerEnabled = true;
             nState = ActiveMasternodeState::Started;
         }

--- a/src/mnode/mnode-config.cpp
+++ b/src/mnode/mnode-config.cpp
@@ -23,13 +23,12 @@ using namespace std;
         "mn1": {                                 // alias
             "mnAddress": "10.10.10.10:1111",     // MN's ip and port
             "mnPrivKey": "",                     // MN's private key
-            "txid": "",                          // collateral_output_txid
-            "outIndex": "",                      // collateral_output_index
+            "txid": "",                          // collateral output txid
+            "outIndex": "",                      // collateral output index
 
             "extAddress": "10.10.10.10:1111",    // The address and port of the MN's Storage Layer
-            "extP@P:port" "10.10.10.10:1111",    // The address and port of the MN's Kademlia point
-            "extKey": "",                        // StoVaCore's private key
-            "extCfg": {},                        // StoVaCore's config
+            "extP2P:port" "10.10.10.10:1111",    // The address and port of the MN's Kademlia point
+            "extCfg": {},                        // Additional config
         }
     }
 */
@@ -151,7 +150,6 @@ bool CMasternodeConfig::read(string& strErr, const bool bNewOnly)
                 {"txid", ""},
                 {"outIndex", ""},
                 {"extAddress", ""},
-                {"extKey", ""},
                 {"extCfg", {}},
                 {"extP2P", ""}
             }}
@@ -183,7 +181,7 @@ bool CMasternodeConfig::read(string& strErr, const bool bNewOnly)
     }
     
     string strWhat;
-    string alias_lowercased, mnAddress, mnPrivKey, txid, outIndex, extAddress, extKey, extCfg, extP2P;
+    string alias_lowercased, mnAddress, mnPrivKey, txid, outIndex, extAddress, extCfg, extP2P;
 
     unique_lock<mutex> lck(m_mtx);
     for (const auto &[alias, cfg] : jsonObj.items())
@@ -240,14 +238,13 @@ bool CMasternodeConfig::read(string& strErr, const bool bNewOnly)
             return false;
         }
 
-        extKey = get_json_cfg_property(cfg, "extKey");
         extCfg = get_json_cfg_obj_as_string(cfg, "extCfg");
 
         if (extCfg.length() > 1024)
             extCfg.erase(1024, string::npos);
 
         CMasternodeEntry cme(alias, move(mnAddress), move(mnPrivKey), move(txid), move(outIndex), 
-            move(extAddress), move(extP2P), move(extKey), move(extCfg));
+            move(extAddress), move(extP2P), move(extCfg));
         m_CfgEntries.emplace(alias_lowercased, cme);
     }
 

--- a/src/mnode/mnode-config.h
+++ b/src/mnode/mnode-config.h
@@ -7,7 +7,7 @@
 #include <mutex>
 
 #include <map_types.h>
-#include <mnode/mnode-masternode.h>
+#include <primitives/transaction.h>
 
 class CMasternodeConfig
 {
@@ -23,13 +23,12 @@ public:
             std::string outputIndex;
             std::string extAddress;
             std::string extP2P;
-            std::string extKey;
             std::string extCfg;
 
         public:
             CMasternodeEntry() noexcept = default;
             CMasternodeEntry(const std::string &alias, std::string &&mnAddress, std::string &&mnPrivKey, std::string &&txHash, 
-                std::string &&outputIndex, std::string &&extAddress, std::string &&extP2P, std::string &&extKey, std::string &&extCfg) noexcept
+                std::string &&outputIndex, std::string &&extAddress, std::string &&extP2P, std::string &&extCfg) noexcept
             {
                 this->alias = alias;
                 this->mnAddress = std::move(mnAddress);
@@ -38,7 +37,6 @@ public:
                 this->outputIndex = std::move(outputIndex);
                 this->extAddress = std::move(extAddress);
                 this->extP2P = std::move(extP2P);
-                this->extKey = std::move(extKey);
                 this->extCfg = std::move(extCfg);
             }
 
@@ -49,13 +47,12 @@ public:
             const std::string& getOutputIndex() const noexcept { return outputIndex; }
             const std::string& getExtIp() const noexcept { return extAddress; }
             const std::string& getExtP2P() const noexcept { return extP2P; }
-            const std::string& getExtKey() const noexcept { return extKey; }
             const std::string& getExtCfg() const noexcept { return extCfg; }
 
             COutPoint getOutPoint() const noexcept;
     };
 
-    CMasternodeConfig() noexcept {}
+    CMasternodeConfig() noexcept = default;
 
     bool read(std::string& strErr, const bool bNewOnly = false);
 

--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -234,6 +234,8 @@ void CMasterNodeController::LockMnOutpoints(CWallet* pWalletMain)
         for (const auto & [alias, mne]: masternodeConfig.getEntries())
         {
             const COutPoint outpoint = mne.getOutPoint();
+            if (outpoint.IsNull())
+                continue;
             // don't lock non-spendable outpoint (i.e. it's already spent or it's not from this wallet at all)
             if (!IsMineSpendable(pWalletMain->GetIsMine(CTxIn(outpoint))))
             {

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -23,7 +23,9 @@ class CMasternodeMan
 public:
     typedef std::pair<arith_uint256, CMasternode*> score_pair_t;
     typedef std::vector<score_pair_t> score_pair_vec_t;
+    // map pair <rank> -> <Masternode>
     typedef std::pair<int, CMasternode> rank_pair_t;
+    // vector of mn-rank pairs: <rank> -> <CMasternode>
     typedef std::vector<rank_pair_t> rank_pair_vec_t;
 
 private:
@@ -75,7 +77,7 @@ private:
     /// Find an entry
     CMasternode* Find(const COutPoint& outpoint);
 
-    bool GetMasternodeScores(const uint256& nBlockHash, score_pair_vec_t& vecMasternodeScoresRet, int nMinProtocol = 0);
+    bool GetMasternodeScores(const uint256& blockHash, score_pair_vec_t& vecMasternodeScoresRet, int nMinProtocol = 0);
 
 public:
     // Keep track of all broadcasts I've seen

--- a/src/mnode/mnode-messageproc.cpp
+++ b/src/mnode/mnode-messageproc.cpp
@@ -131,7 +131,7 @@ string CMasternodeMessage::ToString() const
         throw runtime_error("Unknown Masternode");
     }
     
-    return make_unique<CMasternodeMessage>(masterNodeCtrl.activeMasternode.outpoint, mnInfo.vin.prevout, msgType, msg);
+    return make_unique<CMasternodeMessage>(masterNodeCtrl.activeMasternode.outpoint, mnInfo.getOutPoint(), msgType, msg);
 }
 
 void CMasternodeMessageProcessor::BroadcastNewFee(const CAmount newFee)

--- a/src/mnode/mnode-msgsigner.cpp
+++ b/src/mnode/mnode-msgsigner.cpp
@@ -45,12 +45,14 @@ bool CHashSigner::SignHash(const uint256& hash, const CKey key, v_uint8& vchSigR
 bool CHashSigner::VerifyHash(const uint256& hash, const CPubKey pubkey, const v_uint8& vchSig, std::string& strErrorRet)
 {
     CPubKey pubkeyFromSig;
-    if(!pubkeyFromSig.RecoverCompact(hash, vchSig)) {
+    if (!pubkeyFromSig.RecoverCompact(hash, vchSig))
+    {
         strErrorRet = "Error recovering public key.";
         return false;
     }
 
-    if(pubkeyFromSig.GetID() != pubkey.GetID()) {
+    if (pubkeyFromSig.GetID() != pubkey.GetID())
+    {
         strErrorRet = strprintf("Keys don't match: pubkey=%s, pubkeyFromSig=%s, hash=%s, vchSig=%s",
                     pubkey.GetID().ToString(), pubkeyFromSig.GetID().ToString(), hash.ToString(),
                     EncodeBase64(&vchSig[0], vchSig.size()));

--- a/src/mnode/mnode-payments.cpp
+++ b/src/mnode/mnode-payments.cpp
@@ -631,7 +631,8 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
     string debugStr = strprintf("CMasternodePayments::CheckPreviousBlockVotes -- nPrevBlockHeight=%d, expected voting MNs: ", nPrevBlockHeight);
 
     CMasternodeMan::rank_pair_vec_t mns;
-    if (!masterNodeCtrl.masternodeManager.GetMasternodeRanks(mns, nPrevBlockHeight + masterNodeCtrl.nMasternodePaymentsVotersIndexDelta)) {
+    if (!masterNodeCtrl.masternodeManager.GetMasternodeRanks(mns, nPrevBlockHeight + masterNodeCtrl.nMasternodePaymentsVotersIndexDelta))
+    {
         debugStr += "GetMasternodeRanks failed\n";
         LogFnPrint("mnpayments", "%s", debugStr);
         return;
@@ -642,6 +643,7 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
     for (size_t i = 0; i < MNPAYMENTS_SIGNATURES_TOTAL && i < mns.size(); ++i)
     {
         auto mn = mns[i];
+        const auto& outpoint = mn.second.getOutPoint();
         CScript payee;
         bool found = false;
 
@@ -657,7 +659,7 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
                         continue;
                     }
                     auto vote = mapMasternodePaymentVotes[voteHash];
-                    if (vote.vinMasternode.prevout == mn.second.vin.prevout)
+                    if (vote.vinMasternode.prevout == outpoint)
                     {
                         payee = vote.payee;
                         found = true;
@@ -670,7 +672,7 @@ void CMasternodePayments::CheckPreviousBlockVotes(int nPrevBlockHeight)
         if (!found)
         {
             debugStr += strprintf("%s - no vote received; ", mn.second.GetDesc());
-            mapMasternodesDidNotVote[mn.second.vin.prevout]++;
+            mapMasternodesDidNotVote[outpoint]++;
             continue;
         }
 

--- a/src/mnode/mnode-sync.cpp
+++ b/src/mnode/mnode-sync.cpp
@@ -36,12 +36,12 @@ void CMasternodeSync::Reset()
     nTimeLastFailure = 0;
 }
 
-void CMasternodeSync::BumpAssetLastTime(string strFuncName)
+void CMasternodeSync::BumpAssetLastTime(const std::string &strMethodName, const std::string &strFuncName)
 {
     if(IsSynced() || IsFailed())
         return;
     nTimeLastBumped = GetTime();
-    LogFnPrint("mnsync", "%s", strFuncName);
+    LogFnPrint("mnsync", "[%s] %s", strMethodName, strFuncName);
 }
 
 string CMasternodeSync::GetSyncStatusShort()
@@ -132,7 +132,7 @@ void CMasternodeSync::SwitchToNextAsset()
     }
     nRequestedMasternodeAttempt = 0;
     nTimeAssetSyncStarted = GetTime();
-    BumpAssetLastTime("CMasternodeSync::SwitchToNextAsset");
+    BumpAssetLastTime(__METHOD_NAME__);
 }
 
 void CMasternodeSync::ProcessMessage(CNode* pfrom, string& strCommand, CDataStream& vRecv)

--- a/src/mnode/mnode-sync.h
+++ b/src/mnode/mnode-sync.h
@@ -73,7 +73,7 @@ public:
 
     int GetAssetID() const noexcept { return (int)syncState; }
     int GetAttempt() const noexcept { return nRequestedMasternodeAttempt; }
-    void BumpAssetLastTime(std::string strFuncName);
+    void BumpAssetLastTime(const std::string &strMethodName, const std::string &strFuncName = "");
     int64_t GetAssetStartTime() const noexcept { return nTimeAssetSyncStarted; }
     std::string GetSyncStatusShort();
     std::string GetSyncStatus();

--- a/src/mnode/rpc/masternodebroadcast.cpp
+++ b/src/mnode/rpc/masternodebroadcast.cpp
@@ -96,12 +96,9 @@ Examples:
         if (masterNodeCtrl.masternodeConfig.GetEntryByAlias(strAlias, mne))
         {
             fFound = true;
-            string strError;
+            string error;
             CMasternodeBroadcast mnb;
-
-            const bool fResult = CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(),
-                                                        mne.getExtIp(), mne.getExtP2P(), mne.getExtKey(), mne.getExtCfg(),
-                                                        strError, mnb, true);
+            const bool fResult = mnb.InitFromConfig(error, mne, true);
 
             statusObj.pushKV(RPC_KEY_RESULT, get_rpc_result(fResult));
             if (fResult)
@@ -111,7 +108,7 @@ Examples:
                 ssVecMnb << vecMnb;
                 statusObj.pushKV("hex", HexStr(ssVecMnb.begin(), ssVecMnb.end()));
             } else
-                statusObj.pushKV(RPC_KEY_ERROR_MESSAGE, strError);
+                statusObj.pushKV(RPC_KEY_ERROR_MESSAGE, error);
         }
 
         if (!fFound)
@@ -143,12 +140,9 @@ Examples:
 
         for (const auto& [alias, mne] : masterNodeCtrl.masternodeConfig.getEntries())
         {
-            string strError;
+            string error;
             CMasternodeBroadcast mnb;
-
-            const bool fResult = CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(),
-                                                        mne.getExtIp(), mne.getExtP2P(), mne.getExtKey(), mne.getExtCfg(),
-                                                        strError, mnb, true);
+            const bool fResult = mnb.InitFromConfig(error, mne, true); 
 
             UniValue statusObj(UniValue::VOBJ);
             statusObj.pushKV(RPC_KEY_ALIAS, mne.getAlias());
@@ -160,7 +154,7 @@ Examples:
                 vecMnb.push_back(mnb);
             } else {
                 nFailed++;
-                statusObj.pushKV(RPC_KEY_ERROR_MESSAGE, strError);
+                statusObj.pushKV(RPC_KEY_ERROR_MESSAGE, error);
             }
 
             resultsObj.pushKV(RPC_KEY_STATUS, statusObj);
@@ -197,7 +191,7 @@ Examples:
             if (mnb.CheckSignature(nDos)) {
                 nSuccessful++;
                 resultObj.pushKV("outpoint", mnb.GetDesc());
-                resultObj.pushKV("addr", mnb.addr.ToString());
+                resultObj.pushKV("addr", mnb.get_address());
 
                 CTxDestination dest1 = mnb.pubKeyCollateralAddress.GetID();
                 string address1 = keyIO.EncodeDestination(dest1);
@@ -257,7 +251,7 @@ Arguments:
             UniValue resultObj(UniValue::VOBJ);
 
             resultObj.pushKV("outpoint", mnb.GetDesc());
-            resultObj.pushKV("addr", mnb.addr.ToString());
+            resultObj.pushKV("addr", mnb.get_address());
 
             int nDos = 0;
             bool fResult;

--- a/src/mnode/tickets/ticket_signing.cpp
+++ b/src/mnode/tickets/ticket_signing.cpp
@@ -213,7 +213,7 @@ ticket_validation_t CTicketSigning::validate_signatures(const uint32_t nCallDept
                 auto topBlockMNs = masterNodeCtrl.masternodeManager.GetTopMNsForBlock(nCreatorHeight, true);
                 const auto foundIt = find_if(topBlockMNs.cbegin(), topBlockMNs.cend(), [&](CMasternode const& mn)
                     {
-                        return mn.vin.prevout == outpoint;
+                        return mn.getOutPoint() == outpoint;
                     });
 
                 if (foundIt == topBlockMNs.cend()) //not found

--- a/src/mnode/tickets/username-change.cpp
+++ b/src/mnode/tickets/username-change.cpp
@@ -34,7 +34,7 @@ CChangeUsernameTicket CChangeUsernameTicket::Create(string &&sPastelID, string &
         // if Pastel ID has no Username yet, the fee is 100 PSL
         ticket.m_fee = masterNodeCtrl.MasternodeUsernameFirstChangeFee;
     } else {
-        // if Pastel ID changed Username before, fee should be 5000
+        // if Pastel ID changed Username before, fee should be 5000 PSL
         ticket.m_fee = masterNodeCtrl.MasternodeUsernameChangeAgainFee;
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -303,14 +303,14 @@ bool IsLocal(const CService& addr)
 }
 
 /** check whether a given network is one we can probably connect to */
-bool IsReachable(enum Network net)
+bool IsReachable(enum Network net) noexcept
 {
     LOCK(cs_mapLocalHost);
     return !vfLimited[net];
 }
 
 /** check whether a given address is in a network we can probably connect to */
-bool IsReachable(const CNetAddr& addr)
+bool IsReachable(const CNetAddr& addr) noexcept
 {
     enum Network net = addr.GetNetwork();
     return IsReachable(net);

--- a/src/net.h
+++ b/src/net.h
@@ -132,8 +132,8 @@ bool RemoveLocal(const CService& addr);
 bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);
 bool GetLocal(CService &addr, const CNetAddr *paddrPeer = nullptr);
-bool IsReachable(enum Network net);
-bool IsReachable(const CNetAddr &addr);
+bool IsReachable(enum Network net) noexcept;
+bool IsReachable(const CNetAddr &addr) noexcept;
 CAddress GetLocalAddress(const CNetAddr *paddrPeer = nullptr);
 
 

--- a/src/pastelid/secure_container.cpp
+++ b/src/pastelid/secure_container.cpp
@@ -142,12 +142,14 @@ bool CSecureContainer::write_to_file(const string& sFilePath, SecureString&& sPa
                                                        item.data.data(), item.data.size(), nullptr, 0, nullptr, item.nonce.data(), pw.p) != 0)
             throw runtime_error(strprintf("Failed to encrypt '%s' data", GetSecureItemTypeName(item.type)));
         const auto szTypeName = GetSecureItemTypeName(item.type);
+        const size_t nEncryptedDataSize = encrypted_data.size();
+        const size_t nItemNonceSize = item.nonce.size();
         jItems.push_back({
             {"type", szTypeName},
             {"nonce", move(item.nonce)},
             {"data", move(encrypted_data)}
         });
-        nJsonSecureSize += 50 + strlen(szTypeName) + item.nonce.size() + encrypted_data.size();
+        nJsonSecureSize += 50 + strlen(szTypeName) + nItemNonceSize + nEncryptedDataSize;
     }
     jSecure.emplace("secure_items", move(jItems));
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -89,12 +89,14 @@ double TxConfirmStats::EstimateMedianVal(const size_t nConfTarget, double suffic
                                          double successBreakPoint, bool requireGreater,
                                          unsigned int nBlockHeight)
 {
+    if (buckets.empty())
+        return -1;
     // Counters for a bucket (or range of buckets)
     double nConf = 0; // Number of tx's confirmed within the confTarget
     double totalNum = 0; // Total number of tx's that were ever confirmed
     int extraNum = 0;  // Number of tx's still in mempool for confTarget or longer
 
-    int maxbucketindex = buckets.size() - 1;
+    unsigned int maxbucketindex = static_cast<unsigned int>(buckets.size() - 1);
 
     // requireGreater means we are looking for the lowest fee/priority such that all higher
     // values pass, so we start at maxbucketindex (highest fee) and look at succesively
@@ -114,10 +116,11 @@ double TxConfirmStats::EstimateMedianVal(const size_t nConfTarget, double suffic
     unsigned int bestFarBucket = startbucket;
 
     bool foundAnswer = false;
-    unsigned int bins = unconfTxs.size();
+    unsigned int bins = static_cast<unsigned int>(unconfTxs.size());
 
     // Start counting from highest(default) or lowest fee/pri transactions
-    for (int bucket = startbucket; bucket >= 0 && bucket <= maxbucketindex; bucket += step) {
+    for (unsigned int bucket = startbucket; bucket <= maxbucketindex; bucket += step)
+    {
         curFarBucket = bucket;
         nConf += confAvg[nConfTarget - 1][bucket];
         totalNum += txCtAvg[bucket];
@@ -314,17 +317,17 @@ CBlockPolicyEstimator::CBlockPolicyEstimator(const CFeeRate& _minRelayFee)
 {
     const auto nMinFeeRate = static_cast<CAmount>(MIN_FEERATE);
     minTrackedFee = _minRelayFee < CFeeRate(nMinFeeRate) ? CFeeRate(nMinFeeRate) : _minRelayFee;
+
     v_doubles vfeelist;
-    for (double bucketBoundary = minTrackedFee.GetFeePerK(); bucketBoundary <= MAX_FEERATE; bucketBoundary *= FEE_SPACING) {
+    for (double bucketBoundary = static_cast<double>(minTrackedFee.GetFeePerK()); bucketBoundary <= MAX_FEERATE; bucketBoundary *= FEE_SPACING)
         vfeelist.push_back(bucketBoundary);
-    }
     feeStats.Initialize(vfeelist, MAX_BLOCK_CONFIRMS, DEFAULT_DECAY, "FeeRate");
 
     minTrackedPriority = ALLOW_FREE_THRESHOLD < MIN_FEE_PRIORITY ? MIN_FEE_PRIORITY : ALLOW_FREE_THRESHOLD;
+
     v_doubles vprilist;
-    for (double bucketBoundary = minTrackedPriority; bucketBoundary <= MAX_FEE_PRIORITY; bucketBoundary *= PRI_SPACING) {
+    for (double bucketBoundary = minTrackedPriority; bucketBoundary <= MAX_FEE_PRIORITY; bucketBoundary *= PRI_SPACING)
         vprilist.push_back(bucketBoundary);
-    }
     priStats.Initialize(vprilist, MAX_BLOCK_CONFIRMS, DEFAULT_DECAY, "Priority");
 
     feeUnlikely = CFeeRate(0);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -56,8 +56,8 @@ static constexpr std::array<RF_NAME, to_index(RetFormat::COUNT)> rf_names =
 
 struct CCoin
 {
-    uint32_t nTxVer; // Don't call this nVersion, that name has a special meaning inside IMPLEMENT_SERIALIZE
-    uint32_t nHeight;
+    uint32_t nTxVer{}; // Don't call this nVersion, that name has a special meaning inside IMPLEMENT_SERIALIZE
+    uint32_t nHeight{};
     CTxOut out;
 
     ADD_SERIALIZE_METHODS;


### PR DESCRIPTION
Changed pasteld code to:
- ignore extKey (mnid) while reading masternode's configuration from masternode.conf
- find mnid by Masternode's collateral transaction outpoint (txid+index). This collateral id (txid-index) is used as a secondary index in the MN Pastel ID Registration ticket.
- don't set ENABLED status for active local MN unless MNID is registered and the corresponding secure container exists locally
- refactored masternodebroadcast creation
- check MNID on processing "mnb" (masternode broadcast) message, retrieve mnid by MN's collateral id (txid+index) in mnb.
- removed duplicate code from "masternode start-alias" & "masternode start-all", created common "process_start_alias" function If MNID is not yet registered for this MN, RPC will return now an additional "message": 
{
	"alias": "mn1",
	"result": "successful",
	"message": "Masternode's Pastel ID is not registered"
}
If MNID is not registered, the result will still be successful, but MN will be in PRE_ENABLED status only.
- updated python tests
- added mn_main.py to MN python test group to build in CircleCI