### PR TITLE
[PSL-798] Change required minimum confirmation for registration tickets from 10 to 5

### DIFF
--- a/qa/rpc-tests/mn_bugs.py
+++ b/qa/rpc-tests/mn_bugs.py
@@ -165,7 +165,7 @@ class MasterNodeGovernanceTest (MasterNodeCommon):
         assert_equal(res1['result'], 'failed')
         
         #MINIG
-        print ("Minig...")
+        print ("Mining...")
         self.slow_mine(2, 10, 2, 0.5)
         #This is a failed TICKET VOTE with NO - one-time change shall be possible
         print("NODE #0: This is a failed TICKET VOTE with NO - already voted no in another block")

--- a/qa/rpc-tests/mn_common.py
+++ b/qa/rpc-tests/mn_common.py
@@ -26,6 +26,7 @@ from pastel_test_framework import (
     TicketType
 )
 
+MIN_TICKET_CONFIRMATIONS = 5
 getcontext().prec = 16
 
 class TicketData:
@@ -746,15 +747,17 @@ class MasterNodeCommon (PastelTestFramework):
         self.create_signatures(TicketType.NFT, creator_node_num, make_bad_signatures_dicts)
 
 
-    def wait_for_confirmation(self, node: int):
-        print(f"block count - {self.nodes[node].getblockcount()}")
+    def wait_for_min_confirmations(self, node_no: int = -1):
+        if node_no == -1:
+            node_no = self.mining_node_num
+        print(f"block count - {self.nodes[node_no].getblockcount()}")
         time.sleep(2)
-        self.generate_and_sync_inc(10, self.mining_node_num)
+        self.generate_and_sync_inc(MIN_TICKET_CONFIRMATIONS, self.mining_node_num)
         time.sleep(2)
-        print(f"block count - {self.nodes[node].getblockcount()}")
+        print(f"block count - {self.nodes[node_no].getblockcount()}")
 
 
-    def wait_for_ticket_tnx(self, blocks_to_generate: int = 5):
+    def wait_for_ticket_tnx(self, blocks_to_generate: int = 2):
         time.sleep(10)
         for _ in range(blocks_to_generate):
             self.nodes[self.mining_node_num].generate(1)
@@ -772,6 +775,3 @@ class MasterNodeCommon (PastelTestFramework):
         self.sync_all(10, 30)
         self.nodes[self.mining_node_num].generate(1)
         self.sync_all(10, 30)
-
-    def wait_for_gen10_blocks(self):
-        self.generate_and_sync_inc(10, self.mining_node_num)

--- a/qa/rpc-tests/mn_expiration.py
+++ b/qa/rpc-tests/mn_expiration.py
@@ -19,7 +19,8 @@ from pastel_test_framework import (
     TicketType
 )
 from mn_common import (
-    MasterNodeCommon
+    MasterNodeCommon,
+    MIN_TICKET_CONFIRMATIONS,
 )
 
 getcontext().prec = 16
@@ -166,10 +167,10 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         """
         print("**** Test expiration of Offer tickets with intended recipient")
         self.register_nft_reg_ticket("nft-indended-for-label")
-        self.wait_for_ticket_tnx(5)
+        self.wait_for_min_confirmations()
 
         self.register_nft_act_ticket()
-        self.wait_for_ticket_tnx(5)
+        self.wait_for_min_confirmations()
         
         nft_ticket = self.tickets[TicketType.NFT]
         
@@ -206,16 +207,16 @@ class MasterNodeTicketsTest(MasterNodeCommon):
 
     def ticket_expiration_tests(self):
         self.register_nft_reg_ticket("nft-label")
-        self.wait_for_confirmation(self.non_mn3)
+        self.wait_for_min_confirmations(self.non_mn3)
 
         self.register_nft_act_ticket()
-        self.wait_for_confirmation(self.non_mn3)
+        self.wait_for_min_confirmations(self.non_mn3)
 
         nft_ticket = self.tickets[TicketType.NFT]
         self.register_offer_ticket(TicketType.NFT)
         offer_ticket1_txid = nft_ticket.offer_txid
         print(f"offer ticket 1 txid {offer_ticket1_txid}")
-        self.wait_for_confirmation(self.non_mn3)
+        self.wait_for_min_confirmations(self.non_mn3)
 
         if (self.total_nft_copies == 1):
             # fail if not enough copies to offer
@@ -398,7 +399,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         cover_price = nft_price + max(10, int(nft_price / 100)) + 5
 
         self.nodes[self.mining_node_num].sendtoaddress(address, num * cover_price, "", "", False)
-        self.wait_for_confirmation(node)
+        self.wait_for_min_confirmations(node)
 
 
     def register_accept_ticket(self, acceptor_node, acceptor_pastelid1):
@@ -429,7 +430,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         assert_true(acceptor_coins_before > 0 and acceptor_coins_before < 1)
 
         self.nodes[self.mining_node_num].sendtoaddress(acceptor_address1, cover_price, "", "", False)
-        self.wait_for_confirmation(acceptor_node)
+        self.wait_for_min_confirmations(acceptor_node)
 
         acceptor_coins_before = self.nodes[acceptor_node].getbalance()
         print(acceptor_coins_before)
@@ -447,7 +448,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
         ticket.transfer_txid = self.nodes[acceptor_node].tickets("register", "transfer", ticket.offer_txid, ticket.accept_txid,
                                            acceptor_pastelid1, self.passphrase)["txid"]
         assert_true(ticket.transfer_txid, "No Transfer ticket was created")
-        self.wait_for_ticket_tnx(10)
+        self.wait_for_min_confirmations()
 
         # check correct amount of change and correct amount spent
         acceptor_coins_after = self.nodes[acceptor_node].getbalance()

--- a/qa/rpc-tests/reorg_limit.py
+++ b/qa/rpc-tests/reorg_limit.py
@@ -15,7 +15,7 @@ from test_framework.util import (
 )
 from time import sleep
 
-def check_stopped(i, timeout=10):
+def check_stopped(i, timeout=15):
     stopped = False
     for x in range(1, timeout):
         ret = check_node(i)

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -14,6 +14,11 @@ constexpr size_t CHAIN_RESERVE_SIZE = 500;
 
 atomic_uint32_t gl_nChainHeight;
 
+CChain::CChain()
+{
+    gl_nChainHeight = 0;
+}
+
 /**
  * CChain implementation
  */

--- a/src/chain.h
+++ b/src/chain.h
@@ -386,6 +386,8 @@ private:
     std::vector<CBlockIndex*> vChain;
 
 public:
+    CChain();
+
     /** Returns the index entry for the genesis block of this chain, or NULL if none. */
     CBlockIndex *Genesis() const {
         return vChain.size() > 0 ? vChain[0] : nullptr;

--- a/src/gtest/test_alert.cpp
+++ b/src/gtest/test_alert.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2013 The Bitcoin Core developers
-// Copyright (c) 2021-2022 The Pastel developers
+// Copyright (c) 2021-2023 The Pastel developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -12,21 +12,21 @@
 
 #include <gtest/gtest.h>
 
-#include "alert.h"
-#include "chain.h"
-#include "chainparams.h"
-#include "clientversion.h"
-#include "data/alertTests.raw.h"
+#include <alert.h>
+#include <chain.h>
+#include <chainparams.h>
+#include <clientversion.h>
+#include <data/alertTests.raw.h>
 
-#include "main.h"
-#include "rpc/protocol.h"
-#include "rpc/server.h"
-#include "serialize.h"
-#include "streams.h"
-#include "util.h"
-#include "utilstrencodings.h"
-#include "key.h"
-#include "alertkeys.h"
+#include <main.h>
+#include <rpc/protocol.h>
+#include <rpc/server.h>
+#include <serialize.h>
+#include <streams.h>
+#include <util.h>
+#include <utilstrencodings.h>
+#include <key.h>
+#include <alertkeys.h>
 
 using namespace std;
 using namespace testing;
@@ -42,7 +42,7 @@ using namespace testing;
  * 2. Set the GENERATE_ALERTS_FLAG to true.
  *
  * 3. Build and run:
- *    test_bitcoin -t Generate_Alert_Test_Data
+ *    pastel_gtest -t Generate_Alert_Test_Data
  *
  * 4. Test data is saved in your current directory as alertTests.raw.NEW
  *    Copy this file to: src/test/data/alertTests.raw

--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -120,7 +120,7 @@ void CMasterNodeController::SetParameters()
 
     nGovernanceVotingPeriodBlocks = 576; //24 hours, 1 block per 2.5 minutes
     
-    MinTicketConfirmations = 10; //blocks
+    MinTicketConfirmations = 5; //blocks
     MaxAcceptTicketAge = 24; //1 hour, 1 block per 2.5 minutes
     
     const auto& chainparams = Params();

--- a/src/mnode/rpc/tickets-activate.cpp
+++ b/src/mnode/rpc/tickets-activate.cpp
@@ -101,7 +101,7 @@ Arguments:
 2. "called-at-height" (string, required) Block height at which action was called ('action_ticket' was created).
 3. fee                (int, required) The supposed fee that Action caller agreed to pay for the registration. 
                          This shall match the amount in the registration ticket.
-                         The transaction with this ticket will pay 90% of this amount to MNs (10% were burnt prior to registration).
+                         The transaction with this ticket will pay 80% of this amount to MNs (20% were burnt prior to registration).
 4. "PastelID"         (string, required) The Pastel ID of Action caller. NOTE: Pastel ID must be generated and stored inside node. See "pastelid newkey".
 5. "passphrase"       (string, required) The passphrase to open secure container associated with the Caller's Pastel ID and stored inside the node. See "pastelid newkey".
 6. "address"          (string, optional) The Pastel blockchain t-address to use for funding the registration.

--- a/src/mnode/tickets/pastelid-reg.cpp
+++ b/src/mnode/tickets/pastelid-reg.cpp
@@ -171,13 +171,8 @@ ticket_validation_t CPastelIDRegTicket::IsValid(const bool bPreReg, const uint32
                 // 2. Check outpoint belongs to active MN
                 // However! If this is validation of an old ticket, MN can be not active or even alive anymore
                 // So will skip the MN validation if ticket is fully confirmed (older then MinTicketConfirmations blocks)
-                unsigned int currentHeight;
-                {
-                    LOCK(cs_main);
-                    currentHeight = static_cast<unsigned int>(chainActive.Height());
-                }
                 //during transaction validation before ticket made in to the block_ticket.ticketBlock will == 0
-                if (_ticket.IsBlock(0) || currentHeight - _ticket.GetBlock() < masterNodeCtrl.MinTicketConfirmations)
+                if (_ticket.IsBlock(0) || gl_nChainHeight - _ticket.GetBlock() < masterNodeCtrl.MinTicketConfirmations)
                 {
                     CMasternode mnInfo;
                     if (!masterNodeCtrl.masternodeManager.Get(m_outpoint, mnInfo))

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2003,15 +2003,22 @@ bool hasActiveNetworkInterface()
     return false;
 }
 
-bool hasInternetConnectivity()
+bool pingHost(const string& sHostName)
+{
+    string sPingCommand = strprintf("ping -c 1 %s >/dev/null 2>&1", sHostName);
+    return std::system(sPingCommand.c_str()) == 0;
+}
+
+bool hasInternetConnectivity(function<bool()> shouldStop)
 {
     const v_strings vHosts = { "google.com", "microsoft.com", "amazon.com", "8.8.8.8", "1.1.1.1" };
 
     for (const auto& sHost : vHosts)
     {
-        std::string cmd = "ping -c 1 " + sHost + " >/dev/null 2>&1";
-        if (std::system(cmd.c_str()) == 0)
+        if (pingHost(sHost ))
             return true;
+        if (shouldStop())
+            break;
     }
     return false;
 }

--- a/src/net.h
+++ b/src/net.h
@@ -8,6 +8,7 @@
 #include <deque>
 #include <atomic>
 #include <stdint.h>
+#include <functional>
 
 #ifndef WIN32
 #include <arpa/inet.h>
@@ -84,7 +85,7 @@ void SocketSendData(CNode *pnode);
 // returns true if we have at least one active network interface
 bool hasActiveNetworkInterface();
 // returns true if we have internet connectivity
-bool hasInternetConnectivity();
+bool hasInternetConnectivity(std::function<bool()> shouldStop);
 
 struct CombinerAll
 {

--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -48,7 +48,7 @@ chrono::seconds CNetManagerThread::checkNetworkConnectivity()
         }
         return INACTIVE_CHECK_PERIOD_SECS;
     }
-    const bool bHasInternetConnectivity = hasInternetConnectivity();
+    const bool bHasInternetConnectivity = hasInternetConnectivity([this]() { return this->shouldStop(); });
     if (bHasInternetConnectivity)
     {
         if (!bPrevNetworkState)

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -205,20 +205,14 @@ Generate 11 blocks
     if (!Params().MineBlocksOnDemand())
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "This method can only be used on regtest");
 
-    int nHeightStart = 0;
-    int nHeightEnd = 0;
-    int nHeight = 0;
     int nGenerate = params[0].get_int();
 #ifdef ENABLE_WALLET
     CReserveKey reservekey(pwalletMain);
 #endif
 
-    {   // Don't keep cs_main locked
-        LOCK(cs_main);
-        nHeightStart = chainActive.Height();
-        nHeight = nHeightStart;
-        nHeightEnd = nHeightStart+nGenerate;
-    }
+    const uint32_t nHeightStart = gl_nChainHeight;
+    const uint32_t nHeightEnd = nHeightStart + nGenerate;
+    uint32_t nHeight = nHeightStart;
     unsigned int nExtraNonce = 0;
     UniValue blockHashes(UniValue::VARR);
     const auto& chainparams = Params();
@@ -252,7 +246,8 @@ Generate 11 blocks
         // H(I||...
         crypto_generichash_blake2b_update(&eh_state, (unsigned char*)&ss[0], ss.size());
 
-        while (true) {
+        while (true)
+        {
             // Yes, there is a chance every nonce could fail to satisfy the -regtest
             // target -- 1 in 2^(2^256). That ain't gonna happen
             pblock->nNonce = ArithToUint256(UintToArith256(pblock->nNonce) + 1);


### PR DESCRIPTION
- changed minimum confirmation for registration tickets from 10 to 5
- corrected python tests for the new confirmation count, redesigned some tests to use MIN_TICKET_CONFIRMATIONS variable instead of harcoding
- removed getting chain height under cs_main lock in few missed places (use atomic gl_nChainHeight variable)
- added an ability to stop on signal while checking internet connectivity in hasInternetConnectivity, CNetManagerThread thread. hasInternetConnectivity function pinging 4 hosts from the list, if network is unreachable - this could take a lot of time and afffect shutdown time, some python tests also could fail because of this