### PR TITLE
[PSL-756] pasteld: upgrade zstd to version 1.5.5

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,8 +1,8 @@
 package=boost
-$(package)_version=1_80_0
+$(package)_version=1_82_0
 $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$(subst _,.,$($(package)_version))/source
 $(package)_file_name=boost_$($(package)_version).tar.gz
-$(package)_sha256_hash=4b2136f98bdd1f5857f1c3dea9ac2018effe65286cf251534b6ae20cc45e1847
+$(package)_sha256_hash=66a469b6e608a51f8347236f4912e27dc5c60c60d7d53ae9bfe4683316c6f04c
 $(package)_dependencies=native_b2
 $(package)_patches=
 

--- a/depends/packages/zstd.mk
+++ b/depends/packages/zstd.mk
@@ -1,8 +1,8 @@
 package=zstd
-$(package)_version=1.5.0
+$(package)_version=1.5.5
 $(package)_download_path=https://github.com/facebook/zstd/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=5194fbfa781fcf45b98c5e849651aa7b3b0a008c6b72d4a0db760f3002291e94
+$(package)_sha256_hash=9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4
 
 define $(package)_preprocess_cmds
   mkdir -p bld

--- a/src/mnode/mnode-payments.h
+++ b/src/mnode/mnode-payments.h
@@ -192,8 +192,8 @@ public:
             do
             {
                 // special handling for read mode - old version didn't have version string
-                const size_t nSerializedVersionSize = SERIALIZATION_VERSION_STRING.length() + 1;
-                if (s.size() < nSerializedVersionSize)
+                const size_t nSerializedVersionSize = SERIALIZATION_VERSION_STRING.length();
+                if (s.size() < nSerializedVersionSize + 1)
                     break;
                 const size_t nSize = static_cast<size_t>(ser_readdata8(s));
                 if (nSize != nSerializedVersionSize)
@@ -202,7 +202,7 @@ public:
                     break;
                 }
                 strVersion.resize(nSize);
-                s.read((char*)&strVersion[0], nSize * sizeof(strVersion[0]));
+                s.read(strVersion.data(), nSize);
                 if (strVersion != SERIALIZATION_VERSION_STRING)
                 {
                     s.rewind(nSerializedVersionSize);


### PR DESCRIPTION
 - upgraded zstd package to v1.5.5 (released 04/04/2023)

[PSL-757] pasteld: upgrade boost library to the latest version 1.82
 - upgraded boost package to v1.82 (released 04/14/2023)
  
 [PSL-858] mnpayments.dat protected mode fix

[PSL-757]: https://pastel-network.atlassian.net/browse/PSL-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSL-858]: https://pastel-network.atlassian.net/browse/PSL-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ