### PR TITLE
[PSL-755] [PSL-763] [PSL-764]

### DIFF
--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
@@ -140,7 +140,7 @@
     <ClCompile Include="..\..\..\src\mnode\tickets\action-act.cpp" />
     <ClCompile Include="..\..\..\src\mnode\tickets\action-reg.cpp" />
     <ClCompile Include="..\..\..\src\mnode\tickets\collection-item.cpp" />
-    <ClCompile Include="..\..\..\src\mnode\tickets\etherium-address-change.cpp" />
+    <ClCompile Include="..\..\..\src\mnode\tickets\ethereum-address-change.cpp" />
     <ClCompile Include="..\..\..\src\mnode\tickets\nft-act.cpp" />
     <ClCompile Include="..\..\..\src\mnode\tickets\accept.cpp" />
     <ClCompile Include="..\..\..\src\mnode\tickets\collection-act.cpp" />
@@ -250,7 +250,7 @@
     <ClInclude Include="..\..\..\src\mnode\tickets\action-act.h" />
     <ClInclude Include="..\..\..\src\mnode\tickets\action-reg.h" />
     <ClInclude Include="..\..\..\src\mnode\tickets\collection-item.h" />
-    <ClInclude Include="..\..\..\src\mnode\tickets\etherium-address-change.h" />
+    <ClInclude Include="..\..\..\src\mnode\tickets\ethereum-address-change.h" />
     <ClInclude Include="..\..\..\src\mnode\tickets\collection-act.h" />
     <ClInclude Include="..\..\..\src\mnode\tickets\collection-reg.h" />
     <ClInclude Include="..\..\..\src\mnode\tickets\ticket-extra-fees.h" />

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
@@ -244,7 +244,7 @@
     <ClCompile Include="..\..\..\src\mnode\tickets\username-change.cpp">
       <Filter>Source Files\mnode\tickets</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\src\mnode\tickets\etherium-address-change.cpp">
+    <ClCompile Include="..\..\..\src\mnode\tickets\ethereum-address-change.cpp">
       <Filter>Source Files\mnode\tickets</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\src\mnode\tickets\transfer.cpp">
@@ -588,7 +588,7 @@
     <ClInclude Include="..\..\..\src\mnode\tickets\username-change.h">
       <Filter>Source Files\mnode\tickets</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\src\mnode\tickets\etherium-address-change.h">
+    <ClInclude Include="..\..\..\src\mnode\tickets\ethereum-address-change.h">
       <Filter>Source Files\mnode\tickets</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\mnode\tickets\ticket-utils.h">

--- a/qa/rpc-tests/mn_tickets.py
+++ b/qa/rpc-tests/mn_tickets.py
@@ -92,7 +92,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         
         self.total_copies = None
         self.collection_name = None
-        self.in_process_collection_ticket_age = 45  # number of blocks until in-process collection will be finalized
+        self.in_process_collection_ticket_age = 60  # number of blocks until in-process collection will be finalized
 
         self.test_high_heights = False
 
@@ -680,7 +680,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
     # ===============================================================================================================
     def create_collection_ticket(self, item_type: CollectionItemType, collection_name: str, creator_node_num: int,
-        collection_final_allowed_block_height: int, max_collection_entries: int,
+        collection_ticket_age: int, max_collection_entries: int,
         collection_item_copy_count: int, list_of_pastelids_of_authorized_contributors,
         royalty, green, make_bad_signatures_dicts = False):
         """Create collection ticket and signatures
@@ -689,7 +689,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             item_type (CollectionItemType): type of collection item
             collection_name (str): collection name
             creator_node_num (int): node that creates collection ticket and signatures
-            collection_final_allowed_block_height (int): a block height after which no new items would be allowed to be added to this collection
+            collection_ticket_age (int): number of blocks after which no new items would be allowed to be added to this collection
             max_collection_entries (int): max number of items allowed in this collection
             collection_item_copy_count (int): allowed number of copies for all items in a collection
             list_of_pastelids_of_authorized_contributors (list): list of Pastel IDs of authorized contributors who permitted to register an item as part of this collection
@@ -738,7 +738,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             "list_of_pastelids_of_authorized_contributors": list_of_pastelids_of_authorized_contributors,
             "blocknum": collection_ticket.reg_height,
             "block_hash": block_hash,
-            "collection_final_allowed_block_height": collection_ticket.reg_height + collection_final_allowed_block_height,
+            "collection_final_allowed_block_height": collection_ticket.reg_height + collection_ticket_age,
             "max_collection_entries": max_collection_entries,
             "collection_item_copy_count": collection_item_copy_count,
             "royalty": royalty,
@@ -753,7 +753,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
     # ===============================================================================================================
     def create_nft_ticket_v2(self, creator_node_num: int, collection_act_txid: str = None, skip_optional: bool = True,
-        total_copies: int = 0, royalty: float = 0.0, green: bool = False):
+        total_copies: int = 1, royalty: float = 0.0, green: bool = False):
         """Create NFT ticket v2 and signatures (collection support)
 
         Args:
@@ -904,8 +904,9 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             ( self.non_mn5, self.nonmn5_pastelid1, self.nonmn5_address1 ),
             ( self.mining_node_num, self.nonmn1_pastelid1, self.miner_address)
         ]
-        for idreg_info in register_ids:
-            self.nodes[idreg_info[0]].tickets("register", "id", idreg_info[1], self.passphrase, idreg_info[2])
+        print(f"Registering {len(register_ids)} Pastel IDs")
+        for (node_id, pastelid, address) in register_ids:
+            self.nodes[node_id].tickets("register", "id", pastelid, self.passphrase, address)
             self.generate_and_sync_inc(1, self.mining_node_num)
         self.inc_ticket_counter(TicketType.ID, len(register_ids))
         self.wait_for_ticket_tnx(5)
@@ -1068,6 +1069,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         result = top_mn_node.tickets("register", ticket_type_name,
             collection_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict),
             self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
+        
         collection_ticket.reg_txid = result["txid"]
         collection_ticket.reg_node_id = self.top_mns[0].index
         ticket_key = result["key"]
@@ -1075,6 +1077,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         assert_true(collection_ticket.reg_txid, "No collection ticket was created")
         self.inc_ticket_counter(TicketType.COLLECTION)
         self.wait_for_ticket_tnx()
+        # collection reg ticket creator-height + 5
         print(top_mn_node.getblockcount())
         tkt = top_mn_node.tickets("get", collection_ticket.reg_txid)
         print(f"Collection registration ticket:\n{json.dumps(tkt, cls=DecimalEncoder, indent=4)}")
@@ -1173,159 +1176,6 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
 
     # ===============================================================================================================
-    # collection tests - tested on non_mn3 node
-    def collection_tests(self, item_type: CollectionItemType, label: str):
-        collection_item_type_name = item_type.type_description
-        print(f"== {collection_item_type_name} Collection Tickets test ==")
-
-        collection_reg_ticket = self.tickets[TicketType.COLLECTION]
-        collection_item = item_type.reg_ticket_type
-        reg_ticket_type_name = collection_item.type_name
-        collection_ticket_type_name = TicketType.COLLECTION.type_name
-
-        self.generate_and_sync_inc(10, self.mining_node_num)
-
-        # invalid collection txid (txid format)
-        if item_type == CollectionItemType.NFT:
-            self.create_nft_ticket_v2(self.non_mn3, "invalid_collection_txid")
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, "invalid_collection_txid")
-        top_mn_node = self.nodes[self.top_mns[0].index]
-        item_ticket = self.tickets[item_type.reg_ticket_type]
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, "Incorrect collection activation ticket txid",
-            top_mn_node.tickets, "register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
-
-        # collection txid does not point to existing txid
-        if item_type == CollectionItemType.NFT:
-            self.create_nft_ticket_v2(self.non_mn3, self.get_random_txid())
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, self.get_random_txid())
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, "is not in the blockchain",
-            top_mn_node.tickets, "register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
-
-        # collection txid does not point to collection activation ticket
-        if item_type == CollectionItemType.NFT:
-            self.create_nft_ticket_v2(self.non_mn3, self.mn_nodes[0].mnid_reg_txid)
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, self.mn_nodes[0].mnid_reg_txid)
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, "has invalid type",
-            top_mn_node.tickets, "register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
-
-        # collection txid points to collection registration ticket instead of activation
-        if item_type == CollectionItemType.NFT:
-            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.reg_txid)
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.reg_txid)
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, "has invalid type",
-            top_mn_node.tickets, "register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
-
-        # adding wrong item to the collection
-        if item_type == CollectionItemType.NFT:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.act_txid)
-            test_wrong_collection_item = ActionType.SENSE.reg_ticket_type.type_name
-            wrong_item_ticket = self.tickets[ActionType.SENSE.reg_ticket_type]
-        else:
-            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
-            test_wrong_collection_item = TicketType.NFT.type_name
-            wrong_item_ticket = self.tickets[TicketType.NFT]
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, "ticket cannot be accepted",
-            top_mn_node.tickets, "register", test_wrong_collection_item,
-            wrong_item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
-            
-        # save creator_pastelid1 
-        saved_creator_pastelid1 = self.creator_pastelid1
-        # creator_pastelid3 is not in list_of_pastelids_of_authorized_contributors list
-        self.creator_pastelid1 = self.creator_pastelid3
-        if item_type == CollectionItemType.NFT:
-            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.act_txid)
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, f"User with Pastel ID '{self.creator_pastelid3}' is not authorized contributor for the collection",
-            top_mn_node.tickets, "register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
-
-        # add item reg ticket #1 successfully (creator_pastelid1 user)
-        self.creator_pastelid1 = saved_creator_pastelid1
-        if item_type == CollectionItemType.NFT:
-            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.act_txid)
-        item_ticket1_txid = top_mn_node.tickets("register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_1", str(self.storage_fee))["txid"]
-        print(f'registered {collection_item.type_name} ticket #1 [{item_ticket1_txid}] in the collection [{self.collection_name}]')
-        self.inc_ticket_counter(collection_item)
-        self.wait_for_ticket_tnx()
-
-        # add item reg ticket #2 successfully (creator_pastelid2 user)
-        self.creator_pastelid1 = self.creator_pastelid2
-        if item_type == CollectionItemType.NFT: 
-            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid2, collection_reg_ticket.act_txid)
-        item_ticket2_txid = self.nodes[self.top_mns[0].index].tickets("register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_2", str(self.storage_fee))["txid"]
-        print(f'registered {collection_item.type_name} ticket #2 [{item_ticket2_txid}] in the collection [{self.collection_name}]')
-        self.inc_ticket_counter(collection_item)
-        self.wait_for_ticket_tnx()
-
-        # cannot register more than 2 collection item tickets (will exceed max_collection_entries)
-        if item_type == CollectionItemType.NFT: 
-            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid2, collection_reg_ticket.act_txid)
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, f"Max number of items ({2}) allowed in the collection '{self.collection_name}' has been exceeded",
-            self.nodes[self.top_mns[0].index].tickets, "register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_3", str(self.storage_fee))
-
-        # test collection final allowed block height, create collection with collection_final_allowed_block_height +10 blocks
-        # register new collection #2
-        # existing  collection in self.tickets saved in ticket local var
-        new_collection_reg_ticket = TicketData()
-        self.tickets[TicketType.COLLECTION] = new_collection_reg_ticket
-        self.create_collection_ticket(item_type, self.collection_name + " (final_allowed_block_height)", self.non_mn3, 10, 
-            2, 10, [], self.royalty, self.is_green)
-        
-        self.nodes[self.mining_node_num].sendtoaddress(self.nonmn3_address1, 1000, "", "", False)
-        
-        top_mn_node = self.nodes[self.top_mns[0].index]
-        new_collection_reg_ticket.reg_txid = top_mn_node.tickets("register", collection_ticket_type_name,
-            new_collection_reg_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict),
-            self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))["txid"]
-        assert_true(new_collection_reg_ticket.reg_txid, f"No {collection_item.type_name} registration ticket was created")
-        self.inc_ticket_counter(TicketType.COLLECTION)
-        self.wait_for_sync_all(1)
-        self.wait_for_sync_all(10)
-        
-        # activate collection #2
-        collection_ticket_act_txid = self.nodes[self.non_mn3].tickets("activate", collection_ticket_type_name,
-            new_collection_reg_ticket.reg_txid, str(new_collection_reg_ticket.reg_height), str(self.storage_fee),
-            new_collection_reg_ticket.reg_pastelid, self.passphrase)["txid"]
-        assert_true(collection_ticket_act_txid, f"No {collection_item.type_name} registration ticket was created")
-        collection_reg_ticket.act_txid = collection_ticket_act_txid
-        self.inc_ticket_counter(TicketType.COLLECTION_ACTIVATE)
-        self.wait_for_ticket_tnx()
-        
-        # cannot add items to this collection any more
-        if item_type == CollectionItemType.NFT: 
-            self.create_nft_ticket_v2(self.non_mn3, collection_ticket_act_txid)
-        else:
-            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid2, collection_ticket_act_txid)
-        assert_raises_rpc(rpc.RPC_MISC_ERROR, "No new items are allowed to be added to the finalized collection",
-            self.nodes[self.top_mns[0].index].tickets, "register", reg_ticket_type_name,
-            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_4", str(self.storage_fee))
-        # restore data for collection #1
-        self.tickets[TicketType.COLLECTION] = collection_reg_ticket
-
-        # restore creator_pastelid1 
-        self.creator_pastelid1 = saved_creator_pastelid1
-        print(f"== {collection_item_type_name} collection tickets tested ==")
-
-
-    # ===============================================================================================================
     def collection_activate_ticket_tests(self, item_type: CollectionItemType, skip_low_coins_tests: bool = False):
         """collection activation ticket tests
 
@@ -1367,6 +1217,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
         self.nodes[self.mining_node_num].sendtoaddress(self.nonmn3_address1, 5000, "", "", False)
         self.wait_for_sync_all10()
+        # collection reg ticket creator-height + 15
 
         #       d.a.3 fail if txid points to invalid ticket (not a Collection Reg ticket)
         assert_raises_rpc(rpc.RPC_MISC_ERROR, "is not valid ticket type",
@@ -1384,6 +1235,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         #    self.nodes[self.non_mn3].tickets, cmd, cmd_param, ticket.reg_txid,
         #    str(ticket.reg_height), str(self.storage_fee), self.ticket.reg_pastelid, self.passphrase)
         self.wait_for_gen10_blocks()
+        # collection reg ticket creator-height + 25
         print(f"Current height: {self.nodes[self.non_mn4].getblockcount()}")
 
         #       d.a.4 fail if Caller's Pastel ID in the activation ticket
@@ -1425,6 +1277,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
             str(self.storage_fee), collection_reg_ticket.reg_pastelid, self.passphrase)["txid"]
         assert_true(collection_reg_ticket.act_txid, "collection was not activated")
         self.wait_for_ticket_tnx()
+        # collection reg ticket creator-height + 30
         collection_act_ticket.act_txid = collection_reg_ticket.act_txid
         self.inc_ticket_counter(TicketType.COLLECTION_ACTIVATE)
         tkt = self.nodes[self.non_mn3].tickets("get", collection_reg_ticket.act_txid)
@@ -1496,6 +1349,10 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         assert_equal(tkt1['reg_txid'], collection_reg_ticket.reg_txid)
         assert_equal(tkt1['creator_height'], collection_reg_ticket.reg_height)
         assert_equal(tkt1['storage_fee'], self.storage_fee)
+        assert_equal(tkt1['activated_item_count'], 0)
+        assert_equal(tkt1['collection_state'], 'in-process')
+        assert_equal(tkt1['is_expired_by_height'], False)
+        assert_equal(tkt1['is_full'], False)
         assert_equal(collection_activate_ticket1['txid'], collection_reg_ticket.act_txid)
 
         #   d.c get the same ticket by txid from d.a.8 and compare with ticket from d.b.2
@@ -1519,6 +1376,240 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         print(collection_tickets_by_height)
 
         print(f"{collection_item_type_name} collection activation tickets tested")
+
+
+    # ===============================================================================================================
+    # collection tests - tested on non_mn3 node
+    def collection_tests(self, item_type: CollectionItemType, label: str):
+        collection_item_type_name = item_type.type_description
+        print(f"== {collection_item_type_name} Collection Tickets test ==")
+
+        collection_reg_ticket = self.tickets[TicketType.COLLECTION]
+        collection_item_type = item_type.reg_ticket_type
+        reg_ticket_type_name = collection_item_type.type_name
+        collection_ticket_type_name = TicketType.COLLECTION.type_name
+
+        self.generate_and_sync_inc(10, self.mining_node_num)
+        # collection reg ticket creator-height + 32
+
+        # invalid collection txid (txid format)
+        if item_type == CollectionItemType.NFT:
+            self.create_nft_ticket_v2(self.non_mn3, "invalid_collection_txid")
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, "invalid_collection_txid")
+        top_mn_node = self.nodes[self.top_mns[0].index]
+        item_ticket = self.tickets[item_type.reg_ticket_type]
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, "Incorrect collection activation ticket txid",
+            top_mn_node.tickets, "register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
+
+        # collection txid does not point to existing txid
+        if item_type == CollectionItemType.NFT:
+            self.create_nft_ticket_v2(self.non_mn3, self.get_random_txid())
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, self.get_random_txid())
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, "is not in the blockchain",
+            top_mn_node.tickets, "register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
+
+        # collection txid does not point to collection activation ticket
+        if item_type == CollectionItemType.NFT:
+            self.create_nft_ticket_v2(self.non_mn3, self.mn_nodes[0].mnid_reg_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, self.mn_nodes[0].mnid_reg_txid)
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, "has invalid type",
+            top_mn_node.tickets, "register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
+
+        # collection txid points to collection registration ticket instead of activation
+        if item_type == CollectionItemType.NFT:
+            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.reg_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.reg_txid)
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, "has invalid type",
+            top_mn_node.tickets, "register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
+
+        # adding wrong item to the collection
+        if item_type == CollectionItemType.NFT:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.act_txid)
+            test_wrong_collection_item = ActionType.SENSE.reg_ticket_type.type_name
+            wrong_item_ticket = self.tickets[ActionType.SENSE.reg_ticket_type]
+        else:
+            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
+            test_wrong_collection_item = TicketType.NFT.type_name
+            wrong_item_ticket = self.tickets[TicketType.NFT]
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, "ticket cannot be accepted",
+            top_mn_node.tickets, "register", test_wrong_collection_item,
+            wrong_item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
+            
+        # save creator_pastelid1 
+        saved_creator_pastelid1 = self.creator_pastelid1
+        # creator_pastelid3 is not in list_of_pastelids_of_authorized_contributors list
+        self.creator_pastelid1 = self.creator_pastelid3
+        if item_type == CollectionItemType.NFT:
+            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.act_txid)
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, f"User with Pastel ID '{self.creator_pastelid3}' is not authorized contributor for the collection",
+            top_mn_node.tickets, "register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))
+
+        # add item reg ticket #1 successfully (creator_pastelid1 user)
+        self.creator_pastelid1 = saved_creator_pastelid1
+        if item_type == CollectionItemType.NFT:
+            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid1, collection_reg_ticket.act_txid)
+        item_ticket.reg_txid = top_mn_node.tickets("register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_1", str(self.storage_fee))["txid"]
+        print(f'registered {collection_item_type.type_name} ticket #1 [{item_ticket.reg_txid}] in the collection [{self.collection_name}]')
+        self.inc_ticket_counter(collection_item_type)
+        item_ticket1 = item_ticket
+        self.tickets[item_type.reg_ticket_type] = TicketData()
+        item_ticket = self.tickets[item_type.reg_ticket_type]
+        self.wait_for_ticket_tnx()
+        # collection reg ticket creator-height + 37
+
+        # add item reg ticket #2 successfully (creator_pastelid2 user)
+        self.creator_pastelid1 = self.creator_pastelid2
+        if item_type == CollectionItemType.NFT: 
+            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid2, collection_reg_ticket.act_txid)
+        item_ticket.reg_txid = self.nodes[self.top_mns[0].index].tickets("register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_2", str(self.storage_fee))["txid"]
+        print(f'registered {collection_item_type.type_name} ticket #2 [{item_ticket.reg_txid}] in the collection [{self.collection_name}]')
+        self.inc_ticket_counter(collection_item_type)
+        item_ticket2 = item_ticket
+        self.tickets[item_type.reg_ticket_type] = TicketData()
+        item_ticket = self.tickets[item_type.reg_ticket_type]
+        self.wait_for_ticket_tnx()
+        # collection reg ticket creator-height + 42
+
+        if item_type == CollectionItemType.NFT:
+            act_item_type = TicketType.ACTIVATE
+        else:
+            act_item_type = TicketType.SENSE_ACTION_ACTIVATE
+
+        # activate ticket #1 successfully
+        item_ticket1.act_txid = self.nodes[item_ticket1.pastelid_node_id].tickets("activate", reg_ticket_type_name,
+            item_ticket1.reg_txid, str(item_ticket1.reg_height), str(self.storage_fee), item_ticket1.reg_pastelid, self.passphrase)["txid"]
+        assert_true(item_ticket1.act_txid, f"{collection_item_type.type_name} was not activated")
+        self.inc_ticket_counter(act_item_type);
+        self.wait_for_ticket_tnx()
+        # collection reg ticket creator-height + 47
+        
+        # check that collection activate ticket returns only one activated collection item ticket
+        # and collection state is 'in-process'
+        coll_act_tkt1 = self.nodes[0].tickets("get", collection_reg_ticket.act_txid)
+        tkt1 = coll_act_tkt1['ticket']
+        assert_equal(coll_act_tkt1['txid'], collection_reg_ticket.act_txid)
+        assert_equal(tkt1['activated_item_count'], 1)
+        assert_equal(tkt1['collection_state'], 'in-process')
+        assert_equal(tkt1['is_expired_by_height'], False)
+        assert_equal(tkt1['is_full'], False)
+        
+        # we still should be able to register item ticket #3, because collection is still in-process and not finalized
+        if item_type == CollectionItemType.NFT: 
+            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid2, collection_reg_ticket.act_txid)
+        item_ticket.reg_txid = self.nodes[self.top_mns[0].index].tickets("register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_2", str(self.storage_fee))["txid"]
+        print(f'registered {collection_item_type.type_name} ticket #3 [{item_ticket.reg_txid}] in the collection [{self.collection_name}]')
+        self.inc_ticket_counter(collection_item_type)
+        item_ticket3 = item_ticket
+        self.tickets[item_type.reg_ticket_type] = TicketData()
+        item_ticket = self.tickets[item_type.reg_ticket_type]
+        self.wait_for_ticket_tnx()
+        # collection reg ticket creator-height + 52
+        
+        # activate ticket #2 successfully
+        item_ticket2.act_txid = self.nodes[item_ticket1.pastelid_node_id].tickets("activate", reg_ticket_type_name,
+            item_ticket2.reg_txid, str(item_ticket2.reg_height), str(self.storage_fee), item_ticket2.reg_pastelid, self.passphrase)["txid"]
+        assert_true(item_ticket2.act_txid, f"{collection_item_type.type_name} was not activated")
+        self.inc_ticket_counter(act_item_type);
+        self.wait_for_ticket_tnx()
+        # collection reg ticket creator-height + 57
+        
+        # check that collection activate ticket returns two activated item tickets
+        # and collection state is 'finalized'
+        coll_act_tkt2 = self.nodes[0].tickets("get", collection_reg_ticket.act_txid)
+        tkt2 = coll_act_tkt2['ticket']
+        assert_equal(coll_act_tkt2['txid'], collection_reg_ticket.act_txid)
+        assert_equal(tkt2['activated_item_count'], 2)
+        assert_equal(tkt2['collection_state'], 'finalized')
+        assert_equal(tkt2['is_expired_by_height'], False)
+        assert_equal(tkt2['is_full'], True)
+        
+        # find all item reg tickets in the collection by collection activate ticket txid
+        # there should be 3 reg tickets in the collection, but only 2 of them are activated
+        txids1 = [ item_ticket1.reg_txid, item_ticket2.reg_txid, item_ticket3.reg_txid ]
+        collection_items = self.nodes[self.non_mn1].tickets("find", reg_ticket_type_name, collection_reg_ticket.act_txid)
+        assert_equal(3, len(collection_items), "collection items count is not 3")
+        txids2 = [ item['txid'] for item in collection_items ]
+        assert_equal(sorted(txids1), sorted(txids2), "collection items are not the same")
+        
+        # find all activated items in the collection by collection activate ticket txid
+        # there should be 2 activated items in the collection
+        txids1 = [ item_ticket1.act_txid, item_ticket2.act_txid ]
+        collection_items = self.nodes[self.non_mn1].tickets("find", act_item_type.type_name, collection_reg_ticket.act_txid)
+        assert_equal(2, len(collection_items), "collection items count is not 2")
+        txids2 = [ item['txid'] for item in collection_items ]
+        assert_equal(sorted(txids1), sorted(txids2), "collection items are not the same")
+        
+        # cannot register more collection item tickets (will exceed max_collection_entries)
+        if item_type == CollectionItemType.NFT: 
+            self.create_nft_ticket_v2(self.non_mn3, collection_reg_ticket.act_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid2, collection_reg_ticket.act_txid)
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, f"Max number of items ({2}) allowed in the collection '{self.collection_name}' has been exceeded",
+            self.nodes[self.top_mns[0].index].tickets, "register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_3", str(self.storage_fee))
+
+        # test collection final allowed block height, create collection with collection_final_allowed_block_height +10 blocks
+        # register new collection #2
+        # existing  collection in self.tickets saved in ticket local var
+        new_collection_reg_ticket = TicketData()
+        self.tickets[TicketType.COLLECTION] = new_collection_reg_ticket
+        self.create_collection_ticket(item_type, self.collection_name + " (final_allowed_block_height)", self.non_mn3, 10, 
+            2, 10, [], self.royalty, self.is_green)
+        
+        self.nodes[self.mining_node_num].sendtoaddress(self.nonmn3_address1, 1000, "", "", False)
+        
+        top_mn_node = self.nodes[self.top_mns[0].index]
+        new_collection_reg_ticket.reg_txid = top_mn_node.tickets("register", collection_ticket_type_name,
+            new_collection_reg_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict),
+            self.top_mns[0].pastelid, self.passphrase, label, str(self.storage_fee))["txid"]
+        assert_true(new_collection_reg_ticket.reg_txid, f"No {collection_item_type.type_name} registration ticket was created")
+        self.inc_ticket_counter(TicketType.COLLECTION)
+        self.wait_for_sync_all(1)
+        self.wait_for_sync_all(10)
+        
+        # activate collection #2
+        collection_ticket_act_txid = self.nodes[self.non_mn3].tickets("activate", collection_ticket_type_name,
+            new_collection_reg_ticket.reg_txid, str(new_collection_reg_ticket.reg_height), str(self.storage_fee),
+            new_collection_reg_ticket.reg_pastelid, self.passphrase)["txid"]
+        assert_true(collection_ticket_act_txid, f"No {collection_item_type.type_name} registration ticket was created")
+        collection_reg_ticket.act_txid = collection_ticket_act_txid
+        self.inc_ticket_counter(TicketType.COLLECTION_ACTIVATE)
+        self.wait_for_ticket_tnx()
+        
+        # cannot add items to this collection any more
+        if item_type == CollectionItemType.NFT: 
+            self.create_nft_ticket_v2(self.non_mn3, collection_ticket_act_txid)
+        else:
+            self.create_action_ticket(self.non_mn3, ActionType.SENSE, self.creator_pastelid2, collection_ticket_act_txid)
+        assert_raises_rpc(rpc.RPC_MISC_ERROR, "No new items are allowed to be added to the finalized collection",
+            self.nodes[self.top_mns[0].index].tickets, "register", reg_ticket_type_name,
+            item_ticket.reg_ticket_base64_encoded, json.dumps(self.signatures_dict), self.top_mns[0].pastelid, self.passphrase, label + "_4", str(self.storage_fee))
+        # restore data for collection #1
+        self.tickets[TicketType.COLLECTION] = collection_reg_ticket
+
+        # restore creator_pastelid1 
+        self.creator_pastelid1 = saved_creator_pastelid1
+        print(f"== {collection_item_type_name} collection tickets tested ==")
 
 
     # ===============================================================================================================

--- a/qa/rpc-tests/mn_tickets.py
+++ b/qa/rpc-tests/mn_tickets.py
@@ -3021,7 +3021,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         tickets_list = self.nodes[self.non_mn3].tickets("list", "nft", "inactive")
         assert_equal(len(tickets_list), self.ticket_counter(TicketType.NFT) - self.ticket_counter(TicketType.ACTIVATE))
         tickets_list = self.nodes[self.non_mn3].tickets("list", "nft", "transferred")
-        assert_equal(len(tickets_list), loop_number + 1)
+        assert_equal(len(tickets_list), loop_number + 2)
 
         print(' --- list act')
         tickets_list = self.nodes[self.non_mn3].tickets("list", "act")
@@ -3031,7 +3031,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         tickets_list = self.nodes[self.non_mn3].tickets("list", "act", "available")
         assert_equal(len(tickets_list), loop_number + 1)
         tickets_list = self.nodes[self.non_mn3].tickets("list", "act", "transferred")
-        assert_equal(len(tickets_list), loop_number + 1)
+        assert_equal(len(tickets_list), loop_number + 2)
 
         cur_block = self.nodes[self.non_mn3].getblockcount()
         offer_ticket1_txid = self.nodes[self.non_mn3].tickets("register", "offer", nft_ticket2_act_ticket_txid,
@@ -3101,7 +3101,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         tickets_list = self.nodes[self.non_mn3].tickets("list", "transfer", "all")
         assert_equal(len(tickets_list), self.ticket_counter(TicketType.TRANSFER))
         tickets_list = self.nodes[self.non_mn3].tickets("list", "transfer", "available")
-        available_transfer_tickets = 8*(loop_number + 1)
+        available_transfer_tickets = 10*(loop_number + 1)
         assert_equal(len(tickets_list), available_transfer_tickets)
         tickets_list = self.nodes[self.non_mn3].tickets("list", "transfer", "transferred")
         assert_equal(len(tickets_list), self.ticket_counter(TicketType.TRANSFER) - available_transfer_tickets)

--- a/qa/rpc-tests/mn_tickets.py
+++ b/qa/rpc-tests/mn_tickets.py
@@ -3021,7 +3021,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         tickets_list = self.nodes[self.non_mn3].tickets("list", "nft", "inactive")
         assert_equal(len(tickets_list), self.ticket_counter(TicketType.NFT) - self.ticket_counter(TicketType.ACTIVATE))
         tickets_list = self.nodes[self.non_mn3].tickets("list", "nft", "transferred")
-        assert_equal(len(tickets_list), 1 + 1*(loop_number + 1))
+        assert_equal(len(tickets_list), loop_number + 1)
 
         print(' --- list act')
         tickets_list = self.nodes[self.non_mn3].tickets("list", "act")
@@ -3029,9 +3029,9 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         tickets_list = self.nodes[self.non_mn3].tickets("list", "act", "all")
         assert_equal(len(tickets_list), self.ticket_counter(TicketType.ACTIVATE))
         tickets_list = self.nodes[self.non_mn3].tickets("list", "act", "available")
-        assert_equal(len(tickets_list), 1 + 2*(loop_number + 1))
+        assert_equal(len(tickets_list), loop_number + 1)
         tickets_list = self.nodes[self.non_mn3].tickets("list", "act", "transferred")
-        assert_equal(len(tickets_list), 1 + 1*(loop_number + 1))
+        assert_equal(len(tickets_list), loop_number + 1)
 
         cur_block = self.nodes[self.non_mn3].getblockcount()
         offer_ticket1_txid = self.nodes[self.non_mn3].tickets("register", "offer", nft_ticket2_act_ticket_txid,
@@ -3101,7 +3101,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         tickets_list = self.nodes[self.non_mn3].tickets("list", "transfer", "all")
         assert_equal(len(tickets_list), self.ticket_counter(TicketType.TRANSFER))
         tickets_list = self.nodes[self.non_mn3].tickets("list", "transfer", "available")
-        available_transfer_tickets = 10*(loop_number + 1)
+        available_transfer_tickets = 8*(loop_number + 1)
         assert_equal(len(tickets_list), available_transfer_tickets)
         tickets_list = self.nodes[self.non_mn3].tickets("list", "transfer", "transferred")
         assert_equal(len(tickets_list), self.ticket_counter(TicketType.TRANSFER) - available_transfer_tickets)

--- a/qa/rpc-tests/ticket_type.py
+++ b/qa/rpc-tests/ticket_type.py
@@ -13,7 +13,7 @@ USE_OAT = True
 # ===============================================================================================================
 class TicketType(Enum):
     """ Pastel ticket types.
-    TicketTypeName    | ID | Description | TypeName | TicketName | FolderName | Ticket Price
+    TicketTypeName          | ID | Description | TypeName | TicketName | FolderName | Ticket Price
     """
     ID                      = 1, "Pastel ID", "id", "pastelid", None, 10
     MNID                    = 2, "MasterNode's Pastel ID", "mnid", "pastelid", None, 10
@@ -25,7 +25,7 @@ class TicketType(Enum):
     DOWN                    = 8, "TakeDown", "take-down", "take-down", None, 10
     ROYALTY                 = 9, "Royalty", "nft-royalty", "nft-royalty", None, 10
     USERNAME                = 10, "UserName Change", "username-change", "username-change", None, 10
-    ETHERIUM_ADDRESS        = 11, "Etherium Address", "ethereum-address-change", "ethereum-address-change", None, 10
+    ETHEREUM_ADDRESS        = 11, "Ethereum Address", "ethereum-address-change", "ethereum-address-change", None, 10
     SENSE_ACTION            = 12, "Sense Action", "action", "action-reg", "sense-result", 10
     SENSE_ACTION_ACTIVATE   = 13, "Sense Action Activation", "action-act", "action-act", "sense-act", 10
     CASCADE_ACTION          = 14, "Cascade Action", "action", "action-reg", "cascade-artifact", 10

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -132,7 +132,7 @@ MNODE_CPP =\
   mnode/tickets/accept.cpp\
   mnode/tickets/action-reg.cpp\
   mnode/tickets/action-act.cpp\
-  mnode/tickets/etherium-address-change.cpp\
+  mnode/tickets/ethereum-address-change.cpp\
   mnode/tickets/nft-act.cpp\
   mnode/tickets/collection-act.cpp\
   mnode/tickets/collection-reg.cpp\
@@ -184,7 +184,7 @@ MNODE_H = \
   mnode/rpc/tickets-tools.h\
   mnode/tickets/action-reg.h\
   mnode/tickets/action-act.h\
-  mnode/tickets/etherium-address-change.h\
+  mnode/tickets/ethereum-address-change.h\
   mnode/tickets/accept.h\
   mnode/tickets/ticket.h\
   mnode/tickets/ticket-extra-fees.h\

--- a/src/alert.h
+++ b/src/alert.h
@@ -45,6 +45,11 @@ public:
     std::string strStatusBar;
     std::string strRPCError;
 
+    CUnsignedAlert()
+    {
+		SetNull();
+	}
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream>

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -36,7 +36,7 @@ void CChain::SetTip(CBlockIndex *pindex)
         vChain[pindex->nHeight] = pindex;
         pindex = pindex->pprev;
     }
-    gl_nChainHeight = vChain.size() - 1;
+    gl_nChainHeight = static_cast<uint32_t>(vChain.size()) - 1;
 }
 
 CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -33,10 +33,10 @@ using MapCheckpoints = std::map<uint32_t, uint256>;
 struct CCheckpointData
 {
     MapCheckpoints mapCheckpoints;
-    int64_t nTimeLastCheckpoint;          // UNIX timestamp of last checkpoint block  
-    int64_t nTransactionsLastCheckpoint;  // total number of transactions between genesis and last checkpoint
-    double fTransactionsPerDay;           // estimated number of transactions per day after checkpoint
-                                          // > total number of tx / (checkpoint block height / (24 * 24))
+    int64_t nTimeLastCheckpoint = 0;          // UNIX timestamp of last checkpoint block  
+    int64_t nTransactionsLastCheckpoint = 0;  // total number of transactions between genesis and last checkpoint
+    double fTransactionsPerDay = 0.0f;        // estimated number of transactions per day after checkpoint
+                                              // > total number of tx / (checkpoint block height / (24 * 24))
 };
 
 class CBaseKeyConstants : public KeyConstants

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -1,7 +1,7 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <optional>
@@ -39,12 +39,12 @@ struct NetworkUpgrade
     /**
      * The first protocol version which will understand the new consensus rules
      */
-    int nProtocolVersion;
+    int nProtocolVersion = 0;
 
     /**
      * Height of the first block for which the new consensus rules will be active
      */
-    uint32_t nActivationHeight;
+    uint32_t nActivationHeight = 0;
 
     /**
      * Special value for nActivationHeight indicating that the upgrade is always active.
@@ -72,34 +72,36 @@ struct Params
 {
     uint256 hashGenesisBlock;
 
-    int nSubsidyHalvingInterval;
+    int nSubsidyHalvingInterval = 0;
     /** Used to check majorities for block version upgrade */
-    int nMajorityEnforceBlockUpgrade;
-    int nMajorityRejectBlockOutdated;
-    int nMajorityWindow;
+    int nMajorityEnforceBlockUpgrade = 0;
+    int nMajorityRejectBlockOutdated = 0;
+    int nMajorityWindow = 0;
     NetworkUpgrade vUpgrades[to_integral_type(UpgradeIndex::MAX_NETWORK_UPGRADES)];
     /** Proof of work parameters */
     unsigned int nEquihashN = 0;
     unsigned int nEquihashK = 0;
     uint256 powLimit;
     std::optional<uint32_t> nPowAllowMinDifficultyBlocksAfterHeight;
-    int64_t nPowAveragingWindow;
-    int64_t nPowMaxAdjustDown;
-    int64_t nPowMaxAdjustUp;
-    int64_t nPowTargetSpacing;
+    int64_t nPowAveragingWindow = 0;
+    int64_t nPowMaxAdjustDown = 0;
+    int64_t nPowMaxAdjustUp = 0;
+    int64_t nPowTargetSpacing = 0;
 
     int64_t AveragingWindowTimespan() const noexcept { return nPowAveragingWindow * nPowTargetSpacing; }
     int64_t MinActualTimespan() const noexcept { return (AveragingWindowTimespan() * (100 - nPowMaxAdjustUp  )) / 100; }
     int64_t MaxActualTimespan() const noexcept { return (AveragingWindowTimespan() * (100 + nPowMaxAdjustDown)) / 100; }
     uint256 nMinimumChainWork;
-    int64_t nMaxGovernanceAmount;
+    int64_t nMaxGovernanceAmount = 0;
     // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks)
     uint32_t nNetworkUpgradePeerPreferenceBlockPeriod = 0;
     ChainNetwork network;
 
     Params(const ChainNetwork aNetwork) :
         network(aNetwork)
-    {}
+    {
+
+    }
 
     /**
      * Add network upgrade.

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -1,26 +1,31 @@
 // Copyright (c) 2017 The Zcash developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include "deprecation.h"
+#include <deprecation.h>
 
-#include "alert.h"
-#include "clientversion.h"
-#include "init.h"
-#include "ui_interface.h"
-#include "util.h"
-#include "chainparams.h"
+#include <alert.h>
+#include <clientversion.h>
+#include <init.h>
+#include <ui_interface.h>
+#include <util.h>
+#include <chainparams.h>
 
-static const std::string CLIENT_VERSION_STR = FormatVersion(CLIENT_VERSION);
+using namespace std;
+
+static const string CLIENT_VERSION_STR = FormatVersion(CLIENT_VERSION);
 
 void EnforceNodeDeprecation(int nHeight, bool forceLogging, bool fThread) {
 
     // Do not enforce deprecation in regtest or on testnet
-    std::string networkID = Params().NetworkIDString();
-    if (networkID != "main") return;
+    const auto &params = Params();
+    if (!params.IsMainNet())
+        return;
 
-    int blocksToDeprecation = DEPRECATION_HEIGHT - nHeight;
-    if (blocksToDeprecation <= 0) {
+    const int blocksToDeprecation = DEPRECATION_HEIGHT - nHeight;
+    if (blocksToDeprecation <= 0)
+    {
         // In order to ensure we only log once per process when deprecation is
         // disabled (to avoid log spam), we only need to log in two cases:
         // - The deprecating block just arrived
@@ -38,7 +43,7 @@ void EnforceNodeDeprecation(int nHeight, bool forceLogging, bool fThread) {
         StartShutdown();
     } else if (blocksToDeprecation == DEPRECATION_WARN_LIMIT ||
                (blocksToDeprecation < DEPRECATION_WARN_LIMIT && forceLogging)) {
-        std::string msg = strprintf(_("This version will be deprecated at block height %d, and will automatically shut down."),
+        string msg = strprintf(_("This version will be deprecated at block height %d, and will automatically shut down."),
                             DEPRECATION_HEIGHT) + " " +
                   _("You should upgrade to the latest version of Pastel.");
         LogPrintf("*** %s\n", msg);

--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -1,13 +1,14 @@
 #pragma once
 // Copyright (c) 2017 The Zcash developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 // Deprecation policy:
-// * Shut down 16 weeks' worth of blocks after the estimated release block height.
+// * Shut down WEEKS_UNTIL_DEPRECATION weeks' worth of blocks after the estimated release block height.
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
-static constexpr unsigned int APPROX_RELEASE_HEIGHT = 438196;
-static constexpr int WEEKS_UNTIL_DEPRECATION = 52;
+static constexpr unsigned int APPROX_RELEASE_HEIGHT = 500'000;
+static constexpr int WEEKS_UNTIL_DEPRECATION = 2 * 52; // 2 years
 static constexpr unsigned int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
 
 // Number of blocks before deprecation to warn users

--- a/src/gtest/test_mnode/test_ticket_collection-reg.cpp
+++ b/src/gtest/test_mnode/test_ticket_collection-reg.cpp
@@ -6,6 +6,7 @@
 #include <utilstrencodings.h>
 #include <mnode/tickets/collection-reg.h>
 #include <mnode/mnode-controller.h>
+
 #include <test_mnode/test_data.h>
 
 using namespace std;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -235,26 +235,10 @@ void Shutdown(CServiceThreadGroup& threadGroup, CScheduler &scheduler)
         LOCK(cs_main);
         if (pcoinsTip)
             FlushStateToDisk();
-        if (pcoinsTip)
-        {
-            delete pcoinsTip;
-            pcoinsTip = nullptr;
-        }
-        if (pcoinscatcher)
-        {
-            delete pcoinscatcher;
-            pcoinscatcher = nullptr;
-        }
-        if (pcoinsdbview)
-        {
-            delete pcoinsdbview;
-            pcoinsdbview = nullptr;
-        }
-        if (pblocktree)
-        {
-            delete pblocktree;
-            pblocktree = nullptr;
-        }
+        safe_delete_obj(pcoinsTip);
+        safe_delete_obj(pcoinscatcher);
+        safe_delete_obj(pcoinsdbview);
+        safe_delete_obj(pblocktree);
     }
 #ifdef ENABLE_WALLET
     if (pwalletMain)
@@ -1499,10 +1483,10 @@ bool AppInit2(CServiceThreadGroup& threadGroup, CScheduler& scheduler)
         do {
             try {
                 UnloadBlockIndex();
-                delete pcoinsTip;
-                delete pcoinsdbview;
-                delete pcoinscatcher;
-                delete pblocktree;
+                safe_delete_obj(pcoinsTip);
+                safe_delete_obj(pcoinsdbview);
+                safe_delete_obj(pcoinscatcher);
+                safe_delete_obj(pblocktree);
 
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
                 pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2775,7 +2775,7 @@ void static UpdateTip(const CChainParams& chainparams, CBlockIndex* pindexNew)
     nTimeBestReceived = GetTime();
     mempool.AddTransactionsUpdated(1);
     const auto pChainTip = chainActive.Tip();
-    LogFnPrintf("new best=%s  height=%d  log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%zutx)", __func__,
+    LogFnPrintf("new best=%s  height=%d  log2_work=%.8g  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%zutx)",
               pChainTip->GetBlockHash().ToString(), chainActive.Height(), log(pChainTip->nChainWork.getdouble()) / log(2.0), (unsigned long)pChainTip->nChainTx,
               DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pChainTip->GetBlockTime()),
               Checkpoints::GuessVerificationProgress(chainparams.Checkpoints(), pChainTip), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1 << 20)), pcoinsTip->GetCacheSize());

--- a/src/mnode/rpc/tickets-activate.cpp
+++ b/src/mnode/rpc/tickets-activate.cpp
@@ -24,6 +24,7 @@ If successful, returns "txid" of the activation ticket.
 Available types of tickets to activate:
   "nft"      - NFT ticket. 
   "action"   - Action ticket.
+  "collection" - Collection ticket.
 )");
 }
 

--- a/src/mnode/rpc/tickets-tools.cpp
+++ b/src/mnode/rpc/tickets-tools.cpp
@@ -11,7 +11,7 @@
 #include "mnode/rpc/mnode-rpc-utils.h"
 #include <mnode/tickets/nft-reg.h>
 #include <mnode/tickets/username-change.h>
-#include <mnode/tickets/etherium-address-change.h>
+#include <mnode/tickets/ethereum-address-change.h>
 #include "mnode/tickets/ticket.h"
 #include "mnode/ticket-processor.h"
 #include "mnode/mnode-controller.h"

--- a/src/mnode/tickets/accept.cpp
+++ b/src/mnode/tickets/accept.cpp
@@ -208,7 +208,7 @@ bool CAcceptTicket::CheckAcceptTicketExistByOfferTicket(const string& offerTxnId
     return masterNodeCtrl.masternodeTickets.CheckTicketExist(ticket);
 }
 
-AcceptTickets_t CAcceptTicket::FindAllTicketByPastelID(const string& pastelID)
+AcceptTickets_t CAcceptTicket::FindAllTicketByMVKey(const string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CAcceptTicket>(pastelID);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CAcceptTicket>(sMVKey);
 }

--- a/src/mnode/tickets/accept.h
+++ b/src/mnode/tickets/accept.h
@@ -31,7 +31,7 @@ public:
     v_uint8 m_signature;
 
 public:
-    CAcceptTicket() = default;
+    CAcceptTicket() noexcept = default;
 
     explicit CAcceptTicket(std::string &&sPastelID) : 
         m_sPastelID(std::move(sPastelID))
@@ -97,7 +97,7 @@ public:
 
     static bool CheckAcceptTicketExistByOfferTicket(const std::string& offerTxnId);
 
-    static AcceptTickets_t FindAllTicketByPastelID(const std::string& pastelID);
+    static AcceptTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
 
 protected:
     std::string m_sPastelID;      // Pastel ID of the new owner (acceptor)

--- a/src/mnode/tickets/action-act.h
+++ b/src/mnode/tickets/action-act.h
@@ -38,7 +38,7 @@ public:
     static constexpr uint8_t PRINCIPAL_MN_FEE_SHARE = 60; // in percents
     static constexpr uint8_t OTHER_MN_FEE_SHARE = 20;     // in percents
 
-    CActionActivateTicket() = default;
+    CActionActivateTicket() noexcept = default;
 
     explicit CActionActivateTicket(std::string &&sCallerPastelID)
     {
@@ -112,8 +112,8 @@ public:
     static CActionActivateTicket Create(std::string &&regTicketTxId, const unsigned int nCalledAtHeight, const CAmount storageFee, std::string &&sCallerPastelID, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CActionActivateTicket& ticket);
 
-    static ActionActivateTickets_t FindAllTicketByPastelID(const std::string& pastelID);
-    static ActionActivateTickets_t FindAllTicketByCalledAtHeight(const unsigned int nCalledAtHeight);
+    static ActionActivateTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
+    static ActionActivateTickets_t FindAllTicketByCalledAtHeight(const uint32_t nCalledAtHeight);
     static bool CheckTicketExistByActionRegTicketID(const std::string& regTicketTxnId);
 
 protected:

--- a/src/mnode/tickets/action-reg.cpp
+++ b/src/mnode/tickets/action-reg.cpp
@@ -8,6 +8,7 @@
 #include <utilstrencodings.h>
 #include <mnode/tickets/pastelid-reg.h>
 #include <mnode/tickets/action-reg.h>
+#include <mnode/tickets/collection-act.h>
 
 #ifdef ENABLE_WALLET
 #include <wallet/wallet.h>
@@ -272,17 +273,11 @@ bool CActionRegTicket::setActionType(const string& sActionType) noexcept
     return (m_ActionType != ACTION_TICKET_TYPE::UNKNOWN);
 }
 
-uint32_t CActionRegTicket::CountItemsInCollection(const uint32_t currentChainHeight) const
+uint32_t CActionRegTicket::CountItemsInCollection() const
 {
-    uint32_t nCollectionItemCount = 0;
-    masterNodeCtrl.masternodeTickets.ProcessTicketsByMVKey<CActionRegTicket>(m_sCollectionActTxid,
-                                                                            [&](const CActionRegTicket& regTicket) -> bool
-                                                                            {
-                                                                                if ((regTicket.GetBlock() <= currentChainHeight))
-                                                                                    ++nCollectionItemCount;
-                                                                                return true;
-                                                                            });
-    return nCollectionItemCount;
+    if (m_ActionType == ACTION_TICKET_TYPE::SENSE)
+        return CollectionActivateTicket::CountItemsInCollection(m_sCollectionActTxid, COLLECTION_ITEM_TYPE::SENSE, true);
+    return 0;
 }
 
 /**
@@ -435,9 +430,9 @@ bool CActionRegTicket::CheckIfTicketInDb(const string& key)
     return masterNodeCtrl.masternodeTickets.CheckTicketExist(ticket);
 }
 
-ActionRegTickets_t CActionRegTicket::FindAllTicketByPastelID(const string& pastelID)
+ActionRegTickets_t CActionRegTicket::FindAllTicketByMVKey(const string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CActionRegTicket>(pastelID);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CActionRegTicket>(sMVKey);
 }
 
 /**

--- a/src/mnode/tickets/action-reg.h
+++ b/src/mnode/tickets/action-reg.h
@@ -52,7 +52,7 @@ signatures: {
 
   key #1: primary key (generated)
 mvkey #1: action caller Pastel ID
-mvkey #2: collection txid (optional)
+mvkey #2: collection activate txid (optional)
 mvkey #3: label (optional)
 */
 
@@ -90,7 +90,7 @@ class CActionRegTicket :
     public CollectionItem
 {
 public:
-    CActionRegTicket() = default;
+    CActionRegTicket() noexcept = default;
     explicit CActionRegTicket(std::string &&actionTicket) :
         m_sActionTicket(std::move(actionTicket))
     {}
@@ -165,10 +165,10 @@ public:
         std::string && sPastelID, SecureString&& strKeyPass, std::string &&label, const CAmount storageFee);
     static bool FindTicketInDb(const std::string& key, CActionRegTicket& _ticket);
     static bool CheckIfTicketInDb(const std::string& key);
-    static ActionRegTickets_t FindAllTicketByPastelID(const std::string& pastelID);
+    static ActionRegTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
     // get action storage fees in PSL
     static action_fee_map_t GetActionFees(const size_t nDataSizeInMB);
-    uint32_t CountItemsInCollection(const uint32_t currentChainHeight) const override;
+    uint32_t CountItemsInCollection() const override;
 
 protected:
     uint16_t m_nActionTicketVersion{0};

--- a/src/mnode/tickets/collection-act.h
+++ b/src/mnode/tickets/collection-act.h
@@ -26,7 +26,7 @@ using CollectionActivateTickets_t = std::vector<CollectionActivateTicket>;
 }
 
 key   #1: Collection Registration ticket txid
-mvkey #1: Pastel ID
+mvkey #1: Collection creator's Pastel ID
 mvkey #2: creator height (converted to string)
 */
 class CollectionActivateTicket : public CPastelTicketMNFee
@@ -37,7 +37,7 @@ public:
     static constexpr uint8_t PRINCIPAL_MN_FEE_SHARE = 60; // in percents
     static constexpr uint8_t OTHER_MN_FEE_SHARE = 20;     // in percents
 
-    CollectionActivateTicket() = default;
+    CollectionActivateTicket() noexcept = default;
 
     explicit CollectionActivateTicket(std::string &&sPastelID)  
     {
@@ -111,15 +111,19 @@ public:
     {
         return {ALL_MN_FEE, PRINCIPAL_MN_FEE_SHARE, OTHER_MN_FEE_SHARE};
     }
-
     CAmount GetExtraOutputs(std::vector<CTxOut>& outputs) const override;
 
     static CollectionActivateTicket Create(std::string &&regTicketTxId, int _creatorHeight, int _storageFee, std::string &&sPastelID, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CollectionActivateTicket& ticket);
 
-    static CollectionActivateTickets_t FindAllTicketByPastelID(const std::string& pastelID);
-    static CollectionActivateTickets_t FindAllTicketByCreatorHeight(const unsigned int nCreatorHeight);
+    static CollectionActivateTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
+    static CollectionActivateTickets_t FindAllTicketByCreatorHeight(const uint32_t nCreatorHeight);
     static bool CheckTicketExistByCollectionTicketID(const std::string& regTicketTxId);
+    static uint32_t CountItemsInCollection(const std::string& sCollectionActTxid, const COLLECTION_ITEM_TYPE itemType, bool bActivatedOnly = true);
+    // retrieve referred collection registration ticket
+    static std::unique_ptr<CPastelTicket> RetrieveCollectionRegTicket(std::string& error, const std::string& sRegTxId, bool& bInvalidTxId) noexcept;
+    // get collection ticket by txid
+    static std::unique_ptr<CPastelTicket> GetCollectionTicket(const uint256& txid);
 
 protected:
     std::string m_sPastelID;     // Pastel ID of the Collection's creator

--- a/src/mnode/tickets/collection-item.h
+++ b/src/mnode/tickets/collection-item.h
@@ -14,19 +14,16 @@ public:
     // getters for ticket fields
     std::string getCollectionActTxId() const noexcept { return m_sCollectionActTxid; }
     std::string getCreatorPastelID_param() const noexcept { return m_sCreatorPastelID; }
+    bool IsCollectionItem() const noexcept { return !m_sCollectionActTxid.empty(); }
+    // count number of items in the collection
+    virtual uint32_t CountItemsInCollection() const = 0;
+    // retrieve referred collection activate ticket
+    virtual std::unique_ptr<CPastelTicket> RetrieveCollectionActivateTicket(std::string& error, bool& bInvalidTxId) const noexcept;
 
 protected:
     std::string m_sCollectionActTxid; // txid of the collection activation ticket - can be empty for the simple item
     std::string m_sCreatorPastelID;   // Pastel ID of the collection item creator
 
-    // retrieve referred collection activate ticket
-    virtual std::unique_ptr<CPastelTicket> RetrieveCollectionActivateTicket(std::string& error, bool& bInvalidTxId) const noexcept;
-    // retrieve referred collection registration ticket
-    static std::unique_ptr<CPastelTicket> RetrieveCollectionRegTicket(std::string& error, const std::string& sRegTxId, bool& bInvalidTxId) noexcept;
-    // get collection ticket by txid
-    static std::unique_ptr<CPastelTicket> GetCollectionTicket(const uint256& txid);
     // validate referred collection
     ticket_validation_t IsValidCollection(const bool bPreReg) const noexcept;
-    // count number of items in the collection
-    virtual uint32_t CountItemsInCollection(const uint32_t currentChainHeight) const = 0;
 };

--- a/src/mnode/tickets/collection-reg.cpp
+++ b/src/mnode/tickets/collection-reg.cpp
@@ -465,7 +465,7 @@ bool CollectionRegTicket::CheckIfTicketInDb(const string& key)
     return masterNodeCtrl.masternodeTickets.CheckTicketExist(ticket);
 }
 
-CollectionRegTickets_t CollectionRegTicket::FindAllTicketByPastelID(const string& pastelID)
+CollectionRegTickets_t CollectionRegTicket::FindAllTicketByMVKey(const string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CollectionRegTicket>(pastelID);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CollectionRegTicket>(sMVKey);
 }

--- a/src/mnode/tickets/collection-reg.h
+++ b/src/mnode/tickets/collection-reg.h
@@ -86,7 +86,7 @@ signatures: {
 
 key   #1: unique primary key (generated)
 key   #2: lowercased collection name (for case insensitive search)
-mvkey #1: creator PastelID
+mvkey #1: creator Pastel ID
 mvkey #2: label (optional)
 }
 */
@@ -95,7 +95,7 @@ class CollectionRegTicket :
     public CTicketSignedWithExtraFees
 {
 public:
-    CollectionRegTicket() = default;
+    CollectionRegTicket() noexcept = default;
     explicit CollectionRegTicket(std::string &&collection_ticket) : 
         m_sCollectionTicket(std::move(collection_ticket))
     {}
@@ -175,7 +175,7 @@ public:
     static bool FindTicketInDb(const std::string& key, CollectionRegTicket& ticket);
     static bool FindTicketInDbByCollectionName(const std::string& sCollectionName, CollectionRegTicket& ticket);
     static bool CheckIfTicketInDb(const std::string& key);
-    static CollectionRegTickets_t FindAllTicketByPastelID(const std::string& pastelID);
+    static CollectionRegTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
 
 protected:
     std::string m_sCollectionTicket;     // collection registration ticket (json format)

--- a/src/mnode/tickets/ethereum-address-change.cpp
+++ b/src/mnode/tickets/ethereum-address-change.cpp
@@ -6,7 +6,7 @@
 
 #include <init.h>
 #include <pastelid/common.h>
-#include <mnode/tickets/etherium-address-change.h>
+#include <mnode/tickets/ethereum-address-change.h>
 #include <mnode/ticket-processor.h>
 #include <mnode/mnode-controller.h>
 #ifdef ENABLE_WALLET
@@ -164,6 +164,11 @@ bool CChangeEthereumAddressTicket::FindTicketInDb(const string& key, CChangeEthe
 {
     ticket.ethereumAddress = key;
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
+}
+
+ChangeEthereumAddressTickets_t CChangeEthereumAddressTicket::FindAllTicketByMVKey(const string& sMVKey)
+{
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CChangeEthereumAddressTicket>(sMVKey);
 }
 
 bool CChangeEthereumAddressTicket::isEthereumAddressInvalid(const string& ethereumAddress, string& error)

--- a/src/mnode/tickets/ethereum-address-change.h
+++ b/src/mnode/tickets/ethereum-address-change.h
@@ -30,7 +30,7 @@ public:
     v_uint8 signature;
 
 public:
-    CChangeEthereumAddressTicket() = default;
+    CChangeEthereumAddressTicket() noexcept = default;
 
     explicit CChangeEthereumAddressTicket(std::string _pastelID, std::string _ethereumAddress) : 
         pastelID(std::move(_pastelID)), 
@@ -94,4 +94,5 @@ public:
     * return: true if bad, false if good to use
     */
     static bool isEthereumAddressInvalid(const std::string& ethereumAddress, std::string& error);
+    static ChangeEthereumAddressTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
 };

--- a/src/mnode/tickets/nft-act.cpp
+++ b/src/mnode/tickets/nft-act.cpp
@@ -10,6 +10,7 @@
 #include <mnode/tickets/pastelid-reg.h>
 #include <mnode/tickets/nft-reg.h>
 #include <mnode/tickets/nft-act.h>
+#include <mnode/tickets/collection-act.h>
 #include <mnode/tickets/ticket-utils.h>
 #ifdef ENABLE_WALLET
 #include <wallet/wallet.h>
@@ -104,9 +105,9 @@ ticket_validation_t CNFTActivateTicket::IsValid(const bool bPreReg, const uint32
             }
         }
 
-        auto NFTTicket = dynamic_cast<CNFTRegTicket*>(pastelTicket.get());
+        auto pNFTRegTicket = dynamic_cast<CNFTRegTicket*>(pastelTicket.get());
         // this is already validated in common_ticket_validation, but just double check that we retrieved a parent activation reg ticket
-        if (!NFTTicket)
+        if (!pNFTRegTicket)
         {
             tv.errorMsg = strprintf(
                 "The NFT Reg ticket with this txid [%s] is not in the blockchain or is invalid",
@@ -114,31 +115,96 @@ ticket_validation_t CNFTActivateTicket::IsValid(const bool bPreReg, const uint32
             break;
         }
 
-        // 1. check creator PastelID in NFTReg ticket matches PastelID from this ticket
-        if (!NFTTicket->IsCreatorPastelId(m_sPastelID))
+        // check creator PastelID in NFTReg ticket matches PastelID from this ticket
+        if (!pNFTRegTicket->IsCreatorPastelId(m_sPastelID))
         {
             tv.errorMsg = strprintf(
                 "The Pastel ID [%s] is not matching the Creator's Pastel ID [%s] in the NFT Reg ticket with this txid [%s]",
-                m_sPastelID, NFTTicket->getCreatorPastelId(), m_regTicketTxId);
+                m_sPastelID, pNFTRegTicket->getCreatorPastelId(), m_regTicketTxId);
             break;
         }
 
-        // 2. check NFTReg ticket is at the assumed height
-        if (NFTTicket->getCreatorHeight() != m_creatorHeight)
+        // check NFTReg ticket is at the assumed height
+        if (pNFTRegTicket->getCreatorHeight() != m_creatorHeight)
         {
             tv.errorMsg = strprintf(
                 "The CreatorHeight [%d] is not matching the CreatorHeight [%d] in the NFT Reg ticket with this txid [%s]",
-                m_creatorHeight, NFTTicket->getCreatorHeight(), m_regTicketTxId);
+                m_creatorHeight, pNFTRegTicket->getCreatorHeight(), m_regTicketTxId);
             break;
         }
 
-        // 3. check NFTReg ticket fee is same as storageFee
-        if (NFTTicket->getStorageFee() != m_storageFee)
+        // check NFTReg ticket fee is same as storageFee
+        if (pNFTRegTicket->getStorageFee() != m_storageFee)
         {
             tv.errorMsg = strprintf(
                 "The storage fee [%d] is not matching the storage fee [%" PRIi64 "] in the NFT Reg ticket with this txid [%s]",
-                m_storageFee, NFTTicket->getStorageFee(), m_regTicketTxId);
+                m_storageFee, pNFTRegTicket->getStorageFee(), m_regTicketTxId);
             break;
+        }
+        // if action belongs to collection - check if we reached max number of items in that collection
+        if (pNFTRegTicket->IsCollectionItem() && bPreReg)
+        {
+            string error;
+            bool bInvalidTxId = false;
+            const string sCollectionActTxId = pNFTRegTicket->getCollectionActTxId();
+            const auto collectionActTicket = pNFTRegTicket->RetrieveCollectionActivateTicket(error, bInvalidTxId);
+            if (bInvalidTxId)
+            {
+                tv.errorMsg = move(error);
+                break;
+            }
+            // check that we've got collection ticket
+            if (!collectionActTicket)
+            {
+                tv.errorMsg = strprintf(
+                    "The %s ticket [txid=%s] referred by this %s ticket [txid=%s] is not in the blockchain. %s",
+                    CollectionActivateTicket::GetTicketDescription(), sCollectionActTxId,
+                    pNFTRegTicket->GetTicketDescription(), pNFTRegTicket->GetTxId(), error);
+                tv.state = TICKET_VALIDATION_STATE::MISSING_INPUTS;
+                break;
+            }
+            const auto pCollActTicket = dynamic_cast<const CollectionActivateTicket*>(collectionActTicket.get());
+            if (collectionActTicket->ID() != TicketID::CollectionAct|| !pCollActTicket)
+            {
+                tv.errorMsg = strprintf(
+                    "The %s ticket [txid=%s] referred by this %s ticket [txid=%s] has invalid type '%s'",
+                    CollectionActivateTicket::GetTicketDescription(), sCollectionActTxId,
+                    pNFTRegTicket->GetTicketDescription(), pNFTRegTicket->GetTxId(), ::GetTicketDescription(collectionActTicket->ID()));
+				break;
+			}
+            const string sCollectionRegTxId = pCollActTicket->getRegTxId();
+            auto collectionRegTicket = CollectionActivateTicket::RetrieveCollectionRegTicket(error, sCollectionRegTxId, bInvalidTxId);
+            if (!collectionRegTicket)
+            {
+                // collection registration ticket should have been validated by this point, but double check it to make sure
+                if (bInvalidTxId)
+                {
+                    tv.errorMsg = move(error);
+                    break;
+                }
+                tv.errorMsg = strprintf(
+					"The %s ticket with this txid [%s] is not in the blockchain or is invalid", 
+					CollectionRegTicket::GetTicketDescription(), sCollectionRegTxId);
+				break;
+			}
+            const auto pCollRegTicket = dynamic_cast<const CollectionRegTicket*>(collectionRegTicket.get());
+            if (collectionRegTicket->ID() != TicketID::CollectionReg || !pCollRegTicket)
+            {
+                tv.errorMsg = strprintf(
+                    "The %s ticket [txid=%s] referred by this %s ticket [txid=%s] has invalid type '%s'",
+                    CollectionRegTicket::GetTicketDescription(), sCollectionRegTxId,
+                    GetTicketDescription(), GetTxId(), ::GetTicketDescription(collectionRegTicket->ID()));
+				break;
+			}
+            const size_t nCollectionItemCount = pNFTRegTicket->CountItemsInCollection();
+            // check if we will have more than allowed number of items in the collection if we register this item
+            if (nCollectionItemCount + 1 > pCollRegTicket->getMaxCollectionEntries())
+            {
+                tv.errorMsg = strprintf(
+					"Collection '%s' with this txid [%s] has reached the maximum number of items [%u] allowed in the collection",
+					pCollRegTicket->getName(), sCollectionRegTxId, pCollRegTicket->getMaxCollectionEntries());
+                break;
+            }
         }
         tv.setValid();
     } while (false);
@@ -219,14 +285,14 @@ bool CNFTActivateTicket::FindTicketInDb(const string& key, CNFTActivateTicket& t
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
 }
 
-NFTActivateTickets_t CNFTActivateTicket::FindAllTicketByPastelID(const std::string& pastelID)
+NFTActivateTickets_t CNFTActivateTicket::FindAllTicketByMVKey(const std::string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CNFTActivateTicket>(pastelID);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CNFTActivateTicket>(sMVKey);
 }
 
-NFTActivateTickets_t CNFTActivateTicket::FindAllTicketByCreatorHeight(const unsigned int nCreatorHeight)
+NFTActivateTickets_t CNFTActivateTicket::FindAllTicketByCreatorHeight(const uint32_t nCreatorHeight)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CNFTActivateTicket>(std::to_string(nCreatorHeight));
+    return FindAllTicketByMVKey(std::to_string(nCreatorHeight));
 }
 
 bool CNFTActivateTicket::CheckTicketExistByNFTTicketID(const std::string& regTicketTxId)

--- a/src/mnode/tickets/nft-act.h
+++ b/src/mnode/tickets/nft-act.h
@@ -35,7 +35,7 @@ public:
     static constexpr uint8_t PRINCIPAL_MN_FEE_SHARE = 60; // in percents
     static constexpr uint8_t OTHER_MN_FEE_SHARE = 20;     // in percents
 
-    CNFTActivateTicket() = default;
+    CNFTActivateTicket() noexcept = default;
 
     explicit CNFTActivateTicket(std::string &&sPastelID)  
     {
@@ -115,8 +115,8 @@ public:
     static CNFTActivateTicket Create(std::string &&regTicketTxId, int _creatorHeight, int _storageFee, std::string &&sPastelID, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CNFTActivateTicket& ticket);
 
-    static NFTActivateTickets_t FindAllTicketByPastelID(const std::string& pastelID);
-    static NFTActivateTickets_t FindAllTicketByCreatorHeight(const unsigned int nCreatorHeight);
+    static NFTActivateTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
+    static NFTActivateTickets_t FindAllTicketByCreatorHeight(const uint32_t nCreatorHeight);
     static bool CheckTicketExistByNFTTicketID(const std::string& regTicketTxId);
 
 protected:

--- a/src/mnode/tickets/nft-reg.cpp
+++ b/src/mnode/tickets/nft-reg.cpp
@@ -12,6 +12,7 @@
 #include <mnode/tickets/nft-royalty.h>
 #include <mnode/tickets/nft-reg.h>
 #include <mnode/tickets/collection-reg.h>
+#include <mnode/tickets/collection-act.h>
 #include <mnode/mnode-controller.h>
 
 #ifdef ENABLE_WALLET
@@ -322,17 +323,9 @@ void CNFTRegTicket::Clear() noexcept
     m_props.clear();
 }
 
-uint32_t CNFTRegTicket::CountItemsInCollection(const uint32_t currentChainHeight) const
+uint32_t CNFTRegTicket::CountItemsInCollection() const
 {
-    uint32_t nCollectionItemCount = 0;
-    masterNodeCtrl.masternodeTickets.ProcessTicketsByMVKey<CNFTRegTicket>(m_sCollectionActTxid,
-                                                                            [&](const CNFTRegTicket& regTicket) -> bool
-                                                                            {
-                                                                                if ((regTicket.GetBlock() <= currentChainHeight))
-                                                                                    ++nCollectionItemCount;
-                                                                                return true;
-                                                                            });
-    return nCollectionItemCount;
+    return CollectionActivateTicket::CountItemsInCollection(m_sCollectionActTxid, COLLECTION_ITEM_TYPE::NFT, true);
 }
 
 /**
@@ -413,7 +406,7 @@ bool CNFTRegTicket::CheckIfTicketInDb(const string& key)
     return masterNodeCtrl.masternodeTickets.CheckTicketExist(ticket);
 }
 
-NFTRegTickets_t CNFTRegTicket::FindAllTicketByPastelID(const string& pastelID)
+NFTRegTickets_t CNFTRegTicket::FindAllTicketByMVKey(const string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CNFTRegTicket>(pastelID);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CNFTRegTicket>(sMVKey);
 }

--- a/src/mnode/tickets/nft-reg.h
+++ b/src/mnode/tickets/nft-reg.h
@@ -100,7 +100,7 @@ signatures: {
 
   key #1: primary unique key (generated, random 32-bytes base32-encoded)
 mvkey #1: Creator Pastel ID
-mvkey #2: collection txid (optional)
+mvkey #2: collection activate txid (optional)
 mvkey #3: label (optional)
 }
  */
@@ -109,7 +109,7 @@ class CNFTRegTicket :
     public CollectionItem
 {
 public:
-    CNFTRegTicket() = default;
+    CNFTRegTicket() noexcept = default;
     explicit CNFTRegTicket(std::string &&nft_ticket) : 
         m_sNFTTicket(std::move(nft_ticket))
     {}
@@ -179,14 +179,14 @@ public:
         SecureString&& strKeyPass, std::string &&label, const CAmount storageFee);
     static bool FindTicketInDb(const std::string& key, CNFTRegTicket& ticket);
     static bool CheckIfTicketInDb(const std::string& key);
-    static NFTRegTickets_t FindAllTicketByPastelID(const std::string& pastelID);
-    uint32_t CountItemsInCollection(const uint32_t currentChainHeight) const override;
+    static NFTRegTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
+    uint32_t CountItemsInCollection() const override;
 
 protected:
     uint16_t m_nNFTTicketVersion{0};
     std::string m_sNFTTicket;         // NFT Registration ticket (nft_ticket)
     std::string m_sTopBlockHash;      // hash of the top block when the ticket was created - this is to map the ticket to the MNs that should process it
-    uint32_t m_nTotalCopies{};        // total copies allowed for this NFT
+    uint32_t m_nTotalCopies{0};       // total copies allowed for this NFT
     std::unordered_set<NFT_TKT_PROP> m_props; // set of properties in the nft_ticket 
 
     // parse base64-encoded nft_ticket in json format, may throw runtime_error exception

--- a/src/mnode/tickets/nft-royalty.cpp
+++ b/src/mnode/tickets/nft-royalty.cpp
@@ -225,9 +225,9 @@ bool CNFTRoyaltyTicket::FindTicketInDb(const string& key, CNFTRoyaltyTicket& tic
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
 }
 
-NFTRoyaltyTickets_t CNFTRoyaltyTicket::FindAllTicketByPastelID(const string& pastelID)
+NFTRoyaltyTickets_t CNFTRoyaltyTicket::FindAllTicketByMVKey(const string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CNFTRoyaltyTicket>(pastelID);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CNFTRoyaltyTicket>(sMVKey);
 }
 
 NFTRoyaltyTickets_t CNFTRoyaltyTicket::FindAllTicketByNFTTxID(const string& NFTTxnId)

--- a/src/mnode/tickets/nft-royalty.h
+++ b/src/mnode/tickets/nft-royalty.h
@@ -28,7 +28,7 @@ using NFTRoyaltyTickets_t = std::vector<CNFTRoyaltyTicket>;
 class CNFTRoyaltyTicket : public CPastelTicket
 {
 public:
-    CNFTRoyaltyTicket() = default;
+    CNFTRoyaltyTicket() noexcept = default;
 
     explicit CNFTRoyaltyTicket(std::string &&sPastelID, std::string &&sNewPastelID) : 
         m_sPastelID(std::move(sPastelID)), 
@@ -92,7 +92,7 @@ public:
     static CNFTRoyaltyTicket Create(std::string &&sNFTTxId, std::string &&sNewPastelID, std::string &&sPastelID, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CNFTRoyaltyTicket& ticket);
 
-    static NFTRoyaltyTickets_t FindAllTicketByPastelID(const std::string& pastelID);
+    static NFTRoyaltyTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
     static NFTRoyaltyTickets_t FindAllTicketByNFTTxID(const std::string& NFTTxnId);
 
 protected:

--- a/src/mnode/tickets/offer.cpp
+++ b/src/mnode/tickets/offer.cpp
@@ -43,7 +43,7 @@ COfferTicket COfferTicket::Create(string &&itemTxId,
     // NOTE: Offer ticket for Transfer ticket will always has copy number = 1
     ticket.m_nCopyNumber = nCopyNumber > 0 ?
         nCopyNumber :
-        static_cast<decltype(ticket.m_nCopyNumber)>(COfferTicket::FindAllTicketByItemTxId(ticket.m_itemTxId).size()) + 1;
+        static_cast<decltype(ticket.m_nCopyNumber)>(COfferTicket::FindAllTicketByMVKey(ticket.m_itemTxId).size()) + 1;
     // set primary search key to <txid>:<copy_number>
     ticket.key = ticket.m_itemTxId + ":" + to_string(ticket.m_nCopyNumber);
     ticket.sign(move(strKeyPass));
@@ -199,7 +199,7 @@ ticket_validation_t COfferTicket::IsValid(const bool bPreReg, const uint32_t nCa
         const auto fnVerifyAvailableCopies = [this, &originalItemType](const string& strTicket, const size_t nTotalCopies) -> ticket_validation_t
         {
             ticket_validation_t tv;
-            const auto vExistingTransferTickets = CTransferTicket::FindAllTicketByItemTxID(m_itemTxId);
+            const auto vExistingTransferTickets = CTransferTicket::FindAllTicketByMVKey(m_itemTxId);
             const size_t nTransferredCopies = vExistingTransferTickets.size();
             do
             {
@@ -383,7 +383,7 @@ ticket_validation_t COfferTicket::IsValid(const bool bPreReg, const uint32_t nCa
         // (ticket transaction replay attack protection)
         // If found similar ticket, replacement is possible if allowed
         // Can be a few Offer tickets
-        const auto vExistingOfferTickets = COfferTicket::FindAllTicketByItemTxId(m_itemTxId);
+        const auto vExistingOfferTickets = COfferTicket::FindAllTicketByMVKey(m_itemTxId);
         ticket_validation_t tv1;
         tv1.setValid();
         for (const auto& t : vExistingOfferTickets)
@@ -479,12 +479,7 @@ bool COfferTicket::FindTicketInDb(const string& key, COfferTicket& ticket)
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
 }
 
-OfferTickets_t COfferTicket::FindAllTicketByPastelID(const string& pastelID)
+OfferTickets_t COfferTicket::FindAllTicketByMVKey(const string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<COfferTicket>(pastelID);
-}
-
-OfferTickets_t COfferTicket::FindAllTicketByItemTxId(const string& itemTxId)
-{
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<COfferTicket>(itemTxId);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<COfferTicket>(sMVKey);
 }

--- a/src/mnode/tickets/offer.h
+++ b/src/mnode/tickets/offer.h
@@ -58,7 +58,7 @@ public:
     std::string key; // primary key to search for the offer ticket
 
 public:
-    COfferTicket() = default;
+    COfferTicket() noexcept = default;
 
     explicit COfferTicket(std::string _pastelID) : 
         m_sPastelID(std::move(_pastelID))
@@ -150,8 +150,7 @@ public:
         SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, COfferTicket& ticket);
 
-    static OfferTickets_t FindAllTicketByPastelID(const std::string& pastelID);
-    static OfferTickets_t FindAllTicketByItemTxId(const std::string& itemTxId);
+    static OfferTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
 
 protected:
     std::string m_itemTxId;  // item activation txid (NFT activation txid, Action activation txid, ...)

--- a/src/mnode/tickets/pastelid-reg.h
+++ b/src/mnode/tickets/pastelid-reg.h
@@ -49,7 +49,7 @@ keys:
 class CPastelIDRegTicket : public CPastelTicket
 {
 public:
-    CPastelIDRegTicket() = default;
+    CPastelIDRegTicket() noexcept = default;
     explicit CPastelIDRegTicket(std::string&& _pastelID) : 
         m_sPastelID(std::move(_pastelID))
     {}

--- a/src/mnode/tickets/tickets-all.h
+++ b/src/mnode/tickets/tickets-all.h
@@ -19,4 +19,4 @@
 #include <mnode/tickets/nft-take-down.h>
 #include <mnode/tickets/nft-royalty.h>
 #include <mnode/tickets/username-change.h>
-#include <mnode/tickets/etherium-address-change.h>
+#include <mnode/tickets/ethereum-address-change.h>

--- a/src/mnode/tickets/transfer.cpp
+++ b/src/mnode/tickets/transfer.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <optional>
+
 #include <json/json.hpp>
 
 #include <init.h>
@@ -140,8 +141,8 @@ ticket_validation_t transfer_copy_validation(const string& itemTxId, const v_uin
         }
 
         size_t nTransferredCopies{0};
-        const auto vExistingTransferTickets = CTransferTicket::FindAllTicketByItemTxID(itemTxId);
-        for (const auto& t : vExistingTransferTickets)
+        const auto vExistingTransferTickets = CTransferTicket::FindAllTicketByMVKey(itemTxId);
+        for (const auto& t: vExistingTransferTickets)
         {
             if (!t.IsSameSignature(signature))
                 ++nTransferredCopies;
@@ -514,19 +515,9 @@ bool CTransferTicket::FindTicketInDb(const string& key, CTransferTicket& ticket)
            masterNodeCtrl.masternodeTickets.FindTicketBySecondaryKey(ticket);
 }
 
-TransferTickets_t CTransferTicket::FindAllTicketByPastelID(const string& pastelID)
+TransferTickets_t CTransferTicket::FindAllTicketByMVKey(const string& sMVKey)
 {
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CTransferTicket>(pastelID);
-}
-
-TransferTickets_t CTransferTicket::FindAllTicketByItemTxID(const string& ItemTxId)
-{
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CTransferTicket>(ItemTxId);
-}
-
-TransferTickets_t CTransferTicket::FindAllTicketByItemRegTxID(const string& itemRegTxnd)
-{
-    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CTransferTicket>(itemRegTxnd);
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CTransferTicket>(sMVKey);
 }
 
 mu_strings CTransferTicket::GetPastelIdAndTxIdWithTopHeightPerCopy(const TransferTickets_t& filteredTickets)

--- a/src/mnode/tickets/transfer.h
+++ b/src/mnode/tickets/transfer.h
@@ -47,7 +47,7 @@ using txid_serial_tuple_t = std::tuple<std::string, std::string>;
 class CTransferTicket : public CPastelTicket
 {
 public:
-    CTransferTicket() = default;
+    CTransferTicket() noexcept = default;
 
     explicit CTransferTicket(std::string &&sPastelID) : 
         m_sPastelID(std::move(sPastelID))
@@ -131,9 +131,7 @@ public:
     static CTransferTicket Create(std::string &&offerTxId, std::string &&acceptTxId, std::string &&sPastelID, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CTransferTicket& ticket);
 
-    static TransferTickets_t FindAllTicketByPastelID(const std::string& pastelID);
-    static TransferTickets_t FindAllTicketByItemTxID(const std::string& ItemTxId);
-    static TransferTickets_t FindAllTicketByItemRegTxID(const std::string& itemRegTxId);
+    static TransferTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
 
     static bool CheckTransferTicketExistByOfferTicket(const std::string& offerTxId);
     static bool CheckTransferTicketExistByAcceptTicket(const std::string& acceptTxId);

--- a/src/mnode/tickets/username-change.cpp
+++ b/src/mnode/tickets/username-change.cpp
@@ -258,6 +258,11 @@ bool CChangeUsernameTicket::FindTicketInDb(const string& key, CChangeUsernameTic
     return masterNodeCtrl.masternodeTickets.FindTicket(ticket);
 }
 
+ChangeUsernameTickets_t CChangeUsernameTicket::FindAllTicketByMVKey(const string& sMVKey)
+{
+    return masterNodeCtrl.masternodeTickets.FindTicketsByMVKey<CChangeUsernameTicket>(sMVKey);
+}
+
 bool CChangeUsernameTicket::isUsernameBad(const string& username, string& error)
 {
     // Check if has only <4, or has more than 12 characters

--- a/src/mnode/tickets/username-change.h
+++ b/src/mnode/tickets/username-change.h
@@ -3,7 +3,6 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <chainparams.h>
-
 #include <mnode/tickets/ticket.h>
 
 // forward ticket class declaration
@@ -26,7 +25,7 @@ using ChangeUsernameTickets_t = std::vector<CChangeUsernameTicket>;
 class CChangeUsernameTicket : public CPastelTicket
 {
 public:
-    CChangeUsernameTicket() = default;
+    CChangeUsernameTicket() noexcept = default;
 
     explicit CChangeUsernameTicket(std::string &&sPastelID, std::string &&sUserName) : 
         m_sPastelID(std::move(sPastelID)),
@@ -102,6 +101,8 @@ public:
 
     static CChangeUsernameTicket Create(std::string &&sPastelID, std::string &&sUserName, SecureString&& strKeyPass);
     static bool FindTicketInDb(const std::string& key, CChangeUsernameTicket& ticket);
+    static ChangeUsernameTickets_t FindAllTicketByMVKey(const std::string& sMVKey);
+
 
     /** Some general checks to see if the username is bad. Below cases will be considered as bad Username
     *     - Contains characters that is different than upper and lowercase Latin characters and numbers

--- a/src/scope_guard.hpp
+++ b/src/scope_guard.hpp
@@ -90,7 +90,11 @@ namespace sg
       scope_guard(scope_guard&& other)
       noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value);
 
-      ~scope_guard() noexcept; // highlight noexcept dtor
+      ~scope_guard() noexcept // highlight noexcept dtor
+      {
+        if (m_active)
+            m_callback();
+      }
 
       void dismiss() noexcept;
 
@@ -135,14 +139,6 @@ noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
     https://is.gd/Tsmh8G) */
   , m_active{true}
 {}
-
-////////////////////////////////////////////////////////////////////////////////
-template<typename Callback>
-sg::detail::scope_guard<Callback>::~scope_guard<Callback>() noexcept
-{
-  if(m_active)
-    m_callback();
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 template<typename Callback>

--- a/src/util.h
+++ b/src/util.h
@@ -1,7 +1,7 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -13,11 +13,6 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#include "compat.h"
-#include "tinyformat.h"
-#include "utiltime.h"
-#include "fs.h"
-
 #include <atomic>
 #include <exception>
 #include <map>
@@ -25,9 +20,15 @@
 #include <string>
 #include <vector>
 #include <optional>
+#include <thread>
 
 #include <boost/signals2.hpp>
-#include <thread>
+
+#include <compat.h>
+#include <tinyformat.h>
+#include <utiltime.h>
+#include <fs.h>
+
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;
@@ -71,7 +72,7 @@ bool SetupNetworking();
 /** Return true if log accepts specified category */
 bool LogAcceptCategory(const char* category);
 /** Send a string to the log output */
-int LogPrintStr(const std::string &str);
+size_t LogPrintStr(const std::string &str);
 
 #ifdef __linux__
 extern thread_local pid_t gl_LinuxTID;
@@ -303,3 +304,12 @@ public:
     }
 };
 
+template <typename _T>
+inline void safe_delete_obj(_T*& obj)
+{
+    if (obj)
+    {
+        delete obj;
+        obj = nullptr;
+    }
+}

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1819,7 +1819,8 @@ optional<pair<
 {
     auto output = this->vShieldedOutput[op.n];
 
-    for (auto ovk : ovks) {
+    for (const auto &ovk : ovks)
+    {
         auto outPt = SaplingOutgoingPlaintext::decrypt(
             output.outCiphertext,
             ovk,
@@ -1855,7 +1856,8 @@ optional<pair<
 {
     auto output = this->vShieldedOutput[op.n];
 
-    for (auto ovk : ovks) {
+    for (const auto &ovk : ovks)
+    {
         auto outPt = SaplingOutgoingPlaintext::decrypt(
             output.outCiphertext,
             ovk,
@@ -3012,7 +3014,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     else
                     {
                         // Insert change txn at random position:
-                        nChangePosRet = GetRandInt(txNew.vout.size()+1);
+                        nChangePosRet = GetRandInt(static_cast<int>(txNew.vout.size()) + 1);
                         const auto position = txNew.vout.cbegin() + nChangePosRet;
                         txNew.vout.insert(position, newTxOut);
                     }


### PR DESCRIPTION
**[PSL-755] pasteld: adjust node deprecation policy for mainnet release**
- set cNode deprecation time for mainnet to 2yrs from approx release height 500000

**[PSL-763] Implement support for finding all tickets belonging to a specific collection in the find API**
- implemented new RPC APIs:
  - tickets find nft "collection_activation_ticket_txid": returns all NFT registration tickets belonging to the collection specified by "collection_activation_ticket_txid". This API returns only NFT registration tickets - it does not check whether there are corresponding NFT activation tickets.
  - tickets find act "collection_activation_ticket_txid": returns all NFT activation tickets belonging to the collection specified by "collection_activation_ticket_txid".
  - tickets find action "collection_activation_ticket_txid": returns all Action Registration tickets (Sense) belonging to the collection specified by "collection_activation_ticket_txid". This API returns only Action registration tickets - it does not check whether corresponding Action activation tickets exist.
  - tickets find action-act "collection_activation_ticket_txid": returns all Action Activation tickets (Sense) belonging to the collection specified by "collection_activation_ticket_txid".
  - tickets find collection "collection_name" Find collection tickets by name - search is case-insensitive.

**[PSL-764] Enhance 'tickets get' to return additional collection ticket information**

- RPC API [tickets get "collection_activate_ticket_txid"] now returns additional fields:
      "activated_item_count": NNN, // number of activated items in this collection
      "collection_state": "in-process|finalized|not-defined", // collection state
      "is_expired_by_height": True|False, // True if collection is in finalized state because final allowed block height for the collection has been reached
      "is_full": True|False, // True if collection is in finalized state because number of activated items in the collection reached max_collection_entries
 - max number of items in a collection is calculated now by activated items only, there can be more registered items in a collection than activated items
 - added nft|action collection item pre-registration check for max_collection_entries (calculated using activate tickets) If collection item is registered, activation ticket for this item may not be validated if number of activated items in that collection reached max.
 - added tests for new "tickets find", test registers 3 items in the collection (nft|sense), but only activates 2, reaching max collection entries = 2.
 - added tests for tickets get "collection_activate_ticket_txid", check number of activated items, collection state by height and max entries
- Other changes:
   - fixed typos (etherium -> ethereum)
   - fixed some compiler warnings
   - fixed an issue with "tickets list nft|act|action transferred", do not count tickets with item_copy_count=0 mn_tickets.py:


[PSL-755]: https://pastel-network.atlassian.net/browse/PSL-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSL-763]: https://pastel-network.atlassian.net/browse/PSL-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSL-764]: https://pastel-network.atlassian.net/browse/PSL-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ