### PR TITLE
Masternode fixes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -535,6 +535,10 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-metricsrefreshtime", strprintf(translate("Number of seconds between metrics refreshes (default: %u if running in a console, %u otherwise)"), 1, 600));
     }
 
+    strUsage += HelpMessageGroup(translate("Masternode options:"));
+    strUsage += HelpMessageOpt("-setminenabledmncount=<n>", translate("Set minimum required ENABLED masternode count in the LOCAL list to validate Tickets (default: 0)"));
+    strUsage += HelpMessageOpt("-setminenabledmnpercent=<n>", translate("Set minimum required ENABLED masternode percent in the LOCAL list to validate Tickets (0-100). Used only if min count is not set by '-setminenabledmncount' command line option (default: 0)"));
+
     return strUsage;
 }
 

--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -126,7 +126,12 @@ void CMasterNodeController::SetParameters()
     
     MinTicketConfirmations = 5; //blocks
     MaxAcceptTicketAge = 24; //1 hour, 1 block per 2.5 minutes
-    
+
+    int minCount = (int)GetArg("-setminenabledmncount", 0);
+    nMinRequiredEnabledMasternodes = (minCount >= 0)? minCount: 0;
+    int minPercent = (int)GetArg("-setminenabledmnpercent", 0);
+    nMinRequiredEnabledMasternodesPercent = (minPercent >= 0 && minPercent <= 100)? minPercent: 0;
+
     const auto& chainparams = Params();
     if (chainparams.IsMainNet())
     {

--- a/src/mnode/mnode-controller.h
+++ b/src/mnode/mnode-controller.h
@@ -70,6 +70,8 @@ public:
     int MNStartRequiredExpirationTime;
     int nGovernanceVotingPeriodBlocks;
 
+    unsigned int nMinRequiredEnabledMasternodes, nMinRequiredEnabledMasternodesPercent;
+
     uint32_t nMasternodeMinimumConfirmations, nMasternodePaymentsIncreaseBlock, nMasternodePaymentsIncreasePeriod;
     int nMasternodePaymentsVotersIndexDelta, nMasternodePaymentsFeatureWinnerBlockIndexDelta;
     int nMasterNodeMaximumOutboundConnections;

--- a/src/mnode/mnode-manager.cpp
+++ b/src/mnode/mnode-manager.cpp
@@ -371,19 +371,24 @@ bool CMasternodeMan::HasEnoughEnabled() const noexcept
     size_t nCurrent = CountCurrent();
     size_t nEnabled = CountEnabled();
 
-    // TODO: Make pastled parameter and API call to set this value
-    size_t nRequired = 22;
-    size_t nPercent = 80;
+    uint32_t nRequired = masterNodeCtrl.nMinRequiredEnabledMasternodes;
+    uint32_t nPercent = masterNodeCtrl.nMinRequiredEnabledMasternodesPercent;
 
-    if (nRequired == -1) // default when not set
+    if (nRequired == 0) // default when not set
     {
+        if (nPercent == 0)
+            return true;
+
         nRequired = nCurrent * nPercent / 100;
     }
 
     if (nEnabled < nRequired)
-        LogFnPrintf("ERROR: Not enough Enabled MNs in local list %d, required %d, total %d", nEnabled, nRequired, nCurrent);
-
-    return nEnabled >= nRequired;
+    {
+        LogFnPrintf("WARNING: Not enough Enabled MNs in local list %d, required %d, total %d", nEnabled, nRequired,
+                    nCurrent);
+        return false;
+    }
+    return true;
 }
 
 

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -202,6 +202,9 @@ public:
     size_t CountEnabled(const int nProtocolVersion = -1) const noexcept;
     uint32_t GetCachedBlockHeight() const noexcept { return nCachedBlockHeight; }
 
+    size_t CountCurrent(const int nProtocolVersion = -1) const noexcept;
+    bool HasEnoughEnabled() const noexcept;
+
     /// Count Masternodes by network type - NET_IPV4, NET_IPV6, NET_TOR
     // int CountByIP(int nNetworkType);
 
@@ -245,6 +248,9 @@ public:
     bool empty() const noexcept { return mapMasternodes.empty(); }
 
     std::string ToString() const;
+    std::string ToJSON() const;
+
+    void ClearCache(bool clearMnList, bool clearSeenLists, bool clearRecoveryLists, bool clearAskedLists);
 
     /// Update masternode list and maps using provided CMasternodeBroadcast
     void UpdateMasternodeList(CMasternodeBroadcast mnb);
@@ -268,5 +274,5 @@ public:
     void UpdatedBlockTip(const CBlockIndex *pindex);
     
     GetTopMasterNodeStatus GetTopMNsForBlock(std::string &error, std::vector<CMasternode> &topMNs, int nBlockHeight = -1, bool bCalculateIfNotSeen = false);
-    GetTopMasterNodeStatus CalculateTopMNsForBlock(std::string &error, std::vector<CMasternode> &topMNs, int nBlockHeight = -1);
+    GetTopMasterNodeStatus CalculateTopMNsForBlock(std::string &error, std::vector<CMasternode> &topMNs, int nBlockHeight = -1, bool bSkipValidCheck = false);
 };

--- a/src/mnode/rpc/masternode.cpp
+++ b/src/mnode/rpc/masternode.cpp
@@ -123,7 +123,10 @@ Examples:
 
     KeyIO keyIO(Params());
     UniValue obj(UniValue::VOBJ);
-    const auto mode = MNLIST.cmd();
+    auto mode = MNLIST.cmd();
+    if (mode == RPC_CMD_MNLIST::unknown)
+        mode = RPC_CMD_MNLIST::status;
+
     if (MNLIST.IsCmd(RPC_CMD_MNLIST::rank)) 
     {
         CMasternodeMan::rank_pair_vec_t vMasternodeRanks;
@@ -322,6 +325,9 @@ UniValue masternode_count(const UniValue& params)
     if (strMode == "enabled")
         return static_cast<uint64_t>(masterNodeCtrl.masternodeManager.CountEnabled());
 
+    if (strMode == "current")
+        return static_cast<uint64_t>(masterNodeCtrl.masternodeManager.CountCurrent());
+
     uint32_t nCount = 0;
     masternode_info_t mnInfo;
     masterNodeCtrl.masternodeManager.GetNextMasternodeInQueueForPayment(true, nCount, mnInfo);
@@ -330,8 +336,11 @@ UniValue masternode_count(const UniValue& params)
         return static_cast<uint64_t>(nCount);
 
     if (strMode == "all")
-        return strprintf("Total: %zu (Enabled: %zu / Qualify: %d)",
-            masterNodeCtrl.masternodeManager.size(), masterNodeCtrl.masternodeManager.CountEnabled(), nCount);
+        return strprintf("Total: %zu. From them: Current: %zu; Enabled: %zu; Qualify: %d",
+                         masterNodeCtrl.masternodeManager.size(),
+                         masterNodeCtrl.masternodeManager.CountCurrent(),
+                         masterNodeCtrl.masternodeManager.CountEnabled(),
+                         nCount);
 
     return NullUniValue;
 }
@@ -1141,15 +1150,55 @@ UniValue masternode_clear_cache(const UniValue& params) {
     return NullUniValue;
 }
 
+UniValue masternode_set_min_mn_count(const UniValue& params)
+{
+    if (params.size() < 2)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Correct usage is: masternode set-min-mn-count <count>");
+
+    int count = get_number(params[1]);
+    if (count < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Count must be positive number: %d", count));
+
+    uint32_t totalCount = masterNodeCtrl.masternodeManager.CountMasternodes();
+    if (count > totalCount)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Count should be less or equal to total number of MNs: %zu", totalCount));
+
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("OldMinMnCount", (int)masterNodeCtrl.nMinRequiredEnabledMasternodes);
+    masterNodeCtrl.nMinRequiredEnabledMasternodes = count;
+    obj.pushKV("NewMinMnCount", (int)masterNodeCtrl.nMinRequiredEnabledMasternodes);
+
+    return obj;
+}
+
+UniValue masternode_set_min_mn_percent(const UniValue& params)
+{
+    if (params.size() < 2)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Correct usage is: masternode set-min-mn-percent <percent>");
+
+    int percent = get_number(params[1]);
+    if (percent <0 || percent > 100)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Percent should be in range 0-100");
+
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("OldMinMnPercent", (int)masterNodeCtrl.nMinRequiredEnabledMasternodesPercent);
+    masterNodeCtrl.nMinRequiredEnabledMasternodesPercent = percent;
+    obj.pushKV("NewMinMnPercent", (int)masterNodeCtrl.nMinRequiredEnabledMasternodesPercent);
+
+    return obj;
+}
+
 UniValue masternode(const UniValue& params, bool fHelp)
 {
 #ifdef ENABLE_WALLET
     RPC_CMD_PARSER(MN, params, init, list, list__conf, count, debug, current, winner, winners,
-        genkey, connect, status, top, message, make__conf, pose__ban__score, print__cache, clear__cache,
+        genkey, connect, status, top, message, make__conf, pose__ban__score,
+        print__cache, clear__cache, min__enabled__mn__count, min__enabled__mn__percent,
         start__many, start__alias, start__all, start__missing, start__disabled, outputs);
 #else
     RPC_CMD_PARSER(MN, params, list, list__conf, count, debug, current, winner, winners,
-        genkey, connect, status, top, message, make__conf, pose__ban__score, print__cache, clear__cache);
+        genkey, connect, status, top, message, make__conf, pose__ban__score,
+        print__cache, clear__cache, min__enabled__mn__count, min__enabled__mn__percent);
 #endif // ENABLE_WALLET
 
 #ifdef ENABLE_WALLET
@@ -1167,7 +1216,7 @@ Arguments:
 1. "command"        (string or set of strings, required) The command to execute
 
 Available commands:
-  count        - Print number of all known masternodes (optional: 'ps', 'enabled', 'all', 'qualify')
+  count        - Print number of all known masternodes (optional: 'ps', 'enabled', 'all', 'current', 'qualify')
   current      - Print info on current masternode winner to be paid the next block (calculated locally)
   genkey       - Generate new masternodeprivkey
 )"
@@ -1191,6 +1240,9 @@ R"(
                  (this maybe not accurate - MN existed before might not be in the current list)
   message <options> - Commands to deal with MN to MN messages - sign, send, print etc\n"
   pose-ban-score - PoSe (Proof-of-Service) ban score management
+  min-enabled-mn-count - Set minimum required ENABLED masternode count in the LOCAL list to validate Tickets
+  min-enabled-mn-percent - Set minimum required ENABLED masternode percent in the LOCAL list to validate Tickets (0-100).
+                           Used only if min count is not set by either 'min-enabled-mn-count' or '-setminenabledmncount' command line option (default: 0)
 )"
 );
 
@@ -1240,6 +1292,12 @@ R"(
 
         case RPC_CMD_MN::clear__cache:
             return masternode_clear_cache(params);
+
+        case RPC_CMD_MN::min__enabled__mn__count:
+            return masternode_set_min_mn_count(params);
+
+        case RPC_CMD_MN::min__enabled__mn__percent:
+            return masternode_set_min_mn_percent(params);
 
 #ifdef ENABLE_WALLET
         case RPC_CMD_MN::init:

--- a/src/mnode/tickets/ticket_signing.cpp
+++ b/src/mnode/tickets/ticket_signing.cpp
@@ -210,7 +210,8 @@ ticket_validation_t CTicketSigning::validate_signatures(const TxOrigin txOrigin,
             }
 
             // Masternodes beyond these Pastel IDs, were in the top 10 at the block when the registration happened
-            if (masterNodeCtrl.masternodeSync.IsSynced()) // ticket needs synced MNs
+            if (masterNodeCtrl.masternodeSync.IsSynced() &&
+                masterNodeCtrl.masternodeManager.HasEnoughEnabled() ) // ticket needs synced AND correct list of MNs
             {
                 vector<CMasternode> topBlockMNs;
                 string error;
@@ -233,7 +234,7 @@ ticket_validation_t CTicketSigning::validate_signatures(const TxOrigin txOrigin,
                     LogFnPrintf("Top MNs for height=%u (status=%d): [%s]", nCreatorHeight, to_integral_type(status), GetListOfMasterNodes(topBlockMNs));
                     tv.state = TICKET_VALIDATION_STATE::INVALID;
                     tv.errorMsg = strprintf(
-                        "MN%hi was NOT in the top masternodes list for block %u", 
+                        "MN%hi was NOT in the top masternodes list for block %u",
                         mnIndex, nCreatorHeight);
                     break;
                 }


### PR DESCRIPTION
1. Added new API: `masternode clear-cache all` - it will clear all lists used by CMasternodeMan: 
- masternodes, 
- seen broadcasts and pings 
- recovery requests and replies. 

2. Added check for enough Enbaled MNs when checking signing MNs in tickets
3. Added paslted parameters 'setminenabledmncount' and 'setminenabledmnpercent', and API calls 'masternode min-enabled-mn-count' and 'masternode min-enabled-mn-percent' to set criteria to check for enough Enabled MNs when checking signing MNs in tickets