### PR TITLE
[PSL-713] Add the connectivity check code and if it's not connected, put it in a suspended mode where it won't ban any other nodes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,9 +63,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - name: Build Pastel cNode project (C++ only)
-      if: contains(steps.init.outputs.languages, 'cpp') 
-      run: |
+    - run: |
        ./build.sh -j4 --enable-debug
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,8 +53,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    # - name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -63,9 +63,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+       build.sh -j4 --enable-debug
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,9 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: |
+    - name: Build Pastel cNode project (C++ only)
+      if: contains(steps.init.outputs.languages, 'cpp') 
+      run: |
        ./build.sh -j4 --enable-debug
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -64,7 +64,7 @@ jobs:
     #    uses a compiled language
 
     - run: |
-       build.sh -j4 --enable-debug
+       ./build.sh -j4 --enable-debug
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="..\..\..\src\mnode\tickets\username-change.cpp" />
     <ClCompile Include="..\..\..\src\net.cpp" />
     <ClCompile Include="..\..\..\src\netmsg\block-cache.cpp" />
+    <ClCompile Include="..\..\..\src\net_manager.cpp" />
     <ClCompile Include="..\..\..\src\noui.cpp" />
     <ClCompile Include="..\..\..\src\orphan-tx.cpp" />
     <ClCompile Include="..\..\..\src\pastelid\pastel_key.cpp" />
@@ -272,6 +273,7 @@
     <ClInclude Include="..\..\..\src\mruset.h" />
     <ClInclude Include="..\..\..\src\net.h" />
     <ClInclude Include="..\..\..\src\netmsg\block-cache.h" />
+    <ClInclude Include="..\..\..\src\net_manager.h" />
     <ClInclude Include="..\..\..\src\nodehelper.h" />
     <ClInclude Include="..\..\..\src\noui.h" />
     <ClInclude Include="..\..\..\src\orphan-tx.h" />

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
@@ -310,6 +310,9 @@
     <ClCompile Include="..\..\..\src\mnode\tickets\ticket-key.cpp">
       <Filter>Source Files\mnode\tickets</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\net_manager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\addrman.h">
@@ -662,6 +665,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\src\mnode\tickets\ticket-key.h">
       <Filter>Source Files\mnode\tickets</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\net_manager.h">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/build-aux/vs2022/pastel_gtest/pastel_gtest.props
+++ b/build-aux/vs2022/pastel_gtest/pastel_gtest.props
@@ -12,7 +12,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libzstd$(LIBDBGSFX).lib;event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb181$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzstd$(LIBDBGSFX).lib;event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb181$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>libcmt$(LIBDBGSFX).lib</IgnoreSpecificDefaultLibraries>
     </Link>

--- a/build-aux/vs2022/pasteld/pasteld.props
+++ b/build-aux/vs2022/pasteld/pasteld.props
@@ -13,7 +13,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libzstd$(LIBDBGSFX).lib;event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb181$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzstd$(LIBDBGSFX).lib;event$(LIBDBGSFX).lib;libbitcoin_server.lib;libbitcoin_wallet.lib;libbitcoin_common.lib;libunivalue.lib;libbitcoin_util.lib;libbitcoin_zmq.lib;libbitcoin_crypto.lib;libzcash.lib;libsnark.lib;libsecp256k1.lib;libleveldb.lib;libcrypto.lib;libsodium$(LIBDBGSFX).lib;libdb181$(LIBDBGSFX).lib;rustzcash.lib;libgmp.lib;libgmpxx.lib;shlwapi.lib;ws2_32.lib;userenv.lib;Iphlpapi.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>libcmt$(LIBDBGSFX).lib</IgnoreSpecificDefaultLibraries>
     </Link>

--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,7 @@ case $host in
      AC_CHECK_LIB([shlwapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([iphlpapi],      [main],, AC_MSG_ERROR(lib missing))
      AC_CHECK_LIB([crypt32],      [main],, AC_MSG_ERROR(lib missing))
+     AC_CHECK_LIB([wininet],      [main],, AC_MSG_ERROR(lib missing))
 
      # -static is interpreted by libtool, where it has a different meaning.
      # In libtool-speak, it's -all-static.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -297,6 +297,7 @@ BITCOIN_CORE_H = \
   mruset.h \
   netmsg/block-cache.h\
   net.h \
+  net_manager.h \
   nodehelper.h \
   netbase.h \
   noui.h \
@@ -405,6 +406,7 @@ libbitcoin_server_a_SOURCES = \
   miner.cpp \
   netmsg/block-cache.cpp\
   net.cpp \
+  net_manager.cpp \
   noui.cpp \
   orphan-tx.cpp \
   policy/fees.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <coins.h>
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -1,8 +1,9 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <compressor.h>
 #include <core_memusage.h>
 #include <memusage.h>
@@ -403,7 +404,7 @@ public:
                     CAnchorsSaplingMap &mapSaplingAnchors,
                     CNullifiersMap &mapSproutNullifiers,
                     CNullifiersMap &mapSaplingNullifiers) override;
-    bool GetStats(CCoinsStats &stats) const;
+    bool GetStats(CCoinsStats &stats) const override;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5248,7 +5248,7 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         }
         if (!vRecv.empty())
         {
-            uint32_t nStartingHeight;
+            int32_t nStartingHeight = 0;
             vRecv >> nStartingHeight;
             pfrom->nStartingHeight = nStartingHeight;
         }
@@ -5329,7 +5329,7 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         if (fLogIPs)
             remoteAddr = ", peeraddr=" + pfrom->addr.ToString();
 
-        LogPrintf("receive version message: %s: version %d, blocks=%u, us=%s, peer=%d%s\n",
+        LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peer=%d%s\n",
                   pfrom->cleanSubVer, pfrom->nVersion,
                   pfrom->nStartingHeight, addrMe.ToString(), pfrom->id,
                   remoteAddr);
@@ -5762,7 +5762,7 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
                 // Headers message had its maximum size; the peer may have more headers.
                 // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
                 // from there instead.
-                LogPrint("net", "more getheaders from height=%d (max: %zu) to peer=%d (startheight=%u)\n",
+                LogPrint("net", "more getheaders from height=%d (max: %zu) to peer=%d (startheight=%d)\n",
                     pindexLast->nHeight, MAX_HEADERS_RESULTS, pfrom->id, pfrom->nStartingHeight);
                 pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256());
             }
@@ -6336,7 +6336,7 @@ bool SendMessages(const CChainParams& chainparams, CNode* pto, bool fSendTrickle
                 state.fSyncStarted = true;
                 nSyncStarted++;
                 const auto pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
-                LogPrint("net", "initial getheaders (height=%d) to peer=%d (startheight=%u)\n",
+                LogPrint("net", "initial getheaders (height=%d) to peer=%d (startheight=%d)\n",
                     pindexStart->nHeight, nodeId, pto->nStartingHeight);
                 pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256());
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Copyright (c) 2015-2018 The Zcash developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -5213,7 +5213,9 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         CAddress addrMe;
         CAddress addrFrom;
         uint64_t nNonce = 1;
-        vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
+        uint64_t nServices;
+        vRecv >> pfrom->nVersion >> nServices >> nTime >> addrMe;
+        pfrom->nServices = nServices;
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version
@@ -5245,7 +5247,11 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
         }
         if (!vRecv.empty())
-            vRecv >> pfrom->nStartingHeight;
+        {
+            uint32_t nStartingHeight;
+            vRecv >> nStartingHeight;
+            pfrom->nStartingHeight = nStartingHeight;
+        }
         if (!vRecv.empty())
             vRecv >> pfrom->fRelayTxes; // set to true after we get the first filter* message
         else
@@ -5323,7 +5329,7 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         if (fLogIPs)
             remoteAddr = ", peeraddr=" + pfrom->addr.ToString();
 
-        LogPrintf("receive version message: %s: version %d, blocks=%d, us=%s, peer=%d%s\n",
+        LogPrintf("receive version message: %s: version %d, blocks=%u, us=%s, peer=%d%s\n",
                   pfrom->cleanSubVer, pfrom->nVersion,
                   pfrom->nStartingHeight, addrMe.ToString(), pfrom->id,
                   remoteAddr);
@@ -5756,7 +5762,8 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
                 // Headers message had its maximum size; the peer may have more headers.
                 // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
                 // from there instead.
-                LogPrint("net", "more getheaders from height=%d (max: %zu) to peer=%d (startheight=%d)\n", pindexLast->nHeight, MAX_HEADERS_RESULTS, pfrom->id, pfrom->nStartingHeight);
+                LogPrint("net", "more getheaders from height=%d (max: %zu) to peer=%d (startheight=%u)\n",
+                    pindexLast->nHeight, MAX_HEADERS_RESULTS, pfrom->id, pfrom->nStartingHeight);
                 pfrom->PushMessage("getheaders", chainActive.GetLocator(pindexLast), uint256());
             }
 
@@ -5892,19 +5899,23 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
         bool bPingFinished = false;
         string sProblem;
 
-        if (nAvail >= sizeof(nonce)) {
+        if (nAvail >= sizeof(nonce))
+        {
             vRecv >> nonce;
 
             // Only process pong message if there is an outstanding ping (old ping without nonce should never pong)
-            if (pfrom->nPingNonceSent != 0) {
-                if (nonce == pfrom->nPingNonceSent) {
+            if (pfrom->nPingNonceSent != 0)
+            {
+                if (nonce == pfrom->nPingNonceSent)
+                {
                     // Matching pong received, this ping is no longer outstanding
                     bPingFinished = true;
                     int64_t pingUsecTime = pingUsecEnd - pfrom->nPingUsecStart;
-                    if (pingUsecTime > 0) {
+                    if (pingUsecTime > 0)
+                    {
                         // Successful ping time measurement, replace previous
                         pfrom->nPingUsecTime = pingUsecTime;
-                        pfrom->nMinPingUsecTime = min(pfrom->nMinPingUsecTime, pingUsecTime);
+                        pfrom->nMinPingUsecTime = min(pfrom->nMinPingUsecTime.load(), pingUsecTime);
                     } else {
                         // This should never happen
                         sProblem = "Timing mishap";
@@ -5912,22 +5923,23 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
                 } else {
                     // Nonce mismatches are normal when pings are overlapping
                     sProblem = "Nonce mismatch";
-                    if (nonce == 0) {
+                    if (nonce == 0)
+                    {
                         // This is most likely a bug in another implementation somewhere; cancel this ping
                         bPingFinished = true;
                         sProblem = "Nonce zero";
                     }
                 }
-            } else {
+            } else
                 sProblem = "Unsolicited pong without ping";
-            }
         } else {
             // This is most likely a bug in another implementation somewhere; cancel this ping
             bPingFinished = true;
             sProblem = "Short payload";
         }
 
-        if (!(sProblem.empty())) {
+        if (!(sProblem.empty()))
+        {
             LogPrint("net", "pong peer=%d %s: %s, %x expected, %x received, %u bytes\n",
                 pfrom->id,
                 pfrom->cleanSubVer,
@@ -5936,9 +5948,8 @@ static bool ProcessMessage(const CChainParams& chainparams, CNode* pfrom, string
                 nonce,
                 nAvail);
         }
-        if (bPingFinished) {
+        if (bPingFinished)
             pfrom->nPingNonceSent = 0;
-        }
     }
 
     else if (fAlerts && strCommand == "alert")
@@ -6213,22 +6224,21 @@ bool SendMessages(const CChainParams& chainparams, CNode* pto, bool fSendTrickle
         // Message: ping
         //
         bool pingSend = false;
-        if (pto->fPingQueued) {
-            // RPC ping request by user
-            pingSend = true;
-        }
-        if (pto->nPingNonceSent == 0 && pto->nPingUsecStart + PING_INTERVAL * 1000000 < GetTimeMicros()) {
-            // Ping automatically sent as a latency probe & keepalive.
-            pingSend = true;
-        }
-        if (pingSend) {
+        if (pto->fPingQueued)
+            pingSend = true; // RPC ping request by user
+        if (pto->nPingNonceSent == 0 && pto->nPingUsecStart + PING_INTERVAL * 1000000 < GetTimeMicros())
+            pingSend = true; // Ping automatically sent as a latency probe & keepalive.
+        if (pingSend)
+        {
             uint64_t nonce = 0;
-            while (nonce == 0) {
+            while (nonce == 0)
+            {
                 GetRandBytes((unsigned char*)&nonce, sizeof(nonce));
             }
             pto->fPingQueued = false;
             pto->nPingUsecStart = GetTimeMicros();
-            if (pto->nVersion > BIP0031_VERSION) {
+            if (pto->nVersion > BIP0031_VERSION)
+            {
                 pto->nPingNonceSent = nonce;
                 pto->PushMessage("ping", nonce);
             } else {
@@ -6326,7 +6336,8 @@ bool SendMessages(const CChainParams& chainparams, CNode* pto, bool fSendTrickle
                 state.fSyncStarted = true;
                 nSyncStarted++;
                 const auto pindexStart = pindexBestHeader->pprev ? pindexBestHeader->pprev : pindexBestHeader;
-                LogPrint("net", "initial getheaders (height=%d) to peer=%d (startheight=%d)\n", pindexStart->nHeight, nodeId, pto->nStartingHeight);
+                LogPrint("net", "initial getheaders (height=%d) to peer=%d (startheight=%u)\n",
+                    pindexStart->nHeight, nodeId, pto->nStartingHeight);
                 pto->PushMessage("getheaders", chainActive.GetLocator(pindexStart), uint256());
             }
         }

--- a/src/main.h
+++ b/src/main.h
@@ -1,7 +1,7 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 

--- a/src/mnode/mnode-manager.cpp
+++ b/src/mnode/mnode-manager.cpp
@@ -1063,7 +1063,7 @@ void CMasternodeMan::CheckSameAddr()
 
 bool CMasternodeMan::SendVerifyRequest(const CAddress& addr, const vector<CMasternode*>& vSortedByAddr)
 {
-     if (masterNodeCtrl.requestTracker.HasFulfilledRequest(addr, strprintf("%s", NetMsgType::MNVERIFY)+"-request"))
+    if (masterNodeCtrl.requestTracker.HasFulfilledRequest(addr, strprintf("%s", NetMsgType::MNVERIFY)+"-request"))
     {
         // we already asked for verification, not a good idea to do this too often, skip it
         LogFnPrint("masternode", "too many requests, skipping... addr=%s", addr.ToString());

--- a/src/mnode/rpc/masternode.cpp
+++ b/src/mnode/rpc/masternode.cpp
@@ -1009,6 +1009,10 @@ As json rpc:
                     throw JSONRPCError(RPC_INTERNAL_ERROR, 
                         strprintf("MasterNode not found by collateral txid-index: %s", outpoint.ToStringShort()));
             } break;
+
+            case RPC_CMD_SCORE::rpc_command_count:
+            case RPC_CMD_SCORE::unknown:
+                break;
         }
         retVal.pushKV("pose-ban-score", mn.getPoSeBanScore());
         const bool isBannedByScore = mn.IsPoSeBannedByScore();

--- a/src/mnode/tickets/action-reg.cpp
+++ b/src/mnode/tickets/action-reg.cpp
@@ -200,6 +200,11 @@ void CActionRegTicket::parse_action_ticket()
                 case ACTION_TKT_PROP::collection_act_txid:
                     value.get_to(m_sCollectionActTxid);
                     break;
+
+                case ACTION_TKT_PROP::version:
+                case ACTION_TKT_PROP::app_ticket:
+                case ACTION_TKT_PROP::unknown:
+                    break;
             }  // switch
         } // for
 

--- a/src/mnode/tickets/collection-reg.cpp
+++ b/src/mnode/tickets/collection-reg.cpp
@@ -176,6 +176,12 @@ void CollectionRegTicket::parse_collection_ticket()
                     if (bHasGreen)
                         m_sGreenAddress = GreenAddress(GetActiveChainHeight());
                 } break;
+
+                case COLL_TKT_PROP::version:
+                case COLL_TKT_PROP::app_ticket:
+                case COLL_TKT_PROP::unknown:
+                    break;
+
             } //switch
         } // for
 

--- a/src/mnode/tickets/nft-reg.cpp
+++ b/src/mnode/tickets/nft-reg.cpp
@@ -179,6 +179,11 @@ void CNFTRegTicket::parse_nft_ticket()
                     if (bHasGreen)
                         m_sGreenAddress = GreenAddress(GetActiveChainHeight());
                 } break;
+
+                case NFT_TKT_PROP::version:
+                case NFT_TKT_PROP::app_ticket:
+                case NFT_TKT_PROP::unknown:
+                    break;
             } // switch
         } // for 
 

--- a/src/mnode/tickets/transfer.cpp
+++ b/src/mnode/tickets/transfer.cpp
@@ -445,6 +445,9 @@ CAmount CTransferTicket::GetExtraOutputs(vector<CTxOut>& outputs) const
                 nGreenNFTAmount = nPriceAmount * CNFTRegTicket::GreenPercent(chainHeight) / 100;
             }
         } break;
+
+        default:
+            break;
     }
 
     nPriceAmount -= (nRoyaltyAmount + nGreenNFTAmount);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1984,7 +1984,6 @@ bool hasActiveNetworkInterface()
             continue;
         if (strcmp(ifa->ifa_name, "lo") == 0 || strcmp(ifa->ifa_name, "lo0") == 0)
             continue;
-        LogFnPrintf("%s is %s", ifa->ifa_name, ifa->ifa_flags & IFF_UP ? "UP" : "DOWN");
         if (!(ifa->ifa_flags & IFF_UP))
             continue;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -8,14 +8,24 @@
 #include "config/bitcoin-config.h"
 #endif
 
+#include <cinttypes>
 #ifdef WIN32
 #include <string.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#include <wininet.h>
 #else
 #include <fcntl.h>
+#include <ifaddrs.h>
 #endif
+
+#include <scope_guard.hpp>
 
 #include <main.h>
 #include <net.h>
+#include <net_manager.h>
+#include <util.h>
 #include <addrman.h>
 #include <chainparams.h>
 #include <clientversion.h>
@@ -24,7 +34,7 @@
 #include <ui_interface.h>
 #include <crypto/common.h>
 #include <svc_thread.h>
-
+#include <util.h>
 //MasterNode
 #include <mnode/mnode-controller.h>
 
@@ -625,9 +635,8 @@ void CNode::copyStats(CNodeStats &stats)
     // So, if a ping is taking an unusually long time in flight,
     // the caller can immediately detect that this is happening.
     int64_t nPingUsecWait = 0;
-    if ((0 != nPingNonceSent) && (0 != nPingUsecStart)) {
+    if ((0 != nPingNonceSent) && (0 != nPingUsecStart))
         nPingUsecWait = GetTimeMicros() - nPingUsecStart;
-    }
 
     // Raw ping time is in microseconds, but show it to user as whole seconds (Bitcoin users should be well used to small numbers with many decimal places by now :)
     stats.dPingTime = (((double)nPingUsecTime) / 1e6);
@@ -727,9 +736,9 @@ int CNetMessage::readData(const char *pch, unsigned int nBytes)
 // requires LOCK(cs_vSend)
 void SocketSendData(CNode *pnode)
 {
-    std::deque<CSerializeData>::iterator it = pnode->vSendMsg.begin();
-
-    while (it != pnode->vSendMsg.end()) {
+    auto it = pnode->vSendMsg.begin();
+    while (it != pnode->vSendMsg.end())
+    {
         const CSerializeData &data = *it;
         assert(data.size() > pnode->nSendOffset);
         const int nBytes = send(pnode->hSocket, &data[pnode->nSendOffset], static_cast<int>(data.size() - pnode->nSendOffset), MSG_NOSIGNAL | MSG_DONTWAIT);
@@ -739,7 +748,8 @@ void SocketSendData(CNode *pnode)
             pnode->nSendBytes += nBytes;
             pnode->nSendOffset += nBytes;
             pnode->RecordBytesSent(nBytes);
-            if (pnode->nSendOffset == data.size()) {
+            if (pnode->nSendOffset == data.size())
+            {
                 pnode->nSendOffset = 0;
                 pnode->nSendSize -= data.size();
                 it++;
@@ -754,7 +764,7 @@ void SocketSendData(CNode *pnode)
                 int nErr = WSAGetLastError();
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
-                    LogPrintf("socket send error %s\n", NetworkErrorString(nErr));
+                    LogFnPrintf("socket send error %s", GetErrorString(nErr));
                     pnode->CloseSocketDisconnect();
                 }
             }
@@ -978,7 +988,7 @@ static void AcceptConnection(const ListenSocket& hListenSocket)
 
     if (hSocket != INVALID_SOCKET)
         if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))
-            LogPrintf("Warning: Unknown socket family\n");
+            LogFnPrintf("Warning: Unknown socket family");
 
     bool whitelisted = hListenSocket.whitelisted || CNode::IsWhitelistedRange(addr);
     {
@@ -994,29 +1004,30 @@ static void AcceptConnection(const ListenSocket& hListenSocket)
     {
         int nErr = WSAGetLastError();
         if (nErr != WSAEWOULDBLOCK)
-            LogPrintf("socket error accept failed: %s\n", NetworkErrorString(nErr));
+            LogFnPrintf("socket error accept failed: %s", GetErrorString(nErr));
         return;
     }
 
     if (!IsSelectableSocket(hSocket))
     {
-        LogPrintf("connection from %s dropped: non-selectable socket\n", addr.ToString());
+        LogFnPrintf("connection from %s dropped: non-selectable socket", addr.ToString());
         CloseSocket(hSocket);
         return;
     }
 
     if (CNode::IsBanned(addr) && !whitelisted)
     {
-        LogPrintf("connection from %s dropped (banned)\n", addr.ToString());
+        LogFnPrintf("connection from %s dropped (banned)", addr.ToString());
         CloseSocket(hSocket);
         return;
     }
 
     if (nInbound >= nMaxInbound)
     {
-        if (!AttemptToEvictConnection(whitelisted)) {
+        if (!AttemptToEvictConnection(whitelisted))
+        {
             // No connection to evict, disconnect the new connection
-            LogPrint("net", "failed to find an eviction candidate - connection dropped (full)\n");
+            LogFnPrint("net", "failed to find an eviction candidate - connection dropped (full)");
             CloseSocket(hSocket);
             return;
         }
@@ -1024,8 +1035,9 @@ static void AcceptConnection(const ListenSocket& hListenSocket)
 
     //MasterNode
     // // don't accept incoming connections until fully synced
-    if(masterNodeCtrl.IsMasterNode() && !masterNodeCtrl.IsSynced()) {
-        LogPrintf("AcceptConnection -- masternode is not synced yet, skipping inbound connection attempt\n");
+    if (masterNodeCtrl.IsMasterNode() && !masterNodeCtrl.IsSynced())
+    {
+        LogFnPrintf("AcceptConnection -- masternode is not synced yet, skipping inbound connection attempt");
         CloseSocket(hSocket);
         return;
     }
@@ -1043,7 +1055,7 @@ static void AcceptConnection(const ListenSocket& hListenSocket)
     CNode* pnode = new CNode(hSocket, addr, "", true);
     pnode->fWhitelisted = whitelisted;
 
-    LogPrint("net", "connection from %s accepted\n", addr.ToString());
+    LogFnPrint("net", "connection from %s accepted", addr.ToString());
 
     {
         LOCK(cs_vNodes);
@@ -1068,7 +1080,7 @@ void CSocketHandlerThread::execute()
                 if (pnode->fDisconnect ||
                     (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0 && pnode->ssSend.empty()))
                 {
-                    LogPrintf("ThreadSocketHandler -- removing node: peer=%d addr=%s nRefCount=%d fNetworkNode=%d fInbound=%d fMasternode=%d\n",
+                    LogFnPrintf("ThreadSocketHandler -- removing node: peer=%d addr=%s nRefCount=%d fNetworkNode=%d fInbound=%d fMasternode=%d",
                               pnode->id, pnode->addr.ToString(), pnode->GetRefCount(), pnode->fNetworkNode, pnode->fInbound, pnode->fMasternode);
                     
                     // remove from vNodes
@@ -1214,7 +1226,7 @@ void CSocketHandlerThread::execute()
             if (have_fds)
             {
                 int nErr = WSAGetLastError();
-                LogPrintf("socket select error %s\n", NetworkErrorString(nErr));
+                LogFnPrintf("socket select error %s", GetErrorString(nErr));
                 for (unsigned int i = 0; i <= hSocketMax; i++)
                     FD_SET(i, &fdsetRecv);
             }
@@ -1292,7 +1304,7 @@ void CSocketHandlerThread::execute()
                             if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                             {
                                 if (!pnode->fDisconnect)
-                                    LogPrintf("socket recv error %s\n", NetworkErrorString(nErr));
+                                    LogFnPrintf("socket recv error %s", GetErrorString(nErr));
                                 pnode->CloseSocketDisconnect();
                             }
                         }
@@ -1314,29 +1326,42 @@ void CSocketHandlerThread::execute()
 
             //
             // Inactivity checking
+            // if network disconnected - do not check for inactivity
+            // if network was connected recently - wait for some time before checking for inactivity
             //
             int64_t nTime = GetTime();
-            if (nTime - pnode->nTimeConnected > 60)
-            {
-                if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
+            if (gl_NetMgr.IsNetworkConnected() && (nTime - pnode->nTimeConnected > 60))
+            {   
+                if (gl_NetMgr.IsNetworkConnectedRecently())
                 {
-                    LogPrint("net", "socket no message in first 60 seconds, %d %d from %d\n", pnode->nLastRecv != 0, pnode->nLastSend != 0, pnode->id);
-                    pnode->fDisconnect = true;
+                    if (!pnode->fPingQueued)
+                    {
+                        pnode->fPingQueued = true;
+                        LogFnPrintf("Node %d ping queued after %" PRId64 "s of network inactivity", pnode->id, gl_NetMgr.GetNetworkInactivityTime(nTime));
+                    }
                 }
-                else if (nTime - pnode->nLastSend > TIMEOUT_INTERVAL)
+                else
                 {
-                    LogPrintf("socket sending timeout: %is\n", nTime - pnode->nLastSend);
-                    pnode->fDisconnect = true;
-                }
-                else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
-                {
-                    LogPrintf("socket receive timeout: %is\n", nTime - pnode->nLastRecv);
-                    pnode->fDisconnect = true;
-                }
-                else if (pnode->nPingNonceSent && pnode->nPingUsecStart + TIMEOUT_INTERVAL * 1000000 < GetTimeMicros())
-                {
-                    LogPrintf("ping timeout: %fs\n", 0.000001 * (GetTimeMicros() - pnode->nPingUsecStart));
-                    pnode->fDisconnect = true;
+                    if (pnode->nLastRecv == 0 || pnode->nLastSend == 0)
+                    {
+                        LogFnPrint("net", "socket no message in first 60 seconds, %d %d from %d", pnode->nLastRecv != 0, pnode->nLastSend != 0, pnode->id);
+                        pnode->fDisconnect = true;
+                    }
+                    else if (nTime - pnode->nLastSend > DISCONNECT_TIMEOUT_INTERVAL_SECS)
+                    {
+                        LogFnPrintf("socket sending timeout: %" PRId64 "s", nTime - pnode->nLastSend);
+                        pnode->fDisconnect = true;
+                    }
+                    else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? DISCONNECT_TIMEOUT_INTERVAL_SECS : 90 * 60))
+                    {
+                        LogFnPrintf("socket receive timeout: %" PRId64 "s", nTime - pnode->nLastRecv);
+                        pnode->fDisconnect = true;
+                    }
+                    else if (pnode->nPingNonceSent && pnode->nPingUsecStart + DISCONNECT_TIMEOUT_INTERVAL_SECS * 1000000 < GetTimeMicros())
+                    {
+                        LogFnPrintf("ping timeout: %fs", 0.000001 * (GetTimeMicros() - pnode->nPingUsecStart));
+                        pnode->fDisconnect = true;
+                    }
                 }
             }
         }
@@ -1371,7 +1396,7 @@ public:
             LOCK(cs_vNodes);
             if (vNodes.size() >= 2)
             {
-                LogPrintf("P2P peers available. Skipped DNS seeding.\n");
+                LogFnPrintf("P2P peers available. Skipped DNS seeding.");
                 return;
             }
         }
@@ -1381,7 +1406,7 @@ public:
         const vector<CDNSSeedData> &vSeeds = Params().DNSSeeds();
         int found = 0;
 
-        LogPrintf("Loading addresses from DNS seeds (could take a while)\n");
+        LogFnPrintf("Loading addresses from DNS seeds (could take a while)");
 
         for (const auto &seed : vSeeds)
         {
@@ -1408,7 +1433,7 @@ public:
             }
         }
 
-        LogPrintf("%d addresses found from DNS seeds\n", found);
+        LogFnPrintf("%d addresses found from DNS seeds", found);
     }
 };
 
@@ -1419,7 +1444,7 @@ void DumpAddresses()
     CAddrDB adb;
     adb.Write(addrman);
 
-    LogPrint("net", "Flushed %d addresses to peers.dat  %dms\n",
+    LogFnPrint("net", "Flushed %zu addresses to peers.dat  %zums",
            addrman.size(), GetTimeMillis() - nStart);
 }
 
@@ -1803,22 +1828,22 @@ bool BindListenPort(const CService &addrBind, string& strError, bool fWhiteliste
     socklen_t len = sizeof(sockaddr);
     if (!addrBind.GetSockAddr((struct sockaddr*)&sockaddr, &len))
     {
-        strError = strprintf("Error: Bind address family for %s not supported", addrBind.ToString());
-        LogPrintf("%s\n", strError);
+        strError = strprintf("ERROR: Bind address family for %s not supported", addrBind.ToString());
+        LogFnPrintf("%s", strError);
         return false;
     }
 
     SOCKET hListenSocket = socket(((struct sockaddr*)&sockaddr)->sa_family, SOCK_STREAM, IPPROTO_TCP);
     if (hListenSocket == INVALID_SOCKET)
     {
-        strError = strprintf("Error: Couldn't open socket for incoming connections (socket returned error %s)", NetworkErrorString(WSAGetLastError()));
-        LogPrintf("%s\n", strError);
+        strError = strprintf("ERROR: Couldn't open socket for incoming connections (socket returned error %s)", GetErrorString(WSAGetLastError()));
+        LogFnPrintf("%s", strError);
         return false;
     }
     if (!IsSelectableSocket(hListenSocket))
     {
-        strError = "Error: Couldn't create a listenable socket for incoming connections";
-        LogPrintf("%s\n", strError);
+        strError = "ERROR: Couldn't create a listenable socket for incoming connections";
+        LogFnPrintf("%s", strError);
         return false;
     }
 
@@ -1839,15 +1864,17 @@ bool BindListenPort(const CService &addrBind, string& strError, bool fWhiteliste
 #endif
 
     // Set to non-blocking, incoming connections will also inherit this
-    if (!SetSocketNonBlocking(hListenSocket, true)) {
-        strError = strprintf("BindListenPort: Setting listening socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
-        LogPrintf("%s\n", strError);
+    if (!SetSocketNonBlocking(hListenSocket, true))
+    {
+        strError = strprintf("Setting listening socket to non-blocking failed, error %s", GetErrorString(WSAGetLastError()));
+        LogFnPrintf("%s", strError);
         return false;
     }
 
     // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
     // and enable it by default or not. Try to enable it, if possible.
-    if (addrBind.IsIPv6()) {
+    if (addrBind.IsIPv6())
+    {
 #ifdef IPV6_V6ONLY
 #ifdef WIN32
         setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&nOne, sizeof(int));
@@ -1867,18 +1894,18 @@ bool BindListenPort(const CService &addrBind, string& strError, bool fWhiteliste
         if (nErr == WSAEADDRINUSE)
             strError = strprintf(_("Unable to bind to %s on this computer. Pastel is probably already running."), addrBind.ToString());
         else
-            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToString(), NetworkErrorString(nErr));
-        LogPrintf("%s\n", strError);
+            strError = strprintf(_("Unable to bind to %s on this computer (bind returned error %s)"), addrBind.ToString(), GetErrorString(nErr));
+        LogFnPrintf("%s", strError);
         CloseSocket(hListenSocket);
         return false;
     }
-    LogPrintf("Bound to %s\n", addrBind.ToString());
+    LogFnPrintf("Bound to %s", addrBind.ToString());
 
     // Listen for incoming connections
     if (listen(hListenSocket, SOMAXCONN) == SOCKET_ERROR)
     {
-        strError = strprintf(_("Error: Listening for incoming connections failed (listen returned error %s)"), NetworkErrorString(WSAGetLastError()));
-        LogPrintf("%s\n", strError);
+        strError = strprintf(_("ERROR: Listening for incoming connections failed (listen returned error %s)"), GetErrorString(WSAGetLastError()));
+        LogFnPrintf("%s", strError);
         CloseSocket(hListenSocket);
         return false;
     }
@@ -1889,6 +1916,105 @@ bool BindListenPort(const CService &addrBind, string& strError, bool fWhiteliste
         AddLocal(addrBind, LOCAL_BIND);
 
     return true;
+}
+
+#ifdef WIN32
+bool hasWinActiveNetworkInterface()
+{
+    ULONG bufferSize = 0;
+    PIP_ADAPTER_ADDRESSES adapterAddresses = nullptr;
+    ULONG result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, adapterAddresses, &bufferSize);
+    if (result == ERROR_BUFFER_OVERFLOW)
+    {
+        adapterAddresses = static_cast<PIP_ADAPTER_ADDRESSES>(malloc(bufferSize));
+        if (!adapterAddresses)
+        {
+            LogFnPrintf("ERROR: Memory allocation failed for IP_ADAPTER_ADDRESSES struct.");
+            return false;
+        }
+        // AF_UNSPEC: unspecified address family (both)
+        // GAA_FLAG_INCLUDE_PREFIX: return a list of both IPv6 and IPv4 IP address prefixes on this adapter.
+        result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr, adapterAddresses, &bufferSize);
+    }
+    auto adapterAddressesGuard = sg::make_scope_guard([&]() noexcept  { free(adapterAddresses); });
+
+    if (result != NO_ERROR)
+    {
+        LogFnPrintf("ERROR: GetAdaptersAddresses failed with error: ");
+        return false;
+    }
+
+    for (PIP_ADAPTER_ADDRESSES adapter = adapterAddresses; adapter != nullptr; adapter = adapter->Next)
+    {
+        if (adapter->OperStatus != IfOperStatusUp)
+            continue;
+        for (PIP_ADAPTER_UNICAST_ADDRESS addr = adapter->FirstUnicastAddress; addr != nullptr; addr = addr->Next)
+        {
+            if (addr->Address.lpSockaddr->sa_family == AF_INET ||
+                addr->Address.lpSockaddr->sa_family == AF_INET6)
+                return true;
+        }
+    }
+    return false;
+}
+#endif // WIN32
+
+bool hasActiveNetworkInterface()
+{
+#ifdef WIN32
+    DWORD dwConnectionFlags = 0;
+    const BOOL bIsConnected = InternetGetConnectedState(&dwConnectionFlags, 0);
+    if (bIsConnected && ((dwConnectionFlags & INTERNET_CONNECTION_OFFLINE) == 0))
+		return true;
+#else
+    struct ifaddrs* ifaddr = nullptr;
+    struct ifaddrs* ifa = nullptr;
+    int family, result;
+
+    if (getifaddrs(&ifaddr) == -1)
+    {
+        LogFnPrintf("ERROR: getifaddrs failed %s", GetErrorString(errno));
+        return false;
+    }
+    auto ifaddr_guard = sg::make_scope_guard([&]() noexcept { freeifaddrs(ifaddr); });
+
+    for (ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next)
+    {
+        if (!ifa->ifa_addr)
+            continue;
+        if (strcmp(ifa->ifa_name, "lo") == 0 || strcmp(ifa->ifa_name, "lo0") == 0)
+            continue;
+        LogFnPrintf("%s is %s", ifa->ifa_name, ifa->ifa_flags & IFF_UP ? "UP" : "DOWN");
+        if (!(ifa->ifa_flags & IFF_UP))
+            continue;
+
+        family = ifa->ifa_addr->sa_family;
+        if (family == AF_INET || family == AF_INET6)
+        {
+            char host[NI_MAXHOST];
+            result = getnameinfo(ifa->ifa_addr,
+                                 (family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6),
+                                 host, NI_MAXHOST,
+                                 nullptr, 0, NI_NUMERICHOST);
+            if (result == 0)
+                return true;
+        }
+    }
+#endif
+    return false;
+}
+
+bool hasInternetConnectivity()
+{
+    const v_strings vHosts = { "google.com", "microsoft.com", "amazon.com", "8.8.8.8", "1.1.1.1" };
+
+    for (const auto& sHost : vHosts)
+    {
+        std::string cmd = "ping -c 1 " + sHost + " >/dev/null 2>&1";
+        if (std::system(cmd.c_str()) == 0)
+            return true;
+    }
+    return false;
 }
 
 void static Discover()
@@ -1954,11 +2080,14 @@ void StartNode(CServiceThreadGroup& threadGroup, CScheduler &scheduler)
     {
         CAddrDB adb;
         if (!adb.Read(addrman))
-            LogPrintf("Invalid or missing peers.dat; recreating\n");
+            LogFnPrintf("Invalid or missing peers.dat; recreating");
     }
-    LogPrintf("Loaded %i addresses from peers.dat  %dms\n",
+    LogFnPrintf("Loaded %i addresses from peers.dat  %dms",
            addrman.size(), GetTimeMillis() - nStart);
     fAddressesInitialized = true;
+
+    // Network Manager thread, check network connectivity
+    gl_NetMgr.start();
 
     if (!semOutbound)
     {
@@ -1977,7 +2106,7 @@ void StartNode(CServiceThreadGroup& threadGroup, CScheduler &scheduler)
     //
 
     if (!GetBoolArg("-dnsseed", true))
-        LogPrintf("DNS seeding disabled\n");
+        LogFnPrintf("DNS seeding disabled");
     else
         threadGroup.add_thread(make_shared<CDNSAddressSeedThread>());
 
@@ -2003,13 +2132,15 @@ void StartNode(CServiceThreadGroup& threadGroup, CScheduler &scheduler)
 
 bool StopNode()
 {
-    LogPrintf("StopNode()\n");
+    LogFnPrintf("StopNode()");
     if (semOutbound)
         for (int i=0; i<MAX_OUTBOUND_CONNECTIONS; i++)
             semOutbound->post();
 
     //MasterNode
     masterNodeCtrl.StopMasterNode();
+
+    gl_NetMgr.stop();
 
     if (fAddressesInitialized)
     {
@@ -2038,7 +2169,7 @@ public:
             if (hListenSocket.socket != INVALID_SOCKET)
             {
                 if (!CloseSocket(hListenSocket.socket))
-                    LogPrintf("CloseSocket(hListenSocket) failed with error %s\n", NetworkErrorString(WSAGetLastError()));
+                    LogFnPrintf("CloseSocket(hListenSocket) failed with error %s", GetErrorString(WSAGetLastError()));
             }
         }
 

--- a/src/net.h
+++ b/src/net.h
@@ -187,7 +187,7 @@ public:
     int nVersion;
     std::string cleanSubVer;
     bool fInbound;
-    uint32_t nStartingHeight;
+    int32_t nStartingHeight;
     uint64_t nSendBytes;
     uint64_t nRecvBytes;
     bool fWhitelisted;
@@ -308,7 +308,7 @@ protected:
 
 public:
     uint256 hashContinue;
-    std::atomic_uint32_t nStartingHeight;
+    std::atomic_int32_t nStartingHeight;
 
     // flood relay
     std::vector<CAddress> vAddrToSend;

--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2018-2023 The Pastel Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <chrono>
+#include <net.h>
+#include <net_manager.h>
+
+using namespace std;
+
+CNetManagerThread gl_NetMgr;
+
+constexpr chrono::seconds ACTIVE_CHECK_PERIOD_SECS = 5s;
+constexpr chrono::seconds INACTIVE_CHECK_PERIOD_SECS = 1s;
+constexpr  int64_t INACTIVITY_CHECK_GRACE_PERIOD_SECS = 30;
+
+CNetManagerThread::CNetManagerThread() : 
+    CStoppableServiceThread("netmgr")
+{
+    m_bNetworkActive = true;
+    m_nNetworkActiveStartTime = GetTime();
+}
+
+void CNetManagerThread::NotifyNetworkConnected()
+{
+    m_bNetworkActive = true;
+    m_nNetworkActiveStartTime = time(nullptr);
+    LogFnPrintf("!!! <<< NETWORK CONNECTED >>> !!!");
+}
+
+void CNetManagerThread::NotifyNetworkDisconnected()
+{
+    LogFnPrintf("!!! <<< NETWORK IS UNREACHABLE >>> !!!");
+    m_bNetworkActive = false;
+    m_nNetworkInactiveStartTime = GetTime();
+}
+
+chrono::seconds CNetManagerThread::checkNetworkConnectivity()
+{
+    const bool bPrevNetworkState = m_bNetworkActive;
+    const bool bHasActiveNetworkInterface = hasActiveNetworkInterface();
+    if (!bHasActiveNetworkInterface)
+    {
+        if (bPrevNetworkState)
+        {
+            LogFnPrintf("No active network interfaces detected!!! Checking internet connectivity...");
+            NotifyNetworkDisconnected();
+        }
+        return INACTIVE_CHECK_PERIOD_SECS;
+    }
+    const bool bHasInternetConnectivity = hasInternetConnectivity();
+    if (bHasInternetConnectivity)
+    {
+        if (!bPrevNetworkState)
+            NotifyNetworkConnected();
+        return ACTIVE_CHECK_PERIOD_SECS;
+    }
+    if (bPrevNetworkState)
+        NotifyNetworkDisconnected();
+    return INACTIVE_CHECK_PERIOD_SECS;
+}
+
+void CNetManagerThread::execute()
+{
+    chrono::seconds check_period = ACTIVE_CHECK_PERIOD_SECS;
+    while (!shouldStop())
+    {
+        unique_lock<mutex> lck(m_mutex);
+        if (m_condVar.wait_for(lck, check_period) == cv_status::no_timeout)
+            continue;
+        check_period = checkNetworkConnectivity();
+    }
+}
+
+bool CNetManagerThread::IsNetworkConnectedRecently() const noexcept
+{
+    if (!m_bNetworkActive)
+        return false;
+    if (GetTime() - m_nNetworkActiveStartTime < INACTIVITY_CHECK_GRACE_PERIOD_SECS)
+        return true;
+    return false;
+}
+
+int64_t CNetManagerThread::GetNetworkInactivityTime(const int64_t nCurrentTime) const noexcept
+{
+    const int64_t nTime = nCurrentTime ? nCurrentTime : GetTime();
+    return nTime - m_nNetworkInactiveStartTime;
+}

--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -18,6 +18,7 @@ CNetManagerThread::CNetManagerThread() :
 {
     m_bNetworkActive = true;
     m_nNetworkActiveStartTime = GetTime();
+    m_nNetworkInactiveStartTime = 0;
 }
 
 void CNetManagerThread::NotifyNetworkConnected()
@@ -73,7 +74,7 @@ void CNetManagerThread::execute()
 
 bool CNetManagerThread::IsNetworkConnectedRecently() const noexcept
 {
-    if (!m_bNetworkActive)
+    if (!m_bNetworkActive || !m_nNetworkInactiveStartTime)
         return false;
     if (GetTime() - m_nNetworkActiveStartTime < INACTIVITY_CHECK_GRACE_PERIOD_SECS)
         return true;

--- a/src/net_manager.h
+++ b/src/net_manager.h
@@ -1,0 +1,29 @@
+#pragma once
+// Copyright (c) 2018-2023 The Pastel Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <atomic>
+#include <svc_thread.h>
+
+class CNetManagerThread : public CStoppableServiceThread
+{
+public:
+    CNetManagerThread();
+
+    void execute() override;
+
+    bool IsNetworkConnected() const noexcept { return m_bNetworkActive; }
+    bool IsNetworkConnectedRecently() const noexcept;
+    int64_t GetNetworkInactivityTime(const int64_t nCurrentTime = 0) const noexcept;
+
+private:
+    std::atomic_bool m_bNetworkActive { true };
+    std::atomic_int64_t m_nNetworkInactiveStartTime;
+    std::atomic_int64_t m_nNetworkActiveStartTime;
+
+    std::chrono::seconds checkNetworkConnectivity();
+    void NotifyNetworkConnected();
+    void NotifyNetworkDisconnected();
+};
+
+extern CNetManagerThread gl_NetMgr;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -195,8 +195,6 @@ bool Lookup(const char *pszName, std::vector<CService>& vAddr, const uint16_t po
 bool LookupNumeric(const char *pszName, CService& addr, const uint16_t portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed = 0);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, uint16_t portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);
-/** Return readable error string for a network error code */
-std::string NetworkErrorString(int err);
 /** Close socket and set hSocket to INVALID_SOCKET */
 bool CloseSocket(SOCKET& hSocket);
 /** Disable or enable blocking-mode for a socket */

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2014 The Bitcoin Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <univalue.h>
 
@@ -156,8 +157,9 @@ Examples:
         // their ver message.
         obj.pushKV("subver", stats.cleanSubVer);
         obj.pushKV("inbound", stats.fInbound);
-        obj.pushKV("startingheight", stats.nStartingHeight);
-        if (fStateStats) {
+        obj.pushKV("startingheight", static_cast<uint64_t>(stats.nStartingHeight));
+        if (fStateStats)
+        {
             obj.pushKV("banscore", statestats.nMisbehavior);
             obj.pushKV("synced_headers", statestats.nSyncHeight);
             obj.pushKV("synced_blocks", statestats.nCommonHeight);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -157,7 +157,7 @@ Examples:
         // their ver message.
         obj.pushKV("subver", stats.cleanSubVer);
         obj.pushKV("inbound", stats.fInbound);
-        obj.pushKV("startingheight", static_cast<uint64_t>(stats.nStartingHeight));
+        obj.pushKV("startingheight", static_cast<int64_t>(stats.nStartingHeight));
         if (fStateStats)
         {
             obj.pushKV("banscore", statestats.nMisbehavior);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -97,7 +97,7 @@ string strMiscWarning;
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
 bool fLogIPs = DEFAULT_LOGIPS;
-std::atomic<bool> fReopenDebugLog(false);
+atomic<bool> fReopenDebugLog(false);
 CTranslationInterface translationInterface;
 
 /**
@@ -111,10 +111,10 @@ CTranslationInterface translationInterface;
  * the mutex).
  */
 
-static std::once_flag debugPrintInitFlag;
+static once_flag debugPrintInitFlag;
 
 /**
- * We use std::call_once() to make sure mutexDebugLog and
+ * We use call_once() to make sure mutexDebugLog and
  * vMsgsBeforeOpenLog are initialized in a thread-safe manner.
  *
  * NOTE: fileout, mutexDebugLog and sometimes vMsgsBeforeOpenLog
@@ -123,24 +123,24 @@ static std::once_flag debugPrintInitFlag;
  * tested, explicit destruction of these objects can be implemented.
  */
 static FILE* fileout = nullptr;
-static std::mutex* mutexDebugLog = nullptr;
+static mutex* mutexDebugLog = nullptr;
 static list<string> *vMsgsBeforeOpenLog;
 
 [[noreturn]] void new_handler_terminate()
 {
-    // Rather than throwing std::bad-alloc if allocation fails, terminate
+    // Rather than throwing bad-alloc if allocation fails, terminate
     // immediately to (try to) avoid chain corruption.
     // Since LogPrintf may itself allocate memory, set the handler directly
     // to terminate first.
-    std::set_new_handler(std::terminate);
+    set_new_handler(terminate);
     fputs("Error: Out of memory. Terminating.\n", stderr);
     LogPrintf("Error: Out of memory. Terminating.\n");
 
     // The log was successful, terminate now.
-    std::terminate();
+    terminate();
 };
 
-static int FileWriteStr(const std::string &str, FILE *fp)
+static int FileWriteStr(const string &str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);
 }
@@ -148,7 +148,7 @@ static int FileWriteStr(const std::string &str, FILE *fp)
 static void DebugPrintInit()
 {
     assert(mutexDebugLog == nullptr);
-    mutexDebugLog = new std::mutex();
+    mutexDebugLog = new mutex();
     vMsgsBeforeOpenLog = new list<string>;
 }
 
@@ -238,7 +238,7 @@ string get_tid() noexcept
 #else
     auto tid = this_thread::get_id();
 #endif
-    std::ostringstream s;
+    ostringstream s;
     s << tid;
     return s.str();
 }
@@ -265,7 +265,7 @@ inline string get_tid_hex() noexcept
  * suppress printing of the timestamp when multiple calls are made that don't
  * end in a newline. Initialize it to true, and hold it, in the calling context.
  */
-static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine)
+static string LogTimestampStr(const string &str, bool *fStartedNewLine)
 {
     string strStamped;
     strStamped.reserve(30 + str.size());
@@ -287,7 +287,7 @@ static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine
     return strStamped;
 }
 
-int LogPrintStr(const std::string &str)
+int LogPrintStr(const string &str)
 {
     int ret = 0; // Returns total number of characters written
     static bool fStartedNewLine = true;
@@ -299,8 +299,8 @@ int LogPrintStr(const std::string &str)
     }
     else if (fPrintToDebugLog)
     {
-        std::call_once(debugPrintInitFlag, &DebugPrintInit);
-        std::scoped_lock scoped_lock(*mutexDebugLog);
+        call_once(debugPrintInitFlag, &DebugPrintInit);
+        scoped_lock scoped_lock(*mutexDebugLog);
 
         string strTimestamped = LogTimestampStr(str, &fStartedNewLine);
 
@@ -333,7 +333,7 @@ static void InterpretNegativeSetting(string name, map<string, string>& mapSettin
     // interpret -nofoo as -foo=0 (and -nofoo=0 as -foo=1) as long as -foo not set
     if (name.find("-no") == 0)
     {
-        std::string positive("-");
+        string positive("-");
         positive.append(name.begin()+3, name.end());
         if (mapSettingsRet.count(positive) == 0)
         {
@@ -350,10 +350,10 @@ void ParseParameters(int argc, const char* const argv[])
 
     for (int i = 1; i < argc; i++)
     {
-        std::string str(argv[i]);
-        std::string strValue;
+        string str(argv[i]);
+        string strValue;
         size_t is_index = str.find('=');
-        if (is_index != std::string::npos)
+        if (is_index != string::npos)
         {
             strValue = str.substr(is_index+1);
             str = str.substr(0, is_index);
@@ -382,21 +382,21 @@ void ParseParameters(int argc, const char* const argv[])
         InterpretNegativeSetting(entry.first, mapArgs);
 }
 
-std::string GetArg(const std::string& strArg, const std::string& strDefault)
+string GetArg(const string& strArg, const string& strDefault)
 {
     if (mapArgs.count(strArg))
         return mapArgs[strArg];
     return strDefault;
 }
 
-int64_t GetArg(const std::string& strArg, int64_t nDefault)
+int64_t GetArg(const string& strArg, int64_t nDefault)
 {
     if (mapArgs.count(strArg))
         return atoi64(mapArgs[strArg]);
     return nDefault;
 }
 
-bool GetBoolArg(const std::string& strArg, bool fDefault)
+bool GetBoolArg(const string& strArg, bool fDefault)
 {
     if (mapArgs.count(strArg))
     {
@@ -407,7 +407,7 @@ bool GetBoolArg(const std::string& strArg, bool fDefault)
     return fDefault;
 }
 
-bool SoftSetArg(const std::string& strArg, const std::string& strValue)
+bool SoftSetArg(const string& strArg, const string& strValue)
 {
     if (mapArgs.count(strArg))
         return false;
@@ -415,30 +415,61 @@ bool SoftSetArg(const std::string& strArg, const std::string& strValue)
     return true;
 }
 
-bool SoftSetBoolArg(const std::string& strArg, bool fValue)
+bool SoftSetBoolArg(const string& strArg, bool fValue)
 {
     if (fValue)
-        return SoftSetArg(strArg, std::string("1"));
+        return SoftSetArg(strArg, string("1"));
     else
-        return SoftSetArg(strArg, std::string("0"));
+        return SoftSetArg(strArg, string("0"));
 }
 
 static const int screenWidth = 79;
 static const int optIndent = 2;
 static const int msgIndent = 7;
 
-std::string HelpMessageGroup(const std::string &message) {
-    return std::string(message) + std::string("\n\n");
+string HelpMessageGroup(const string &message)
+{
+    return string(message) + string("\n\n");
 }
 
-std::string HelpMessageOpt(const std::string &option, const std::string &message) {
-    return std::string(optIndent,' ') + std::string(option) +
-           std::string("\n") + std::string(msgIndent,' ') +
+string HelpMessageOpt(const string &option, const string &message)
+{
+    return string(optIndent,' ') + string(option) +
+           string("\n") + string(msgIndent,' ') +
            FormatParagraph(message, screenWidth - msgIndent, msgIndent) +
-           std::string("\n\n");
+           string("\n\n");
 }
 
-static std::string FormatException(const std::exception* pex, const char* pszThread)
+#ifdef WIN32
+string GetErrorString(const int err)
+{
+    char buf[256];
+    buf[0] = 0;
+    if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+            nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            buf, sizeof(buf), nullptr))
+        return strprintf("%s (%d)", buf, err);
+    return strprintf("Unknown error (%d)", err);
+}
+#else
+string GetErrorString(const int err)
+{
+    char buf[256];
+    const char *s = buf;
+    buf[0] = 0;
+    /* Too bad there are two incompatible implementations of the
+     * thread-safe strerror. */
+#ifdef STRERROR_R_CHAR_P /* GNU variant can return a pointer outside the passed buffer */
+    s = strerror_r(err, buf, sizeof(buf));
+#else /* POSIX variant always returns message in buffer */
+    if (strerror_r(err, buf, sizeof(buf)))
+        buf[0] = 0;
+#endif
+    return strprintf("%s (%d)", s, err);
+}
+#endif
+
+static string FormatException(const exception* pex, const char* pszThread)
 {
 #ifdef WIN32
     char pszModule[MAX_PATH] = "";
@@ -454,9 +485,9 @@ static std::string FormatException(const std::exception* pex, const char* pszThr
             "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, pszThread);
 }
 
-void PrintExceptionContinue(const std::exception* pex, const char* pszThread)
+void PrintExceptionContinue(const exception* pex, const char* pszThread)
 {
-    std::string message = FormatException(pex, pszThread);
+    string message = FormatException(pex, pszThread);
     LogPrintf("\n\n************************\n%s\n", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
     strMiscWarning = message;
@@ -550,10 +581,10 @@ const fs::path GetExportDir()
     if (mapArgs.count("-exportdir")) {
         path = fs::absolute(mapArgs["-exportdir"]);
         if (fs::exists(path) && !fs::is_directory(path)) {
-            throw std::runtime_error(strprintf("The -exportdir '%s' already exists and is not a directory", path.string()));
+            throw runtime_error(strprintf("The -exportdir '%s' already exists and is not a directory", path.string()));
         }
         if (!fs::exists(path) && !fs::create_directories(path)) {
-            throw std::runtime_error(strprintf("Failed to create directory at -exportdir '%s'", path.string()));
+            throw runtime_error(strprintf("Failed to create directory at -exportdir '%s'", path.string()));
         }
     }
     return path;
@@ -658,7 +689,7 @@ bool RenameOver(fs::path src, fs::path dest)
     return MoveFileExA(src.string().c_str(), dest.string().c_str(),
                        MOVEFILE_REPLACE_EXISTING) != 0;
 #else
-    int rc = std::rename(src.string().c_str(), dest.string().c_str());
+    int rc = rename(src.string().c_str(), dest.string().c_str());
     return (rc == 0);
 #endif /* WIN32 */
 }
@@ -784,7 +815,7 @@ void ShrinkDebugFile()
     if (file && fs::file_size(pathLog) > 10 * 1000000)
     {
         // Restart the file with some of the end
-        std::vector <char> vch(200000,0);
+        vector <char> vch(200000,0);
         fseek(file, -((long)vch.size()), SEEK_END);
         int nBytes = fread(begin_ptr(vch), 1, vch.size(), file);
         fclose(file);
@@ -820,7 +851,7 @@ fs::path GetTempPath()
     return fs::temp_directory_path();
 }
 
-void runCommand(const std::string& strCommand)
+void runCommand(const string& strCommand)
 {
     int nErr = ::system(strCommand.c_str());
     if (nErr)
@@ -862,8 +893,8 @@ void SetupEnvironment()
     // may be invalid, in which case the "C" locale is used as fallback.
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
     try {
-        std::locale(""); // Raises a runtime error if current locale is invalid
-    } catch (const std::runtime_error&) {
+        locale(""); // Raises a runtime error if current locale is invalid
+    } catch (const runtime_error&) {
         setenv("LC_ALL", "C", 1);
     }
 #endif
@@ -871,7 +902,7 @@ void SetupEnvironment()
     // in multithreading environments, it is set explicitly by the main thread.
     // A dummy locale is used to extract the internal default locale, used by
     // fs::path, which is then used to explicitly imbue the path.
-    std::locale loc = fs::path::imbue(std::locale::classic());
+    locale loc = fs::path::imbue(locale::classic());
     fs::path::imbue(loc);
 }
 
@@ -900,14 +931,14 @@ void SetThreadPriority(int nPriority)
 #endif // WIN32
 }
 
-std::string PrivacyInfo()
+string PrivacyInfo()
 {
     return "\n" +
            FormatParagraph(strprintf(_("In order to ensure you are adequately protecting your privacy when using Pastel, please see <%s>."),
                                      "")) + "\n";
 }
 
-std::string LicenseInfo()
+string LicenseInfo()
 {
     return "\n" +
            FormatParagraph(strprintf(_("Copyright (C) 2009-%i The Bitcoin Core Developers"), COPYRIGHT_YEAR)) + "\n" +
@@ -924,7 +955,7 @@ std::string LicenseInfo()
 
 int GetNumCores()
 {
-    return std::thread::hardware_concurrency();
+    return thread::hardware_concurrency();
 }
 
 InsecureRand::InsecureRand(bool _fDeterministic)

--- a/src/util.h
+++ b/src/util.h
@@ -157,6 +157,9 @@ bool warning_msg(const char* fmt, const Args&... args)
 
 const fs::path& ZC_GetParamsDir();
 
+/** Return readable error string for a system error code */
+std::string GetErrorString(const int err);
+
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
 void ParseParameters(int argc, const char*const argv[]);
 void FileCommit(FILE *fileout);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <boost/bind/bind.hpp>

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -1,7 +1,7 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2017 The Zcash developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/asyncrpcoperation_shieldcoinbase.h
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.h
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright (c) 2017 The Zcash developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <unordered_map>
@@ -52,9 +52,9 @@ public:
     AsyncRPCOperation_shieldcoinbase& operator=(AsyncRPCOperation_shieldcoinbase const&) = delete;  // Copy assign
     AsyncRPCOperation_shieldcoinbase& operator=(AsyncRPCOperation_shieldcoinbase &&) = delete;      // Move assign
 
-    virtual void main();
+    void main() override;
 
-    virtual UniValue getStatus() const;
+    UniValue getStatus() const override;
 
     bool testmode = false;  // Set to true to disable sending txs and generating proofs
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1,7 +1,7 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <algorithm>
@@ -901,7 +901,7 @@ public:
      */
     CPubKey GenerateNewKey();
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
+    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
     //! Load metadata (used by LoadWallet)
@@ -910,10 +910,10 @@ public:
     bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
 
     //! Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey &vchPubKey, const v_uint8 &vchCryptedSecret);
+    bool AddCryptedKey(const CPubKey &vchPubKey, const v_uint8 &vchCryptedSecret) override;
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
     bool LoadCryptedKey(const CPubKey& vchPubKey, const v_uint8& vchCryptedSecret);
-    bool AddCScript(const CScript& redeemScript);
+    bool AddCScript(const CScript& redeemScript) override;
     bool LoadCScript(const CScript& redeemScript);
 
     //! Adds a destination data tuple to the store, and saves it to disk
@@ -926,8 +926,8 @@ public:
     bool GetDestData(const CTxDestination &dest, const std::string &key, std::string *value) const;
 
     //! Adds a watch-only address to the store, and saves it to disk.
-    bool AddWatchOnly(const CScript &dest);
-    bool RemoveWatchOnly(const CScript &dest);
+    bool AddWatchOnly(const CScript &dest) override;
+    bool RemoveWatchOnly(const CScript &dest) override;
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript &dest);
 
@@ -950,13 +950,13 @@ public:
     //! full viewing key to disk. Inside CCryptoKeyStore and CBasicKeyStore,
     //! CBasicKeyStore::AddSaplingFullViewingKey is called directly when adding a
     //! full viewing key to the keystore, to avoid this override.
-    bool AddSaplingFullViewingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk);
+    bool AddSaplingFullViewingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk) override;
     bool AddSaplingIncomingViewingKey(
         const libzcash::SaplingIncomingViewingKey &ivk,
-        const libzcash::SaplingPaymentAddress &addr);
+        const libzcash::SaplingPaymentAddress &addr) override;
     bool AddCryptedSaplingSpendingKey(
         const libzcash::SaplingExtendedFullViewingKey &extfvk,
-        const v_uint8 &vchCryptedSecret);
+        const v_uint8 &vchCryptedSecret) override;
     //! Adds spending key to the store, without saving it to disk (used by LoadWallet)
     bool LoadSaplingZKey(const libzcash::SaplingExtendedSpendingKey &key);
     //! Load spending key metadata (used by LoadWallet)
@@ -994,12 +994,12 @@ public:
     void UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx);
     void UpdateSaplingNullifierNoteMapForBlock(const CBlock* pblock);
     bool AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletDB* pwalletdb);
-    void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
+    void SyncTransaction(const CTransaction& tx, const CBlock* pblock) override;
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
-    void EraseFromWallet(const uint256 &hash);
+    void EraseFromWallet(const uint256 &hash) override;
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
-    void ResendWalletTransactions(int64_t nBestBlockTime);
+    void ResendWalletTransactions(int64_t nBestBlockTime) override;
     v_uint256 ResendWalletTransactionsBefore(int64_t nTime);
     CAmount GetBalance() const;
     CAmount GetUnconfirmedBalance() const;
@@ -1067,9 +1067,9 @@ public:
     CAmount GetDebit(const CTransaction& tx, const isminetype& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminetype& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
-    void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SaplingMerkleTree saplingTree, bool added);
+    void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, SaplingMerkleTree saplingTree, bool added) override;
     /** Saves witness caches and best block locator to disk. */
-    void SetBestChain(const CBlockLocator& loc);
+    void SetBestChain(const CBlockLocator& loc) override;
     std::set<std::pair<libzcash::PaymentAddress, uint256>> GetNullifiersForAddresses(const std::set<libzcash::PaymentAddress> & addresses);
     bool IsNoteSaplingChange(const std::set<std::pair<libzcash::PaymentAddress, uint256>> & nullifierSet, const libzcash::PaymentAddress & address, const SaplingOutPoint & entry);
 
@@ -1080,9 +1080,9 @@ public:
 
     bool DelAddressBook(const CTxDestination& address);
 
-    void UpdatedTransaction(const uint256 &hashTx);
+    void UpdatedTransaction(const uint256 &hashTx) override;
 
-    void Inventory(const uint256 &hash)
+    void Inventory(const uint256 &hash) override
     {
         {
             LOCK(cs_wallet);
@@ -1154,7 +1154,7 @@ public:
        this function). */
     void GenerateNewSeed();
 
-    bool SetHDSeed(const HDSeed& seed);
+    bool SetHDSeed(const HDSeed& seed) override;
     bool SetCryptedHDSeed(const uint256& seedFp, const v_uint8 &vchCryptedSecret) override;
 
     /* Returns the wallet's HD seed or throw JSONRPCError(...) */


### PR DESCRIPTION
- implemented net manager that runs in a separate thread to check network connectivity - different check wait time for active/inactive modes - checks for active network interface (Windows,Linux specific versions) and for Internet connectivity
- changed logic that checks for nodes inactivity and disconnects (ban) nodes: - skip inactive nodes check if network is unreachable
   - use grace period for timed out nodes when network comes up, force nodes to send ping message again
- changed some Node fields related to ping functionality to atomic types (fields that can be accessed simultaneously from different threads):
- fixed some compilation warnings for missing override in virtual methods