### PR TITLE
[PSL-782] Put a cap on the number of entries in `list_of_pastelids_of _authorized_contributors` in collection tickets

### DIFF
--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -142,11 +142,13 @@ void CMasterNodeController::SetParameters()
         nMasternodeMinimumConfirmations = 1;
         nMasternodePaymentsIncreaseBlock = 4030;
         nMasternodePaymentsIncreasePeriod = 10;
+        nFulfilledRequestExpireTime = 60*60; // 60 minutes
         
         TicketGreenAddress = "tPj5BfCrLfLpuviSJrD3B1yyWp3XkgtFjb6";
-
         m_nMaxInProcessCollectionTicketAge = MAX_IN_PROCESS_COLLECTION_TICKET_AGE;
     } else if (chainparams.IsRegTest()) {
+        MasternodeCollateral                = 1000; // PSL
+
         nMasternodeMinimumConfirmations = 1;
         nMasternodePaymentsIncreaseBlock = 350;
         nMasternodePaymentsIncreasePeriod = 10;
@@ -158,8 +160,6 @@ void CMasterNodeController::SetParameters()
 
         MNStartRequiredExpirationTime             =  10 * 60;
 
-        MasternodeCollateral                = 1000; // PSL
-        
         TicketGreenAddress = "tPj5BfCrLfLpuviSJrD3B1yyWp3XkgtFjb6";
     
         // for regtest we set 200 blocks for collection ticket age

--- a/src/mnode/mnode-requesttracker.cpp
+++ b/src/mnode/mnode-requesttracker.cpp
@@ -1,71 +1,73 @@
 // Copyright (c) 2014-2017 The Dash Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
-#include "main.h"
+#include <util.h>
+#include <main.h>
 
-#include "mnode/mnode-controller.h"
-#include "mnode/mnode-requesttracker.h"
+#include <mnode/mnode-controller.h>
+#include <mnode/mnode-requesttracker.h>
 
-void CMasternodeRequestTracker::AddFulfilledRequest(CAddress addr, std::string strRequest)
+using namespace std;
+
+void CMasternodeRequestTracker::AddFulfilledRequest(CAddress addr, string strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
     mapFulfilledRequests[addr][strRequest] = GetTime() + masterNodeCtrl.nFulfilledRequestExpireTime;
 }
 
-bool CMasternodeRequestTracker::HasFulfilledRequest(CAddress addr, std::string strRequest)
+bool CMasternodeRequestTracker::HasFulfilledRequest(CAddress addr, string strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
+    const auto it = mapFulfilledRequests.find(addr);
 
-    return  it != mapFulfilledRequests.end() &&
-            it->second.find(strRequest) != it->second.end() &&
+    return  it != mapFulfilledRequests.cend() &&
+            it->second.find(strRequest) != it->second.cend() &&
             it->second[strRequest] > GetTime();
 }
 
-int64_t CMasternodeRequestTracker::GetFulfilledRequestTime(CAddress addr, std::string strRequest)
+int64_t CMasternodeRequestTracker::GetFulfilledRequestTime(CAddress addr, string strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
+    const auto it = mapFulfilledRequests.find(addr);
 
-    if (it != mapFulfilledRequests.end() &&
-       it->second.find(strRequest) != it->second.end())
+    if (it != mapFulfilledRequests.cend() &&
+       it->second.find(strRequest) != it->second.cend())
         return it->second[strRequest];
     return -1;
 }
 
-void CMasternodeRequestTracker::RemoveFulfilledRequest(CAddress addr, std::string strRequest)
+void CMasternodeRequestTracker::RemoveFulfilledRequest(CAddress addr, string strRequest)
 {
     LOCK(cs_mapFulfilledRequests);
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.find(addr);
+    auto it = mapFulfilledRequests.find(addr);
 
-    if (it != mapFulfilledRequests.end()) {
+    if (it != mapFulfilledRequests.end())
         it->second.erase(strRequest);
-    }
 }
 
 void CMasternodeRequestTracker::CheckAndRemove()
 {
     LOCK(cs_mapFulfilledRequests);
 
-    int64_t now = GetTime();
-    fulfilledreqmap_t::iterator it = mapFulfilledRequests.begin();
+    const int64_t now = GetTime();
+    auto it = mapFulfilledRequests.begin();
 
-    while(it != mapFulfilledRequests.end()) {
-        fulfilledreqmapentry_t::iterator it_entry = it->second.begin();
-        while(it_entry != it->second.end()) {
-            if(now > it_entry->second) {
+    while (it != mapFulfilledRequests.end())
+    {
+        auto it_entry = it->second.begin();
+        while(it_entry != it->second.end())
+        {
+            if (now > it_entry->second)
                 it->second.erase(it_entry++);
-            } else {
+            else
                 ++it_entry;
-            }
         }
-        if(it->second.size() == 0) {
+        if (it->second.empty())
             mapFulfilledRequests.erase(it++);
-        } else {
+        else
             ++it;
-        }
     }
 }
 
@@ -75,9 +77,9 @@ void CMasternodeRequestTracker::Clear()
     mapFulfilledRequests.clear();
 }
 
-std::string CMasternodeRequestTracker::ToString() const
+string CMasternodeRequestTracker::ToString() const
 {
-    std::ostringstream info;
+    ostringstream info;
     info << "Nodes with fulfilled requests: " << (int)mapFulfilledRequests.size();
     return info.str();
 }

--- a/src/mnode/mnode-requesttracker.h
+++ b/src/mnode/mnode-requesttracker.h
@@ -1,8 +1,9 @@
 #pragma once
 // Copyright (c) 2014-2017 The Dash Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include "protocol.h"
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <protocol.h>
 
 // Fulfilled requests are used to prevent nodes from asking for the same data on sync
 // and from being banned for doing so too often.

--- a/src/mnode/tickets/collection-item.cpp
+++ b/src/mnode/tickets/collection-item.cpp
@@ -148,13 +148,16 @@ ticket_validation_t CollectionItem::IsValidCollection(const bool bPreReg) const 
         const auto nActiveChainHeight = gl_nChainHeight + 1;
 
         // check that ticket height is less than final allowed block height for the collection
-        if (bPreReg && (nActiveChainHeight > pCollRegTicket->getCollectionFinalAllowedBlockHeight()))
+        if (bPreReg)
         {
-            // a "final allowed" block height after which no new items will be allowed to add to the collection
-            tv.errorMsg = strprintf(
-                "No new items are allowed to be added to the finalized collection '%s' after the 'final allowed' block height %u",
-                pCollRegTicket->getName(), pCollRegTicket->getCollectionFinalAllowedBlockHeight());
-            break;
+            if (nActiveChainHeight > pCollRegTicket->getCollectionFinalAllowedBlockHeight())
+            {
+                // a "final allowed" block height after which no new items will be allowed to add to the collection
+                tv.errorMsg = strprintf(
+                    "No new items are allowed to be added to the finalized collection '%s' after the 'final allowed' block height %u",
+                    pCollRegTicket->getName(), pCollRegTicket->getCollectionFinalAllowedBlockHeight());
+                break;
+            }
         }
 
         // count all registered items in a collection up to the current height

--- a/src/mnode/tickets/collection-reg.cpp
+++ b/src/mnode/tickets/collection-reg.cpp
@@ -291,6 +291,15 @@ ticket_validation_t CollectionRegTicket::IsValid(const bool bPreReg, const uint3
                     fullTicketPricePSL);
                 break;
             }
+
+            // check if we exceed maximum number of authorized contributors
+            if (m_AuthorizedContributors.size() > MAX_ALLOWED_AUTHORIZED_CONTRIBUTORS)
+            {
+                tv.errorMsg = strprintf(
+					"Exceeded the maximum number of authorized contributors in the %s collection. %zu defined, but only %zu are allowed",
+					getCollectionItemDesc(), m_AuthorizedContributors.size(), MAX_ALLOWED_AUTHORIZED_CONTRIBUTORS);
+				break;
+			}
         }
 
         // validate max collection entries

--- a/src/mnode/tickets/collection-reg.h
+++ b/src/mnode/tickets/collection-reg.h
@@ -17,6 +17,8 @@ using CollectionRegTickets_t = std::vector<CollectionRegTicket>;
 
 // maximum allowed number of items in a collection
 constexpr uint32_t MAX_ALLOWED_COLLECTION_ENTRIES = 10'000;
+// maximum allowed number of authorized contributors in a collection
+constexpr size_t MAX_ALLOWED_AUTHORIZED_CONTRIBUTORS = 250;
 
 constexpr auto COLL_TICKET_APP_OBJ = "app_ticket";
 


### PR DESCRIPTION
**[PSL-782] Put a cap on the number of entries in `list_of_pastelids_of _authorized_contributors` in collection tickets**
- added validation for collection reg ticket in pre-reg, allow max 250 authorized contributors

**[PSL-788] cNode: define nFulfilledRequestExpireTime for testnet**

[PSL-782]: https://pastel-network.atlassian.net/browse/PSL-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSL-788]: https://pastel-network.atlassian.net/browse/PSL-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ