### PR TITLE
[PSL-758] pasteld: two Accept tickets for the same Offet ticket in a block

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -12,6 +12,8 @@ using namespace std;
 
 constexpr size_t CHAIN_RESERVE_SIZE = 500;
 
+atomic_uint32_t gl_nChainHeight;
+
 /**
  * CChain implementation
  */
@@ -20,6 +22,7 @@ void CChain::SetTip(CBlockIndex *pindex)
     if (!pindex)
     {
         vChain.clear();
+        gl_nChainHeight = 0;
         return;
     }
     const size_t nRequiredSize = pindex->nHeight + 1;
@@ -33,6 +36,7 @@ void CChain::SetTip(CBlockIndex *pindex)
         vChain[pindex->nHeight] = pindex;
         pindex = pindex->pprev;
     }
+    gl_nChainHeight = vChain.size() - 1;
 }
 
 CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <deque>
@@ -9,6 +9,8 @@
 #include <main.h>
 
 using namespace std;
+
+constexpr size_t CHAIN_RESERVE_SIZE = 500;
 
 /**
  * CChain implementation
@@ -20,7 +22,12 @@ void CChain::SetTip(CBlockIndex *pindex)
         vChain.clear();
         return;
     }
-    vChain.resize(pindex->nHeight + 1);
+    const size_t nRequiredSize = pindex->nHeight + 1;
+    if (vChain.capacity() < nRequiredSize + CHAIN_RESERVE_SIZE)
+    {
+        vChain.reserve(nRequiredSize + CHAIN_RESERVE_SIZE);
+    }
+    vChain.resize(nRequiredSize);
     while (pindex && vChain[pindex->nHeight] != pindex)
     {
         vChain[pindex->nHeight] = pindex;

--- a/src/chain.h
+++ b/src/chain.h
@@ -1,7 +1,7 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 Pastel Core developers
+// Copyright (c) 2018-2023 Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -420,7 +420,8 @@ public:
     }
 
     /** Return the maximal height in the chain. Is equal to chain.Tip() ? chain.Tip()->nHeight : -1. */
-    int Height() const {
+    int Height() const noexcept
+    {
         return int(vChain.size()) - 1;
     }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -4,6 +4,7 @@
 // Copyright (c) 2018-2023 Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <atomic>
 
 #include <arith_uint256.h>
 #include <primitives/block.h>
@@ -14,6 +15,9 @@
 
 constexpr int SPROUT_VALUE_VERSION = 1001400;
 constexpr int SAPLING_VALUE_VERSION = 1010100;
+
+// cached current blockchain height - reflects chainActive.Height()
+extern std::atomic_uint32_t gl_nChainHeight;
 
 struct CDiskBlockPos
 {

--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -7,7 +7,7 @@
 // * Shut down 16 weeks' worth of blocks after the estimated release block height.
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
 static constexpr unsigned int APPROX_RELEASE_HEIGHT = 438196;
-static constexpr int WEEKS_UNTIL_DEPRECATION = 16;
+static constexpr int WEEKS_UNTIL_DEPRECATION = 52;
 static constexpr unsigned int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
 
 // Number of blocks before deprecation to warn users

--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -1,10 +1,8 @@
+#pragma once
 // Copyright (c) 2015 The Bitcoin Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#ifndef BITCOIN_HTTPRPC_H
-#define BITCOIN_HTTPRPC_H
-
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <string>
 #include <map>
 
@@ -33,5 +31,3 @@ void InterruptREST();
  * Precondition; HTTP and RPC has been stopped.
  */
 void StopREST();
-
-#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2775,7 +2775,7 @@ void static UpdateTip(const CChainParams& chainparams, CBlockIndex* pindexNew)
     nTimeBestReceived = GetTime();
     mempool.AddTransactionsUpdated(1);
     const auto pChainTip = chainActive.Tip();
-    LogPrintf("%s: new best=%s  height=%d  log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%zutx)\n", __func__,
+    LogFnPrintf("new best=%s  height=%d  log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%zutx)", __func__,
               pChainTip->GetBlockHash().ToString(), chainActive.Height(), log(pChainTip->nChainWork.getdouble()) / log(2.0), (unsigned long)pChainTip->nChainTx,
               DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pChainTip->GetBlockTime()),
               Checkpoints::GuessVerificationProgress(chainparams.Checkpoints(), pChainTip), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1 << 20)), pcoinsTip->GetCacheSize());

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -84,7 +84,7 @@ private:
     /// Find an entry
     CMasternode* Find(const COutPoint& outpoint);
 
-    bool GetMasternodeScores(const uint256& blockHash, score_pair_vec_t& vecMasternodeScoresRet, int nMinProtocol = 0);
+    bool GetMasternodeScores(std::string &error, const uint256& blockHash, score_pair_vec_t& vecMasternodeScoresRet, int nMinProtocol = 0);
 
 public:
     // Keep track of all broadcasts I've seen
@@ -179,7 +179,7 @@ public:
     auto GetFullMasternodeMap() const noexcept { return mapMasternodes; }
 
     GetTopMasterNodeStatus GetMasternodeRanks(std::string &error, rank_pair_vec_t& vecMasternodeRanksRet, int nBlockHeight = -1, int nMinProtocol = 0);
-    bool GetMasternodeRank(const COutPoint &outpoint, int& nRankRet, int nBlockHeight = -1, int nMinProtocol = 0);
+    bool GetMasternodeRank(std::string &error, const COutPoint &outpoint, int& nRankRet, int nBlockHeight = -1, int nMinProtocol = 0);
 
     void ProcessMasternodeConnections();
     std::pair<CService, std::set<uint256> > PopScheduledMnbRequestConnection();

--- a/src/mnode/mnode-payments.h
+++ b/src/mnode/mnode-payments.h
@@ -1,7 +1,7 @@
 #pragma once
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <vector>
 #include <map>

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <tuple>
 #include <optional>
+#include <atomic>
 
 #include <json/json.hpp>
 
@@ -27,11 +28,6 @@ constexpr uint8_t TICKET_COMPRESS_DISABLE_MASK = 0x7F;
 
 // tuple <item id, item registration txid, transfer ticket txid>
 using reg_transfer_txid_t = std::tuple<TicketID, std::string, std::string>;
-
-// Get height of the active blockchain + 1
-uint32_t GetActiveChainHeight();
-// Get height of the active blockchain
-uint32_t GetCurrentChainHeight();
 
 // structure used by 'tickets tools searchthumbids' rpc
 typedef struct _search_thumbids_t
@@ -122,7 +118,7 @@ public:
             return;
         // read primary keys for the given MV key
         itDB->second->Read(realMVKey, vMainKeys);
-        const auto nCurrentChainHeight = GetCurrentChainHeight();
+        const uint32_t nCurrentChainHeight = gl_nChainHeight;
         for (const auto& key : vMainKeys)
         {
             // read ticket & call the functor

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -29,7 +29,9 @@ constexpr uint8_t TICKET_COMPRESS_DISABLE_MASK = 0x7F;
 using reg_transfer_txid_t = std::tuple<TicketID, std::string, std::string>;
 
 // Get height of the active blockchain + 1
-unsigned int GetActiveChainHeight();
+uint32_t GetActiveChainHeight();
+// Get height of the active blockchain
+uint32_t GetCurrentChainHeight();
 
 // structure used by 'tickets tools searchthumbids' rpc
 typedef struct _search_thumbids_t
@@ -120,12 +122,12 @@ public:
             return;
         // read primary keys for the given MV key
         itDB->second->Read(realMVKey, vMainKeys);
-        const auto nActiveChainHeight = GetActiveChainHeight();
+        const auto nCurrentChainHeight = GetCurrentChainHeight();
         for (const auto& key : vMainKeys)
         {
             // read ticket & call the functor
             _TicketType ticket;
-            if (itDB->second->Read(key, ticket) && !ticket.IsBlockNewerThan(nActiveChainHeight))
+            if (itDB->second->Read(key, ticket) && !ticket.IsBlockNewerThan(nCurrentChainHeight))
             {
                 if (!f(ticket))
                     break; // stop processing tickets if functor returned false

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -93,12 +93,12 @@ public:
     void UpdateDB_MVK(const CPastelTicket& ticket, const std::string& mvKey);
 
     // check whether ticket exists (use keyOne as a key)
-    bool CheckTicketExist(const CPastelTicket& ticket);
+    bool CheckTicketExist(const CPastelTicket& ticket) const;
     bool FindTicket(CPastelTicket& ticket) const;
 
     // Check whether ticket exists (use keyTwo as a key).
-    bool CheckTicketExistBySecondaryKey(const CPastelTicket& ticket);
-    bool FindTicketBySecondaryKey(CPastelTicket& ticket);
+    bool CheckTicketExistBySecondaryKey(const CPastelTicket& ticket) const;
+    bool FindTicketBySecondaryKey(CPastelTicket& ticket) const;
 
     /**
     * Process tickets of the specified type using functor F.
@@ -120,11 +120,12 @@ public:
             return;
         // read primary keys for the given MV key
         itDB->second->Read(realMVKey, vMainKeys);
+        const auto nActiveChainHeight = GetActiveChainHeight();
         for (const auto& key : vMainKeys)
         {
             // read ticket & call the functor
             _TicketType ticket;
-            if (itDB->second->Read(key, ticket))
+            if (itDB->second->Read(key, ticket) && !ticket.IsBlockNewerThan(nActiveChainHeight))
             {
                 if (!f(ticket))
                     break; // stop processing tickets if functor returned false

--- a/src/mnode/tickets/accept.cpp
+++ b/src/mnode/tickets/accept.cpp
@@ -48,7 +48,7 @@ string CAcceptTicket::ToStr() const noexcept
 */
 ticket_validation_t CAcceptTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -58,7 +58,7 @@ ticket_validation_t CAcceptTicket::IsValid(const bool bPreReg, const uint32_t nC
             *this, bPreReg, m_offerTxId, offerTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::Offer); },
             GetTicketDescription(), COfferTicket::GetTicketDescription(), nCallDepth, 
-            m_nPricePSL + TicketPricePSL(chainHeight));
+            m_nPricePSL + TicketPricePSL(nActiveChainHeight));
         if (commonTV.IsNotValid())
         {
             tv.errorMsg = strprintf(
@@ -106,7 +106,7 @@ ticket_validation_t CAcceptTicket::IsValid(const bool bPreReg, const uint32_t nC
                 }
 
                 //check age
-                if (existingAcceptTicket.GetBlock() + masterNodeCtrl.MaxAcceptTicketAge > chainHeight)
+                if (existingAcceptTicket.GetBlock() + masterNodeCtrl.MaxAcceptTicketAge > nActiveChainHeight)
                 {
                     tv.errorMsg = strprintf(
                         "%s ticket [%s] already exists and is not yet 1h old for this Offer ticket [%s] [%sfound ticket block=%u, txid=%s]",
@@ -128,7 +128,7 @@ ticket_validation_t CAcceptTicket::IsValid(const bool bPreReg, const uint32_t nC
         }
 
         // Verify Offer ticket is already or still active
-        const unsigned int height = (bPreReg || IsBlock(0)) ? chainHeight : m_nBlock;
+        const unsigned int height = (bPreReg || IsBlock(0)) ? nActiveChainHeight : m_nBlock;
         const auto offerTicketState = pOfferTicket->checkValidState(height);
         if (offerTicketState == OFFER_TICKET_STATE::NOT_ACTIVE)
         {

--- a/src/mnode/tickets/action-act.cpp
+++ b/src/mnode/tickets/action-act.cpp
@@ -95,7 +95,7 @@ void CActionActivateTicket::sign(SecureString&& strKeyPass)
  */
 ticket_validation_t CActionActivateTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -105,7 +105,7 @@ ticket_validation_t CActionActivateTicket::IsValid(const bool bPreReg, const uin
             *this, bPreReg, m_regTicketTxId, pastelTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::ActionReg); },
             GetTicketDescription(), CActionRegTicket::GetTicketDescription(), nCallDepth,
-            TicketPricePSL(chainHeight) + static_cast<CAmount>(getAllMNFeesPSL())); // fee for ticket + all MN storage fees (percent from storage fee)
+            TicketPricePSL(nActiveChainHeight) + static_cast<CAmount>(getAllMNFeesPSL())); // fee for ticket + all MN storage fees (percent from storage fee)
 
         if (commonTV.IsNotValid())
         {

--- a/src/mnode/tickets/action-reg.cpp
+++ b/src/mnode/tickets/action-reg.cpp
@@ -344,7 +344,7 @@ string CActionRegTicket::ToJSON(const bool bDecodeProperties) const noexcept
  */
 ticket_validation_t CActionRegTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -363,7 +363,7 @@ ticket_validation_t CActionRegTicket::IsValid(const bool bPreReg, const uint32_t
             }
 
             // A.2 validate that address has coins to pay for registration - 10PSL
-            const auto fullTicketPrice = TicketPricePSL(chainHeight); //10% of storage fee is paid by the 'caller' and this ticket is created by MN
+            const auto fullTicketPrice = TicketPricePSL(nActiveChainHeight); //10% of storage fee is paid by the 'caller' and this ticket is created by MN
             if (pwalletMain->GetBalance() < fullTicketPrice * COIN)
             {
                 tv.errorMsg = strprintf(

--- a/src/mnode/tickets/collection-act.cpp
+++ b/src/mnode/tickets/collection-act.cpp
@@ -63,7 +63,7 @@ void CollectionActivateTicket::sign(SecureString&& strKeyPass)
 */
 ticket_validation_t CollectionActivateTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -73,7 +73,7 @@ ticket_validation_t CollectionActivateTicket::IsValid(const bool bPreReg, const 
             *this, bPreReg, m_regTicketTxId, pastelTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::CollectionReg); },
             GetTicketDescription(), CollectionRegTicket::GetTicketDescription(), nCallDepth,
-            TicketPricePSL(chainHeight) + static_cast<CAmount>(getAllMNFeesPSL())); // fee for ticket + all MN storage fees (percent from storage fee)
+            TicketPricePSL(nActiveChainHeight) + static_cast<CAmount>(getAllMNFeesPSL())); // fee for ticket + all MN storage fees (percent from storage fee)
 
         if (commonTV.IsNotValid())
         {

--- a/src/mnode/tickets/collection-item.cpp
+++ b/src/mnode/tickets/collection-item.cpp
@@ -191,10 +191,10 @@ ticket_validation_t CollectionItem::IsValidCollection(const bool bPreReg) const 
             break;
         }
 
-        const auto chainHeight = GetActiveChainHeight();
+        const auto nActiveChainHeight = gl_nChainHeight + 1;
 
         // check that ticket height is less than final allowed block height for the collection
-        if (bPreReg && (chainHeight > pCollRegTicket->getCollectionFinalAllowedBlockHeight()))
+        if (bPreReg && (nActiveChainHeight > pCollRegTicket->getCollectionFinalAllowedBlockHeight()))
         {
             // a "final allowed" block height after which no new items will be allowed to add to the collection
             tv.errorMsg = strprintf(
@@ -205,7 +205,7 @@ ticket_validation_t CollectionItem::IsValidCollection(const bool bPreReg) const 
 
         // count all registered items in a collection up to the current height
         // don't count current reg ticket
-        const uint32_t nCollectionItemCount = CountItemsInCollection(chainHeight);
+        const uint32_t nCollectionItemCount = CountItemsInCollection(nActiveChainHeight);
 
         // check if we have more than allowed number of items in the collection
         if (nCollectionItemCount + (bPreReg ? 1 : 0) > pCollRegTicket->getMaxCollectionEntries())

--- a/src/mnode/tickets/collection-reg.cpp
+++ b/src/mnode/tickets/collection-reg.cpp
@@ -174,7 +174,7 @@ void CollectionRegTicket::parse_collection_ticket()
                     bool bHasGreen = false;
                     value.get_to(bHasGreen);
                     if (bHasGreen)
-                        m_sGreenAddress = GreenAddress(GetActiveChainHeight());
+                        m_sGreenAddress = GreenAddress(gl_nChainHeight + 1);
                 } break;
 
                 case COLL_TKT_PROP::version:
@@ -247,7 +247,7 @@ bool CollectionRegTicket::CanAcceptTicket(const CPastelTicket &ticket) const noe
 */
 ticket_validation_t CollectionRegTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -283,7 +283,7 @@ ticket_validation_t CollectionRegTicket::IsValid(const bool bPreReg, const uint3
             }
 
             // validate that address has coins to pay for registration - 10 PSL (default fee)
-            const auto fullTicketPricePSL = TicketPricePSL(chainHeight); //10% of storage fee is paid by the 'creator' and this ticket is created by MN
+            const auto fullTicketPricePSL = TicketPricePSL(nActiveChainHeight); //10% of storage fee is paid by the 'creator' and this ticket is created by MN
             if (pwalletMain->GetBalance() < fullTicketPricePSL * COIN)
             {
                 tv.errorMsg = strprintf(

--- a/src/mnode/tickets/etherium-address-change.cpp
+++ b/src/mnode/tickets/etherium-address-change.cpp
@@ -57,7 +57,7 @@ string CChangeEthereumAddressTicket::ToStr() const noexcept
  */
 ticket_validation_t CChangeEthereumAddressTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -67,7 +67,7 @@ ticket_validation_t CChangeEthereumAddressTicket::IsValid(const bool bPreReg, co
         if (bPreReg)
         {
             // A2. Check if address has coins to pay for Ethereum Address Change Ticket
-            const auto fullTicketPrice = TicketPricePSL(chainHeight);
+            const auto fullTicketPrice = TicketPricePSL(nActiveChainHeight);
             if (pwalletMain->GetBalance() < fullTicketPrice * COIN)
             {
                 tv.errorMsg = strprintf(
@@ -114,7 +114,7 @@ ticket_validation_t CChangeEthereumAddressTicket::IsValid(const bool bPreReg, co
         const bool bFoundTicketBySecondaryKey = masterNodeCtrl.masternodeTickets.FindTicketBySecondaryKey(_ticket);
         if (bFoundTicketBySecondaryKey)
         {
-            const unsigned int height = (bPreReg || IsBlock(0)) ? chainHeight : m_nBlock;
+            const unsigned int height = (bPreReg || IsBlock(0)) ? nActiveChainHeight : m_nBlock;
             if (height <= _ticket.m_nBlock + 24 * 24)
             { // For testing purpose, the value 24 * 24 can be lower to decrease the waiting time
                 // D.2 IF Pastel ID has changed Ethereum Address in last 24 hours (~24*24 blocks), do not allow them to change

--- a/src/mnode/tickets/nft-act.cpp
+++ b/src/mnode/tickets/nft-act.cpp
@@ -63,7 +63,7 @@ void CNFTActivateTicket::sign(SecureString&& strKeyPass)
  */
 ticket_validation_t CNFTActivateTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -73,7 +73,7 @@ ticket_validation_t CNFTActivateTicket::IsValid(const bool bPreReg, const uint32
             *this, bPreReg, m_regTicketTxId, pastelTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::NFT); },
             GetTicketDescription(), CNFTRegTicket::GetTicketDescription(), nCallDepth,
-            TicketPricePSL(chainHeight) + static_cast<CAmount>(getAllMNFeesPSL())); // fee for ticket + all MN storage fees (percent from storage fee)
+            TicketPricePSL(nActiveChainHeight) + static_cast<CAmount>(getAllMNFeesPSL())); // fee for ticket + all MN storage fees (percent from storage fee)
 
         if (commonTV.IsNotValid())
         {

--- a/src/mnode/tickets/nft-reg.cpp
+++ b/src/mnode/tickets/nft-reg.cpp
@@ -177,7 +177,7 @@ void CNFTRegTicket::parse_nft_ticket()
                     bool bHasGreen = false;
                     value.get_to(bHasGreen);
                     if (bHasGreen)
-                        m_sGreenAddress = GreenAddress(GetActiveChainHeight());
+                        m_sGreenAddress = GreenAddress(gl_nChainHeight + 1);
                 } break;
 
                 case NFT_TKT_PROP::version:
@@ -244,7 +244,7 @@ void CNFTRegTicket::set_collection_properties() noexcept
  */
 ticket_validation_t CNFTRegTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -263,7 +263,7 @@ ticket_validation_t CNFTRegTicket::IsValid(const bool bPreReg, const uint32_t nC
             }
 
             // A.2 validate that address has coins to pay for registration - 10PSL
-            const auto fullTicketPrice = TicketPricePSL(chainHeight); //10% of storage fee is paid by the 'creator' and this ticket is created by MN
+            const auto fullTicketPrice = TicketPricePSL(nActiveChainHeight); //10% of storage fee is paid by the 'creator' and this ticket is created by MN
             if (pwalletMain->GetBalance() < fullTicketPrice * COIN)
             {
                 tv.errorMsg = strprintf(

--- a/src/mnode/tickets/nft-royalty.cpp
+++ b/src/mnode/tickets/nft-royalty.cpp
@@ -67,7 +67,7 @@ string CNFTRoyaltyTicket::ToStr() const noexcept
  */
 ticket_validation_t CNFTRoyaltyTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -89,7 +89,7 @@ ticket_validation_t CNFTRoyaltyTicket::IsValid(const bool bPreReg, const uint32_
             *this, bPreReg, m_sNFTTxId, pastelTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::NFT); },
             GetTicketDescription(), CNFTRegTicket::GetTicketDescription(), nCallDepth, 
-            TicketPricePSL(chainHeight));
+            TicketPricePSL(nActiveChainHeight));
         if (commonTV.IsNotValid())
         {
             // enrich the error message

--- a/src/mnode/tickets/offer.cpp
+++ b/src/mnode/tickets/offer.cpp
@@ -133,7 +133,7 @@ OFFER_TICKET_STATE COfferTicket::checkValidState(const uint32_t nHeight) const n
  */
 ticket_validation_t COfferTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
     do
     {
@@ -152,7 +152,7 @@ ticket_validation_t COfferTicket::IsValid(const bool bPreReg, const uint32_t nCa
                 */
                 return !is_enum_any_of(tid, TicketID::Activate, TicketID::ActionActivate, TicketID::Transfer);
             },
-            GetTicketDescription(), "activation or transfer", nCallDepth, TicketPricePSL(chainHeight));
+            GetTicketDescription(), "activation or transfer", nCallDepth, TicketPricePSL(nActiveChainHeight));
         if (commonTV.IsNotValid())
         {
             tv.errorMsg = strprintf(
@@ -419,7 +419,7 @@ ticket_validation_t COfferTicket::IsValid(const bool bPreReg, const uint32_t nCa
                 tv1.state = TICKET_VALIDATION_STATE::INVALID;
                 break;
             }
-            if (t.m_nBlock + Params().getOfferReplacementAllowedBlocks() > chainHeight)
+            if (t.m_nBlock + Params().getOfferReplacementAllowedBlocks() > nActiveChainHeight)
             {
                 // 1 block per 2.5; 4 blocks per 10 min; 24 blocks per 1h; 576 blocks per 24 h;
                 tv1.errorMsg = strprintf(

--- a/src/mnode/tickets/ticket-utils.h
+++ b/src/mnode/tickets/ticket-utils.h
@@ -104,16 +104,16 @@ ticket_validation_t common_ticket_validation(
         // C.1 Something to validate only if NOT Initial Download
         if (masterNodeCtrl.masternodeSync.IsSynced())
         {
-            const auto chainHeight = GetActiveChainHeight();
+            const auto nActiveChainHeight = gl_nChainHeight + 1;
 
             // C.2 Verify Min Confirmations
-            const auto height = ticket.IsBlock(0) ? chainHeight : ticket.GetBlock();
-            if (chainHeight - referredItemTicket->GetBlock() < masterNodeCtrl.MinTicketConfirmations)
+            const auto height = ticket.IsBlock(0) ? nActiveChainHeight : ticket.GetBlock();
+            if (nActiveChainHeight - referredItemTicket->GetBlock() < masterNodeCtrl.MinTicketConfirmations)
             {
                 tv.errorMsg = strprintf(
                     "%s ticket can be created only after [%s] confirmations of the %s ticket. chainHeight=%u, block=%u",
                     sThisTicketDescription, masterNodeCtrl.MinTicketConfirmations, 
-                    sReferredItemTicketDescription, chainHeight, ticket.GetBlock());
+                    sReferredItemTicketDescription, nActiveChainHeight, ticket.GetBlock());
                 break;
             }
         }

--- a/src/mnode/tickets/ticket.h
+++ b/src/mnode/tickets/ticket.h
@@ -109,6 +109,7 @@ public:
     unsigned int GetBlock() const noexcept { return m_nBlock; }
     std::int64_t GetTimestamp() const noexcept { return m_nTimestamp; }
     bool IsBlock(const unsigned int nBlock) const noexcept { return m_nBlock == nBlock; }
+    bool IsBlockNewerThan(const uint32_t nBlockHeight) const noexcept { return m_nBlock > nBlockHeight; }
     auto GetTicketName() const noexcept
     {
         return TICKET_INFO[to_integral_type<TicketID>(ID())].szName;

--- a/src/mnode/tickets/transfer.cpp
+++ b/src/mnode/tickets/transfer.cpp
@@ -247,7 +247,7 @@ string CTransferTicket::ToStr() const noexcept
  */
 ticket_validation_t CTransferTicket::IsValid(const bool bPreReg, const uint32_t nCallDepth) const noexcept
 {
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
     ticket_validation_t tv;
 
     do
@@ -258,7 +258,7 @@ ticket_validation_t CTransferTicket::IsValid(const bool bPreReg, const uint32_t 
             *this, bPreReg, m_offerTxId, offerTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::Offer); },
             GetTicketDescription(), COfferTicket::GetTicketDescription(), nCallDepth, 
-            m_nPricePSL + TicketPricePSL(chainHeight));
+            m_nPricePSL + TicketPricePSL(nActiveChainHeight));
         if (commonTV.IsNotValid())
         {
             tv.errorMsg = strprintf(
@@ -273,7 +273,7 @@ ticket_validation_t CTransferTicket::IsValid(const bool bPreReg, const uint32_t 
             *this, bPreReg, m_acceptTxId, acceptTicket,
             [](const TicketID tid) noexcept { return (tid != TicketID::Accept); },
             GetTicketDescription(), CAcceptTicket::GetTicketDescription(), nCallDepth, 
-            m_nPricePSL + TicketPricePSL(chainHeight));
+            m_nPricePSL + TicketPricePSL(nActiveChainHeight));
         if (commonTV.IsNotValid())
         {
             tv.errorMsg = strprintf(
@@ -441,8 +441,7 @@ CAmount CTransferTicket::GetExtraOutputs(vector<CTxOut>& outputs) const
             if (pNFTRegTicket->hasGreenFee())
             {
                 sGreenAddress = pNFTRegTicket->getGreenAddress();
-                const auto chainHeight = GetActiveChainHeight();
-                nGreenNFTAmount = nPriceAmount * CNFTRegTicket::GreenPercent(chainHeight) / 100;
+                nGreenNFTAmount = nPriceAmount * CNFTRegTicket::GreenPercent(gl_nChainHeight + 1) / 100;
             }
         } break;
 

--- a/src/mnode/tickets/username-change.cpp
+++ b/src/mnode/tickets/username-change.cpp
@@ -123,7 +123,6 @@ ticket_validation_t CChangeUsernameTicket::IsValid(const bool bPreReg, const uin
     const bool bDBUserChangedName_MemPool = bTicketExistsInDB && TktMemPool.TicketExistsBySecondaryKey(tktDB.m_sPastelID);
 
     ticket_validation_t tv;
-
     do
     {
         // These checks executed ONLY before ticket made into transaction
@@ -226,7 +225,7 @@ ticket_validation_t CChangeUsernameTicket::IsValid(const bool bPreReg, const uin
                 string sTimeDiff;
                 // If Pastel ID has changed Username in last 24 hours (~24*24 blocks), do not allow them to change (for mainnet & testnet)
                 // For regtest - number of blocks is 10
-                const seconds diffTime(time(nullptr) - tktDB.m_nTimestamp);
+                const seconds diffTime(time(nullptr) - tktDB.GetTimestamp());
                 if (diffTime > 1h)
                     sTimeDiff = strprintf("%d hours", ceil<hours>(diffTime).count());
                 else

--- a/src/mnode/tickets/username-change.cpp
+++ b/src/mnode/tickets/username-change.cpp
@@ -109,7 +109,7 @@ ticket_validation_t CChangeUsernameTicket::IsValid(const bool bPreReg, const uin
     // username-change ticket keys:
     // 1) username
     // 2) pastelid
-    const auto chainHeight = GetActiveChainHeight();
+    const auto nActiveChainHeight = gl_nChainHeight + 1;
 
     // initialize Pastel Ticket mempool processor for username-change tickets
     // retrieve mempool transactions with TicketID::Username tickets
@@ -169,7 +169,7 @@ ticket_validation_t CChangeUsernameTicket::IsValid(const bool bPreReg, const uin
             }
 
             // Check if address has coins to pay for Username Change Ticket
-            const auto fullTicketPrice = TicketPricePSL(chainHeight);
+            const auto fullTicketPrice = TicketPricePSL(nActiveChainHeight);
 
             if (pwalletMain->GetBalance() < fullTicketPrice * COIN)
             {
@@ -219,7 +219,7 @@ ticket_validation_t CChangeUsernameTicket::IsValid(const bool bPreReg, const uin
         const bool bFoundTicketByPastelID_DB = masterNodeCtrl.masternodeTickets.FindTicketBySecondaryKey(tktDB);
         if (bFoundTicketByPastelID_DB)
         {
-            const unsigned int height = (bPreReg || IsBlock(0)) ? chainHeight : m_nBlock;
+            const unsigned int height = (bPreReg || IsBlock(0)) ? nActiveChainHeight : m_nBlock;
             if (height <= tktDB.GetBlock() + CChangeUsernameTicket::GetDisablePeriodInBlocks())
             {
                 string sTimeDiff;


### PR DESCRIPTION
Changed all functions that retrieve tickets from TicketDB - added validation for the ticket height, if the ticket height is greater than active chain height - ignore this ticket. That will ensure proper ticket validation - no tickets with a height greater than the active chain height will be used for validation.