### PR TITLE
[PSL-478] cNode crashes on invalid RPC command parameter type

### DIFF
--- a/src/gtest/pastel_gtest_main.h
+++ b/src/gtest/pastel_gtest_main.h
@@ -30,6 +30,8 @@ public:
     // cleanup temp datadir
     void ClearTempDataDir();
 
+    fs::path GetTempDataDir() const noexcept { return m_TempDataDir; }
+
 protected:
     CCoinsViewDB* pcoinsdbview = nullptr;
     CServiceThreadGroup threadGroup;

--- a/src/gtest/test_mnode/test_pastelid.cpp
+++ b/src/gtest/test_mnode/test_pastelid.cpp
@@ -16,6 +16,9 @@
 using namespace std;
 using namespace testing;
 
+constexpr auto TEST_PASS1 = "passphrase1";
+constexpr auto TEST_PASS2 = "passphrase2";
+
 class PTest_PastelID_Alg : public TestWithParam<tuple<string, CPastelID::SIGN_ALGORITHM>>
 {};
 
@@ -47,9 +50,7 @@ TEST(PastelID, GetStoredPastelIDs)
     auto mapIDs = CPastelID::GetStoredPastelIDs(true);
     EXPECT_TRUE(mapIDs.empty()) << "Found some Pastel IDs in [" << sTempPath << "]";
 
-    const auto PASS1 = "passphrase1";
-    const auto PASS2 = "passphrase2";
-    const auto mapIDs_1 = CPastelID::CreateNewPastelKeys(PASS1);
+    const auto mapIDs_1 = CPastelID::CreateNewPastelKeys(TEST_PASS1);
     EXPECT_TRUE(!mapIDs_1.empty());
     const auto it = mapIDs_1.cbegin();
     EXPECT_NE(it, mapIDs_1.cend());
@@ -61,7 +62,7 @@ TEST(PastelID, GetStoredPastelIDs)
         EXPECT_NE(it1, mapIDs.cend());
         EXPECT_EQ(it1->second, it->second);
     }
-    const auto mapIDs_2 = CPastelID::CreateNewPastelKeys(PASS2);
+    const auto mapIDs_2 = CPastelID::CreateNewPastelKeys(TEST_PASS2);
     EXPECT_TRUE(!mapIDs_2.empty());
     const auto it2 = mapIDs_2.cbegin();
     EXPECT_NE(it2, mapIDs_2.cend());

--- a/src/gtest/test_mnode/test_ticket_processor.cpp
+++ b/src/gtest/test_mnode/test_ticket_processor.cpp
@@ -62,18 +62,18 @@ TEST_F(TestTicketProcessor, ticket_compression)
 {
     constexpr auto TEST_PASSPHRASE = "passphrase";
     // create valid PastelID
-    auto keys = CPastelID::CreateNewPastelKeys(move(TEST_PASSPHRASE));
+    const auto keys = CPastelID::CreateNewPastelKeys(TEST_PASSPHRASE);
     ASSERT_TRUE(!keys.empty());
 
     auto ticket = make_unique<MockChangeUserNameTicket>();
     ASSERT_NE(ticket.get(), nullptr);
     // set some ticket data
     ticket->setUserName(string(12, 'a'));
-    auto sPastelID = keys.begin()->first;
+    auto sPastelID = keys.cbegin()->first;
     ticket->setPastelID(move(sPastelID));
     ticket->setFee(0);
     const auto strTicket = ticket->ToStr();
-    ticket->set_signature(CPastelID::Sign(strTicket, ticket->getPastelID(), move(TEST_PASSPHRASE)));
+    ticket->set_signature(CPastelID::Sign(strTicket, ticket->getPastelID(), TEST_PASSPHRASE));
 
     ticket_validation_t tvValid;
     tvValid.state = TICKET_VALIDATION_STATE::VALID;

--- a/src/gtest/test_rpccmd_parser.cpp
+++ b/src/gtest/test_rpccmd_parser.cpp
@@ -50,10 +50,33 @@ TEST(rpc_cmd_parser, invalid)
     try
     {
         RPCCommandParser<TestEnum> tst(params, 0, "cmd1, cmd2, cmd3");
-    } catch (const UniValue& objError) {
+    }
+    catch (const UniValue& objError)
+    {
         objErr = objError;
     }
     ExpectRPCError(objErr, RPC_MISC_ERROR, "enum mismatch");
+}
+
+TEST(rpc_cmd_parser, invalid_cmd_parameter_type)
+{
+    UniValue objErr;
+    UniValue params(UniValue::VARR);
+    UniValue cmdArrayParam(UniValue::VARR);
+    cmdArrayParam.push_back("cmd2");
+    params.push_back("cmd1");
+    params.push_back(cmdArrayParam);
+    params.push_back("cmd_param3");
+
+    try
+    {
+        RPC_CMD_PARSER2(TST, params, cmd1, cmd2);
+    }
+    catch (const UniValue& objError)
+    {
+        objErr = objError;
+    }
+    ExpectRPCError(objErr, RPC_INVALID_PARAMETER, "not a string");
 }
 
 TEST(rpc_cmd_parser, test_known_parameter)

--- a/src/mnode/rpc/masternode.cpp
+++ b/src/mnode/rpc/masternode.cpp
@@ -89,7 +89,7 @@ Available modes:
   lastpaidblock  - Print the last block height a node was paid on the network
   lastpaidtime   - Print the last time a node was paid on the network
   lastseen       - Print timestamp of when a masternode was last seen on the network
-  payee          - Print Dash address associated with a masternode (can be additionally filtered,
+  payee          - Print Pastel address associated with a masternode (can be additionally filtered,
                    partial match)
   protocol       - Print protocol of a masternode (can be additionally filtered, exact match)
   pubkey         - Print the masternode (not collateral) public key

--- a/src/mnode/rpc/pastelid-rpc.h
+++ b/src/mnode/rpc/pastelid-rpc.h
@@ -1,5 +1,5 @@
 #pragma once
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2022 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 

--- a/src/pastelid/pastel_key.h
+++ b/src/pastelid/pastel_key.h
@@ -47,7 +47,7 @@ public:
     static bool isValidPassphrase(const std::string& sPastelId, const SecureString& strKeyPass) noexcept;
     // Change passphrase used to encrypt the secure container
     static bool ChangePassphrase(std::string &error, const std::string& sPastelId, SecureString&& sOldPassphrase, SecureString&& sNewPassphrase);
-    // read ed448 private key from PKCS8 file (olf format)
+    // read ed448 private key from PKCS8 file (old format)
     static bool ProcessEd448_PastelKeyFile(std::string& error, const std::string& sFilePath, const SecureString& sOldPassPhrase, SecureString &&sNewPassPhrase);
 
 protected:

--- a/src/rpc/rpc_parser.h
+++ b/src/rpc/rpc_parser.h
@@ -26,7 +26,7 @@ public:
         if (!ParseCmdList(error, szCmdList))
             throw JSONRPCError(RPC_MISC_ERROR, "Failed to parse the list of RPC commands. " + error);
         if (!ParseParams(error))
-            throw JSONRPCError(RPC_INVALID_PARAMS, "Failed to parse RPC parameters. " + error);
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Failed to parse RPC parameters. " + error);
     }
 
     // returns number of supported commands

--- a/src/rpc/rpc_parser.h
+++ b/src/rpc/rpc_parser.h
@@ -25,7 +25,8 @@ public:
         std::string error;
         if (!ParseCmdList(error, szCmdList))
             throw JSONRPCError(RPC_MISC_ERROR, "Failed to parse the list of RPC commands. " + error);
-        ParseParams();
+        if (!ParseParams(error))
+            throw JSONRPCError(RPC_INVALID_PARAMS, "Failed to parse RPC parameters. " + error);
     }
 
     // returns number of supported commands
@@ -92,18 +93,26 @@ protected:
         return bRet;
     }
 
-    void ParseParams() noexcept
+    bool ParseParams(std::string &error)
     {
+        // check if we can retrieve command from param list by index
         if (m_Params.size() <= m_nCmdIndex)
-            return;
-        m_sCmd = m_Params[m_nCmdIndex].get_str();
+            return true; // not an error - command not passed, so help message will be returned
+        const auto &cmdParam = m_Params[m_nCmdIndex];
+        if (!cmdParam.isStr())
+        {
+            error = strprintf("RPC command parameter #%zu is not a string", m_nCmdIndex + 1);
+            return false;
+        }
+        m_sCmd = cmdParam.get_str();
         trim(m_sCmd);
         lowercase(m_sCmd);
         if (m_sCmd.empty())
-            return;
+            return true;
         const auto it = m_CmdMap.find(m_sCmd);
         if (it != m_CmdMap.cend())
             m_Cmd = it->second;
+        return true;
     }
 
     map_cmdenum_t m_CmdMap;     // map <command -> cmd_enum>

--- a/src/wallet/gtest/test_wallet_zkeys.cpp
+++ b/src/wallet/gtest/test_wallet_zkeys.cpp
@@ -129,7 +129,7 @@ public:
 TEST_F(CTestWalletZkeys, WriteCryptedSaplingZkeyDirectToDb)
 {
     bool fFirstRun = true;
-    fs::path tempWalletPath = fs::temp_directory_path() / "wallet_crypted_sapling.dat";
+    fs::path tempWalletPath = gl_pPastelTestEnv->GetTempDataDir() / "wallet_crypted_sapling.dat";
 
     // cleanup temp wallet after test completes
     auto guard = sg::make_scope_guard([&]() noexcept
@@ -193,9 +193,13 @@ TEST_F(CTestWalletZkeys, WriteCryptedSaplingZkeyDirectToDb)
     ASSERT_TRUE(&wallet != &wallet2);
     ASSERT_TRUE(wallet2.HaveHDSeed());
 
-    // wallet should have three addresses
+    // wallet should have three addresses: the default addresses for the two
+    // generated keys, and the added diversified address.
     wallet2.GetSaplingPaymentAddresses(addrs);
     ASSERT_EQ(3, addrs.size());
+
+    // flush the wallet to prevent race conditions
+    wallet.Flush();
 
     //check we have entries for our payment addresses
     ASSERT_TRUE(addrs.count(address));


### PR DESCRIPTION
- added validation for the RPC command parameter type. cNode crashes if RPC command parameter type is not a string.
- corrected RPC help in "masternode list"