### PR TITLE
[PSL-471] Accept outpoint index numeric parameter in "pose-ban-score" RPC API

### DIFF
--- a/src/gtest/test_rpc.cpp
+++ b/src/gtest/test_rpc.cpp
@@ -36,8 +36,7 @@ TEST(rpc, check_blockToJSON_returns_minified_solution) {
 }
 */
 
-UniValue
-createArgs(int nRequired, const char* address1=nullptr, const char* address2=nullptr)
+UniValue createArgs(int nRequired, const char* address1=nullptr, const char* address2=nullptr)
 {
     UniValue result(UniValue::VARR);
     result.push_back(nRequired);
@@ -61,10 +60,10 @@ UniValue CallRPC(string args)
     string strMethod = vArgs[0];
     vArgs.erase(vArgs.begin());
     // Handle empty strings the same way as CLI
-    for (auto i = 0; i < vArgs.size(); i++) {
-        if (vArgs[i] == "\"\"") {
+    for (auto i = 0; i < vArgs.size(); i++)
+    {
+        if (vArgs[i] == "\"\"")
             vArgs[i] = "";
-        }
     }
     UniValue params = RPCConvertValues(strMethod, vArgs);
     EXPECT_TRUE(tableRPC[strMethod] != nullptr);

--- a/src/pastel-cli.cpp
+++ b/src/pastel-cli.cpp
@@ -15,6 +15,7 @@
 #include <rpc/client.h>
 #include <rpc/protocol.h>
 #include <rpc/rpc_consts.h>
+#include <vector_types.h>
 #include <util.h>
 #include <enum_util.h>
 #include <utilstrencodings.h>
@@ -292,7 +293,7 @@ int CommandLineRPC(int argc, char *argv[])
         if (args.size() < 1)
             throw std::runtime_error("too few parameters (need at least command)");
         const std::string strMethod = args[0];
-        UniValue params = RPCConvertValues(strMethod, std::vector<std::string>(args.begin()+1, args.end()));
+        UniValue params = RPCConvertValues(strMethod, v_strings(args.begin()+1, args.end()));
 
         // Execute and handle connection failures with -rpcwait
         const bool fWait = GetBoolArg("-rpcwait", false);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -1,196 +1,195 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Cor
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#include "rpc/client.h"
-#include "rpc/protocol.h"
-#include "util.h"
-
 #include <set>
+#include <array>
+#include <unordered_map>
 #include <stdint.h>
 
 #include <univalue.h>
+
+#include <rpc/client.h>
+#include <rpc/protocol.h>
+#include <util.h>
+#include <str_utils.h>
 
 using namespace std;
 
 class CRPCConvertParam
 {
 public:
-    std::string methodName;            //! method whose params want conversion
-    int paramIdx;                      //! 0-based idx of param to convert
+    const char *szMethodName;     // method whose params want conversion
+    const char* szMethodExName;   //   optional method second parameter
+    set<uint8_t> vParamIdx;       // set of 0-based indexes of the params to convert
 };
 
-static const CRPCConvertParam vRPCConvertParams[] =
-{
-    { "stop", 0 },
-    { "setmocktime", 0 },
-    { "getaddednodeinfo", 0 },
-    { "setgenerate", 0 },
-    { "setgenerate", 1 },
-    { "generate", 0 },
-    { "getnetworkhashps", 0 },
-    { "getnetworkhashps", 1 },
-    { "getnetworksolps", 0 },
-    { "getnetworksolps", 1 },
-    { "sendtoaddress", 1 },
-    { "sendtoaddress", 4 },
-    { "settxfee", 0 },
-    { "getreceivedbyaddress", 1 },
-    { "getreceivedbyaccount", 1 },
-    { "listreceivedbyaddress", 0 },
-    { "listreceivedbyaddress", 1 },
-    { "listreceivedbyaddress", 2 },
-    { "listreceivedbyaccount", 0 },
-    { "listreceivedbyaccount", 1 },
-    { "listreceivedbyaccount", 2 },
-    { "listaddressamounts", 0 },
-    { "getbalance", 1 },
-    { "getbalance", 2 },
-    { "getblockhash", 0 },
-    { "move", 2 },
-    { "move", 3 },
-    { "sendfrom", 2 },
-    { "sendfrom", 3 },
-    { "listtransactions", 1 },
-    { "listtransactions", 2 },
-    { "listtransactions", 3 },
-    { "listaccounts", 0 },
-    { "listaccounts", 1 },
-    { "walletpassphrase", 1 },
-    { "getblocktemplate", 0 },
-    { "listsinceblock", 1 },
-    { "listsinceblock", 2 },
-    { "sendmany", 1 },
-    { "sendmany", 2 },
-    { "sendmany", 4 },
-    { "addmultisigaddress", 0 },
-    { "addmultisigaddress", 1 },
-    { "createmultisig", 0 },
-    { "createmultisig", 1 },
-    { "listunspent", 0 },
-    { "listunspent", 1 },
-    { "listunspent", 2 },
-    { "getblock", 1 },
-    { "getblockheader", 1 },
-    { "gettransaction", 1 },
-    { "getrawtransaction", 1 },
-    { "createrawtransaction", 0 },
-    { "createrawtransaction", 1 },
-    { "createrawtransaction", 2 },
-    { "createrawtransaction", 3 },
-    { "signrawtransaction", 1 },
-    { "signrawtransaction", 2 },
-    { "sendrawtransaction", 1 },
-    { "fundrawtransaction", 1 },
-    { "gettxout", 1 },
-    { "gettxout", 2 },
-    { "gettxoutproof", 0 },
-    { "lockunspent", 0 },
-    { "lockunspent", 1 },
-    { "importprivkey", 2 },
-    { "importaddress", 2 },
-    { "verifychain", 0 },
-    { "verifychain", 1 },
-    { "keypoolrefill", 0 },
-    { "getrawmempool", 0 },
-    { "estimatefee", 0 },
-    { "estimatepriority", 0 },
-    { "prioritisetransaction", 1 },
-    { "prioritisetransaction", 2 },
-    { "setban", 2 },
-    { "setban", 3 },
-    { "getaddressmempool", 0},
-    { "getblockdeltas", 0},
-    { "zcrawjoinsplit", 1 },
-    { "zcrawjoinsplit", 2 },
-    { "zcrawjoinsplit", 3 },
-    { "zcrawjoinsplit", 4 },
-    { "zcbenchmark", 1 },
-    { "zcbenchmark", 2 },
-    { "getnextblocksubsidy", 0},
-    { "getblocksubsidy", 0},
-    { "z_listaddresses", 0},
-    { "z_listreceivedbyaddress", 1},
-    { "z_listunspent", 0 },
-    { "z_listunspent", 1 },
-    { "z_listunspent", 2 },
-    { "z_listunspent", 3 },
-    { "z_getbalance", 1},
-    { "z_gettotalbalance", 0},
-    { "z_gettotalbalance", 1},
-    { "z_gettotalbalance", 2},
-    { "z_mergetoaddress", 0},
-    { "z_mergetoaddress", 2},
-    { "z_mergetoaddress", 3},
-    { "z_mergetoaddress", 4},
-    { "z_sendmany", 1},
-    { "z_sendmany", 2},
-    { "z_sendmany", 3},
-    { "z_sendmanywithchangetosender", 1},
-    { "z_sendmanywithchangetosender", 2},
-    { "z_sendmanywithchangetosender", 3},
-    { "z_shieldcoinbase", 2},
-    { "z_shieldcoinbase", 3},
-    { "z_getoperationstatus", 0},
-    { "z_getoperationresult", 0},
-    { "z_importkey", 2 },
-    { "z_importviewingkey", 2 }
-};
+static const array<CRPCConvertParam, 67> gl_vRPCConvertParams =
+{{
+    { "stop", nullptr, {0} },
+    { "setmocktime", nullptr, {0} },
+    { "getaddednodeinfo", nullptr, {0} },
+    { "setgenerate", nullptr, {0, 1} },
+    { "generate", nullptr, {0} },
+    { "getnetworkhashps", nullptr, {0, 1} },
+    { "getnetworksolps", nullptr, {0, 1} },
+    { "sendtoaddress", nullptr, {1, 4} },
+    { "settxfee", nullptr, {0} },
+    { "getreceivedbyaddress", nullptr, {1} },
+    { "getreceivedbyaccount", nullptr, {1} },
+    { "listreceivedbyaddress", nullptr, {0, 1, 2} },
+    { "listreceivedbyaccount", nullptr, {0, 1, 2} },
+    { "listaddressamounts", nullptr, {0} },
+    { "getbalance", nullptr, {1, 2} },
+    { "getblockhash", nullptr, {0} },
+    { "move", nullptr, {2, 3} },
+    { "sendfrom", nullptr, {2, 3} },
+    { "listtransactions", nullptr, {1, 2, 3} },
+    { "listaccounts", nullptr, {0, 1} },
+    { "walletpassphrase", nullptr, {1} },
+    { "getblocktemplate", nullptr, {0} },
+    { "listsinceblock", nullptr, {1, 2} },
+    { "sendmany", nullptr, {1, 2, 4} },
+    { "addmultisigaddress", nullptr, {0, 1} },
+    { "createmultisig", nullptr, {0, 1} },
+    { "listunspent", nullptr, {0, 1, 2} },
+    { "masternode", "pose-ban-score", {3} },
+    { "getblock", nullptr, {1} },
+    { "getblockheader", nullptr, {1} },
+    { "gettransaction", nullptr, {1} },
+    { "getrawtransaction", nullptr, {1} },
+    { "createrawtransaction", nullptr, {0, 1, 2, 3} },
+    { "signrawtransaction", nullptr, {1, 2} },
+    { "sendrawtransaction", nullptr, {1} },
+    { "fundrawtransaction", nullptr, {1} },
+    { "gettxout", nullptr, {1, 2} },
+    { "gettxoutproof", nullptr, {0} },
+    { "lockunspent", nullptr, {0, 1} },
+    { "importprivkey", nullptr, {2} },
+    { "importaddress", nullptr, {2} },
+    { "verifychain", nullptr, {0, 1} },
+    { "keypoolrefill", nullptr, {0} },
+    { "getrawmempool", nullptr, {0} },
+    { "estimatefee", nullptr, {0} },
+    { "estimatepriority", nullptr, {0} },
+    { "prioritisetransaction", nullptr, {1, 2} },
+    { "setban", nullptr, {2, 3} },
+    { "getaddressmempool", nullptr, {0} },
+    { "getblockdeltas", nullptr, {0} },
+    { "zcrawjoinsplit", nullptr, {1, 2, 3, 4} },
+    { "zcbenchmark", nullptr, {1, 2} },
+    { "getnextblocksubsidy", nullptr, {0} },
+    { "getblocksubsidy", nullptr, {0} },
+    { "z_listaddresses", nullptr, {0} },
+    { "z_listreceivedbyaddress", nullptr, {1} },
+    { "z_listunspent", nullptr, {0, 1, 2, 3} },
+    { "z_getbalance", nullptr, {1} },
+    { "z_gettotalbalance", nullptr, {0, 1, 2} },
+    { "z_mergetoaddress", nullptr, {0, 2, 3, 4} },
+    { "z_sendmany", nullptr, {1, 2, 3} },
+    { "z_sendmanywithchangetosender", nullptr, {1, 2, 3} },
+    { "z_shieldcoinbase", nullptr, {2, 3} },
+    { "z_getoperationstatus", nullptr, {0} },
+    { "z_getoperationresult", nullptr, {0} },
+    { "z_importkey", nullptr, {2} },
+    { "z_importviewingkey", nullptr, {2} }
+}};
 
-class CRPCConvertTable
+class CRPCParamConvert
 {
-private:
-    std::set<std::pair<std::string, int> > members;
-
 public:
-    CRPCConvertTable();
+    using T_RPCConvertMap = unordered_map<string, set<uint8_t>>;
 
-    bool convert(const std::string& method, int idx) {
-        return (members.count(std::make_pair(method, idx)) > 0);
+    CRPCParamConvert()
+    {
+        // initialize convert map with search key:
+        //    [method-*]         - in case sub-method is not specified
+        //    [method-submethod] - if sub-method is also defined
+        string sSearchKey;
+        for (const auto& entry : gl_vRPCConvertParams)
+        {
+            sSearchKey = SAFE_SZ(entry.szMethodName);
+            sSearchKey += '-';
+            if (entry.szMethodExName)
+                sSearchKey += entry.szMethodExName;
+            else
+                sSearchKey += '*';
+            m_ConvertMap.emplace(lowercase(sSearchKey), entry.vParamIdx);
+        }
     }
+
+    /**
+     * Check if conversion is required for the given RPC method.
+     * 
+     * \param strMethod - method name
+     * \param vParams - parameters
+     * \param indexSet - set of parameter indexes for which conversion is required
+     * \return true if parameter conversion is required
+     */
+    bool NeedConversion(const string& strMethod, const v_strings &vParams, set<uint8_t> &indexSet) const noexcept
+    {
+        indexSet.clear();
+        string sSearchKey(lowercase(strMethod));
+        sSearchKey += '-';
+        if (!vParams.empty())
+        {
+            // search by key [method-submethod]
+            const auto it = m_ConvertMap.find(sSearchKey + lowercase(vParams[0]));
+            if (it != m_ConvertMap.cend())
+            {
+                indexSet = it->second;
+                return true;
+            }
+        }
+        // search by key [method-*]
+        sSearchKey += '*';
+        const auto it = m_ConvertMap.find(sSearchKey);
+        if (it != m_ConvertMap.cend())
+        {
+            indexSet = it->second;
+            return true;
+        }
+        return false;
+    }
+
+private:
+    T_RPCConvertMap m_ConvertMap;
 };
 
-CRPCConvertTable::CRPCConvertTable()
-{
-    const unsigned int n_elem =
-        (sizeof(vRPCConvertParams) / sizeof(vRPCConvertParams[0]));
 
-    for (unsigned int i = 0; i < n_elem; i++) {
-        members.insert(std::make_pair(vRPCConvertParams[i].methodName,
-                                      vRPCConvertParams[i].paramIdx));
-    }
-}
-
-static CRPCConvertTable rpcCvtTable;
+static CRPCParamConvert gl_RPCParamConvert;
 
 /** Non-RFC4627 JSON parser, accepts internal values (such as numbers, true, false, null)
  * as well as objects and arrays.
  */
-UniValue ParseNonRFCJSONValue(const std::string& strVal)
+UniValue ParseNonRFCJSONValue(const string& strVal)
 {
     UniValue jVal;
-    if (!jVal.read(std::string("[")+strVal+std::string("]")) ||
+    if (!jVal.read(string("[")+strVal+string("]")) ||
         !jVal.isArray() || jVal.size()!=1)
         throw runtime_error(string("Error parsing JSON:")+strVal);
     return jVal[0];
 }
 
 /** Convert strings to command-specific RPC representation */
-UniValue RPCConvertValues(const std::string &strMethod, const std::vector<std::string> &strParams)
+UniValue RPCConvertValues(const string &strMethod, const v_strings &vParams)
 {
     UniValue params(UniValue::VARR);
 
-    for (unsigned int idx = 0; idx < strParams.size(); idx++) {
-        const std::string& strVal = strParams[idx];
+    set<uint8_t> indexSet;
+    const bool bNeedConversion = gl_RPCParamConvert.NeedConversion(strMethod, vParams, indexSet);
 
-        if (!rpcCvtTable.convert(strMethod, idx)) {
-            // insert string value directly
-            params.push_back(strVal);
-        } else {
+    for (size_t idx = 0; idx < vParams.size(); ++idx)
+    {
+        const string& strVal = vParams[idx];
+
+        if (bNeedConversion && indexSet.count(static_cast<uint8_t>(idx)))
             // parse string as JSON, insert bool/number/object/etc. value
             params.push_back(ParseNonRFCJSONValue(strVal));
-        }
+        else
+            // insert string value directly
+            params.push_back(strVal);
     }
 
     return params;

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -1,17 +1,16 @@
+#pragma once
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2022 The Pastel Code developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_RPCCLIENT_H
-#define BITCOIN_RPCCLIENT_H
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <univalue.h>
 
-UniValue RPCConvertValues(const std::string& strMethod, const std::vector<std::string>& strParams);
+#include <vector_types.h>
+
+UniValue RPCConvertValues(const std::string& strMethod, const v_strings& strParams);
 /** Non-RFC4627 JSON parser, accepts internal values (such as numbers, true, false, null)
  * as well as objects and arrays.
  */
 UniValue ParseNonRFCJSONValue(const std::string& strVal);
-
-#endif // BITCOIN_RPCCLIENT_H


### PR DESCRIPTION
Array with RPC method names associated with parameter indexes was used to search for RPC parameters that needed conversion (use non-RFC4627 JSON parser). RPC Param Convert class was changed:
 - removed duplicate entries from RPC params initialization array with the same RPC method name, added set of parameter indexes
 - added capability to define optional sub-method: for example: { "masternode", "pose-ban-score", {3} } - use non-RFC4627 parsing only for 3rd parameter in "masternode pose-ban-score" API
 - on class initialization create an unordered map with key: [method-submethod] - for entries with submethod [method-*] - for APIs without submethod
 - improved performance for the search of the RPC parameters that require conversion - search in the hash-map by key is much faster than linear vector search. 
 - search logic: 
       - if submethod is defined - search by key [method-submethod], then if not found by [method-*]
       - if submethod is not defined - search by key [method-*]