### PR TITLE
 [PSL-714] Fit it so a node won't reject a block as being invalid just because it was signed by an SN that the node had already banned

### DIFF
--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -30,7 +30,7 @@ void EnforceNodeDeprecation(int nHeight, bool forceLogging, bool fThread) {
         if (blocksToDeprecation == 0 || forceLogging) {
             auto msg = strprintf(_("This version has been deprecated as of block height %d."),
                                  DEPRECATION_HEIGHT) + " " +
-                       _("You should upgrade to the latest version of Zcash.");
+                       _("You should upgrade to the latest version of Pastel.");
             LogPrintf("*** %s\n", msg);
             CAlert::Notify(msg, fThread);
             uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_ERROR);
@@ -40,7 +40,7 @@ void EnforceNodeDeprecation(int nHeight, bool forceLogging, bool fThread) {
                (blocksToDeprecation < DEPRECATION_WARN_LIMIT && forceLogging)) {
         std::string msg = strprintf(_("This version will be deprecated at block height %d, and will automatically shut down."),
                             DEPRECATION_HEIGHT) + " " +
-                  _("You should upgrade to the latest version of Zcash.");
+                  _("You should upgrade to the latest version of Pastel.");
         LogPrintf("*** %s\n", msg);
         CAlert::Notify(msg, fThread);
         uiInterface.ThreadSafeMessageBox(msg, "", CClientUIInterface::MSG_WARNING);

--- a/src/gtest/test_deprecation.cpp
+++ b/src/gtest/test_deprecation.cpp
@@ -123,7 +123,8 @@ TEST_F(DeprecationTest, DeprecatedNodeIgnoredOnTestnet) {
     EXPECT_FALSE(ShutdownRequested());
 }
 
-TEST_F(DeprecationTest, AlertNotify) {
+TEST_F(DeprecationTest, AlertNotify)
+{
     fs::path temp = GetTempPath() /
         fs::unique_path("alertnotify-%%%%.txt");
 
@@ -137,7 +138,7 @@ TEST_F(DeprecationTest, AlertNotify) {
 
     // -alertnotify restricts the message to safe characters.
     auto expectedMsg = strprintf(
-        "This version will be deprecated at block height %d, and will automatically shut down. You should upgrade to the latest version of Zcash.",
+        "This version will be deprecated at block height %d, and will automatically shut down. You should upgrade to the latest version of Pastel.",
         DEPRECATION_HEIGHT);
 
     // Windows built-in echo semantics are different than posixy shells. Quotes and

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3041,7 +3041,8 @@ static bool ActivateBestChainStep(CValidationState &state, const CChainParams& c
     //   our genesis block. In practice this (probably) won't happen because of checks elsewhere.
     auto reorgLength = pindexOldTip ? pindexOldTip->nHeight - (pindexFork ? pindexFork->nHeight : -1) : 0;
     static_assert(MAX_REORG_LENGTH > 0, "We must be able to reorg some distance");
-    if (reorgLength > MAX_REORG_LENGTH) {
+    if (reorgLength > MAX_REORG_LENGTH)
+    {
         auto msg = strprintf(_(
             "A block chain reorganization has been detected that would roll back %d blocks! "
             "This is larger than the maximum of %d blocks, and so the node is shutting down for your safety."

--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -63,8 +63,8 @@ void CMasterNodeController::InvalidateParameters()
     nMasternodePaymentsVotersIndexDelta = 0;
     nMasternodePaymentsFeatureWinnerBlockIndexDelta = 0;
 
-    nMasternodeTopMNsNumberMin = 0;
-    nMasternodeTopMNsNumber = 0;
+    m_nMasternodeTopMNsNumberMin = 0;
+    m_nMasternodeTopMNsNumber = 0;
 
     nGovernanceVotingPeriodBlocks = 0;
     MinTicketConfirmations = 0;
@@ -115,8 +115,8 @@ void CMasterNodeController::SetParameters()
     nMasternodePaymentsVotersIndexDelta = -101;
     nMasternodePaymentsFeatureWinnerBlockIndexDelta = 10;
     
-    nMasternodeTopMNsNumberMin = 3;
-    nMasternodeTopMNsNumber = 10;
+    m_nMasternodeTopMNsNumberMin = 3;
+    m_nMasternodeTopMNsNumber = 10;
 
     nGovernanceVotingPeriodBlocks = 576; //24 hours, 1 block per 2.5 minutes
     

--- a/src/mnode/mnode-controller.h
+++ b/src/mnode/mnode-controller.h
@@ -79,7 +79,6 @@ public:
 
     uint32_t nMasternodeMinimumConfirmations, nMasternodePaymentsIncreaseBlock, nMasternodePaymentsIncreasePeriod;
     int nMasternodePaymentsVotersIndexDelta, nMasternodePaymentsFeatureWinnerBlockIndexDelta;
-    int nMasternodeTopMNsNumber, nMasternodeTopMNsNumberMin;
     int nMasterNodeMaximumOutboundConnections;
     int nFulfilledRequestExpireTime;
 
@@ -98,6 +97,8 @@ public:
 
     int getPOSEBanMaxScore() const noexcept { return m_nMasternodePOSEBanMaxScore; }
     uint32_t getMaxInProcessCollectionTicketAge() const noexcept { return m_nMaxInProcessCollectionTicketAge; }
+    size_t getMasternodeTopMNsNumberMin() const noexcept { return m_nMasternodeTopMNsNumberMin; }
+    size_t getMasternodeTopMNsNumber() const noexcept { return m_nMasternodeTopMNsNumber; }
 
 #ifdef ENABLE_WALLET
     bool EnableMasterNode(std::ostringstream& strErrors, CServiceThreadGroup& threadGroup, CWallet* pwalletMain);
@@ -135,6 +136,10 @@ protected:
     int m_nMasternodePOSEBanMaxScore = 0;
     // max age of the in-process collection ticket in blocks before it becomes finalized
     uint32_t m_nMaxInProcessCollectionTicketAge;
+    // min required number of masternodes
+    size_t m_nMasternodeTopMNsNumberMin;
+    // number of top masternodes
+    size_t m_nMasternodeTopMNsNumber;
 
 
     void SetParameters();

--- a/src/mnode/mnode-governance.cpp
+++ b/src/mnode/mnode-governance.cpp
@@ -276,7 +276,7 @@ bool CMasternodeGovernance::IsTransactionValid(const CTransaction& txNew, int nH
     ExtractDestination(scriptPubKey, dest);
     string address = keyIO.EncodeDestination(dest);
 
-    LogFnPrintf("ERROR: %s required governance payment, possible payees: '%s', actual amount: %f PASTEL. Should be %f PASTEL", 
+    LogFnPrintf("ERROR: %s required governance payment, possible payees: '%s', actual amount: %f PSL. Should be %f PSL", 
             (tnxPayment == 0)? "Missing": "Invalid",
             address,
             (float)tnxPayment/COIN,

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -14,6 +14,17 @@
 #include <vector_types.h>
 #include <mnode/mnode-masternode.h>
 
+enum class GetTopMasterNodeStatus: int
+{
+    SUCCEEDED = 0,              // successfully got top masternodes
+    SUCCEEDED_FROM_HISTORY = 1, // successfully got top masternodes from historical top mn data
+    MN_NOT_SYNCED = -1,         // masternode is not synced
+    BLOCK_NOT_FOUND = -2,       // block not found
+    GET_MN_SCORES_FAILED = -3,  // failed to get masternode scores
+    NOT_ENOUGH_MNS = -4,        // not enough top masternodes
+    HISTORY_NOT_FOUND = -5,	    // historical top mn data not found
+};
+
 class CMasternodeMan
 {
 public:
@@ -65,7 +76,7 @@ private:
     std::map<uint256, std::vector<CMasternodeBroadcast> > mMnbRecoveryGoodReplies;
     std::list< std::pair<CService, uint256> > listScheduledMnbRequestConnections;
     
-    std::map<int, std::vector<CMasternode>> mapHistoricalTopMNs;
+    std::map<uint32_t, std::vector<CMasternode>> mapHistoricalTopMNs;
     
     int64_t nLastWatchdogVoteTime;
 
@@ -167,7 +178,7 @@ public:
 
     auto GetFullMasternodeMap() const noexcept { return mapMasternodes; }
 
-    bool GetMasternodeRanks(rank_pair_vec_t& vecMasternodeRanksRet, int nBlockHeight = -1, int nMinProtocol = 0);
+    GetTopMasterNodeStatus GetMasternodeRanks(std::string &error, rank_pair_vec_t& vecMasternodeRanksRet, int nBlockHeight = -1, int nMinProtocol = 0);
     bool GetMasternodeRank(const COutPoint &outpoint, int& nRankRet, int nBlockHeight = -1, int nMinProtocol = 0);
 
     void ProcessMasternodeConnections();
@@ -209,6 +220,6 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *pindex);
     
-    std::vector<CMasternode> GetTopMNsForBlock(int nBlockHeight = -1, bool bCalculateIfNotSeen = false);
-    std::vector<CMasternode> CalculateTopMNsForBlock(int nBlockHeight = -1);
+    GetTopMasterNodeStatus GetTopMNsForBlock(std::string &error, std::vector<CMasternode> &topMNs, int nBlockHeight = -1, bool bCalculateIfNotSeen = false);
+    GetTopMasterNodeStatus CalculateTopMNsForBlock(std::string &error, std::vector<CMasternode> &topMNs, int nBlockHeight = -1);
 };

--- a/src/mnode/mnode-validation.cpp
+++ b/src/mnode/mnode-validation.cpp
@@ -19,8 +19,9 @@ bool GetBlockHash(uint256& hashRet, int nBlockHeight)
         return false;
     if (nBlockHeight < -1 || nBlockHeight > chainActive.Height())
         return false;
-    if (nBlockHeight == -1) nBlockHeight = chainActive.Height();
-        hashRet = chainActive[nBlockHeight]->GetBlockHash();
+    if (nBlockHeight == -1)
+        nBlockHeight = chainActive.Height();
+    hashRet = chainActive[nBlockHeight]->GetBlockHash();
     return true;
 }
 

--- a/src/mnode/rpc/masternode.cpp
+++ b/src/mnode/rpc/masternode.cpp
@@ -127,7 +127,8 @@ Examples:
     if (MNLIST.IsCmd(RPC_CMD_MNLIST::rank)) 
     {
         CMasternodeMan::rank_pair_vec_t vMasternodeRanks;
-        masterNodeCtrl.masternodeManager.GetMasternodeRanks(vMasternodeRanks);
+        string error;
+        const auto status = masterNodeCtrl.masternodeManager.GetMasternodeRanks(error, vMasternodeRanks);
         for (const auto& mnpair : vMasternodeRanks)
         {
             string strOutpoint = mnpair.second.GetDesc();
@@ -923,8 +924,11 @@ UniValue masternode_top(const UniValue& params)
     if (params.size() == 3)
         bCalculateIfNotSeen = params[2].get_str() == "1";
 
-    auto topBlockMNs = masterNodeCtrl.masternodeManager.GetTopMNsForBlock(nHeight, bCalculateIfNotSeen);
-
+    string error;
+    vector<CMasternode> topBlockMNs;
+    auto status = masterNodeCtrl.masternodeManager.GetTopMNsForBlock(error, topBlockMNs, nHeight, bCalculateIfNotSeen);
+    if (status != GetTopMasterNodeStatus::SUCCEEDED && status != GetTopMasterNodeStatus::SUCCEEDED_FROM_HISTORY)
+        LogFnPrintf("%s", error);
     UniValue mnsArray = formatMnsInfo(topBlockMNs);
     obj.pushKV(strprintf("%d", nHeight), move(mnsArray));
     return obj;

--- a/src/mnode/tickets/accept.cpp
+++ b/src/mnode/tickets/accept.cpp
@@ -97,7 +97,7 @@ ticket_validation_t CAcceptTicket::IsValid(const bool bPreReg, const uint32_t nC
                 }
 
                 // find if it is the old ticket
-                if (m_nBlock > 0 && existingAcceptTicket.m_nBlock > m_nBlock)
+                if (m_nBlock > 0 && existingAcceptTicket.GetBlock() > m_nBlock)
                 {
                     tv.errorMsg = strprintf(
                         "This %s ticket has been replaced with another ticket, txid - [%s]",
@@ -106,13 +106,13 @@ ticket_validation_t CAcceptTicket::IsValid(const bool bPreReg, const uint32_t nC
                 }
 
                 //check age
-                if (existingAcceptTicket.m_nBlock + masterNodeCtrl.MaxAcceptTicketAge > chainHeight)
+                if (existingAcceptTicket.GetBlock() + masterNodeCtrl.MaxAcceptTicketAge > chainHeight)
                 {
                     tv.errorMsg = strprintf(
                         "%s ticket [%s] already exists and is not yet 1h old for this Offer ticket [%s] [%sfound ticket block=%u, txid=%s]",
-                        GetTicketDescription(), existingAcceptTicket.m_txid, m_offerTxId, 
+                        GetTicketDescription(), existingAcceptTicket.GetTxId(), m_offerTxId,
                         bPreReg ? "" : strprintf("this ticket block=%u txid=%s; ", m_nBlock, m_txid),
-                        existingAcceptTicket.m_nBlock, existingAcceptTicket.m_txid);
+                        existingAcceptTicket.GetBlock(), existingAcceptTicket.GetTxId());
                     break;
                 }
             }

--- a/src/netmsg/block-cache.h
+++ b/src/netmsg/block-cache.h
@@ -1,5 +1,5 @@
 #pragma once
-// Copyright (c) 2022 The Pastel Core developers
+// Copyright (c) 2022-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <map>
@@ -49,9 +49,11 @@ protected:
         time_t nTimeAdded;           // time in secs when the block was cached
         time_t nTimeValidated;       // time in secs of the last revalidation attempt
         bool bRevalidating;          // true if block is being revalidated
+        uint32_t nBlockHeight;	     // block height (0 - not defined)
 
-        _BLOCK_CACHE_ITEM(const NodeId id, CBlock &&block_in) noexcept : 
+        _BLOCK_CACHE_ITEM(const NodeId id, uint32_t nHeight, CBlock &&block_in) noexcept : 
             nodeId(id),
+            nBlockHeight(nHeight),
             block(std::move(block_in))
         {
             Added();


### PR DESCRIPTION
 - introduced detailed status enum for getting top mns for the given block:
    SUCCEEDED              : successfully got top masternodes
    SUCCEEDED_FROM_HISTORY : successfully got top masternodes from historical top mn data
    MN_NOT_SYNCED          : masternode is not synced
    BLOCK_NOT_FOUND        : block not found
    GET_MN_SCORES_FAILED   : failed to get masternode scores
    NOT_ENOUGH_MNS         : not enough top masternodes
    HISTORY_NOT_FOUND      : historical top mn data not found
 GetTopMNsForBlock,CalculateTopMNsForBlock,GetMasternodeRanks functions now return this detailed status along with the error message.
 - changed ticket signature validation in case MN synced flag is set:
    - check if there was an error getting top mns for the ticket creator height - return TICKET_VALIDATION_STATE::MISSING_INPUTS along with
	  the detailed error. Block will be cached for the revalidation after some time.
 - enhanced block cache revalidator class:
    - get height of the block if possible from block index map when it is added to the cache
	- sort blocks for revalidation in ascending order of the block height so that blocks with lower height will be revalidated first