### PR TITLE
[PSL-946] pasteld: convert CMasternode raw to smart pointers

### DIFF
--- a/build-aux/vs/port/uint128.cpp
+++ b/build-aux/vs/port/uint128.cpp
@@ -12,7 +12,7 @@ uint128_t::uint128_t(const char *s, const std::size_t len, uint8_t base) {
 }
 
 uint128_t::uint128_t(const bool & b)
-    : uint128_t((uint8_t) b)
+    : uint128_t(static_cast<uint8_t>(b))
 {}
 
 void uint128_t::init(const char *s, std::size_t len, uint8_t base) {

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
@@ -319,9 +319,6 @@
     <ClInclude Include="..\..\vs\port\cyclicbarrier\cyclicbarrier.hpp" />
     <ClInclude Include="..\..\vs\port\uint128.h" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="cpp.hint" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
@@ -709,7 +709,4 @@
       <Filter>Source Files\netmsg</Filter>
     </ClInclude>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="cpp.hint" />
-  </ItemGroup>
 </Project>

--- a/build-aux/vs2022/pasteld/pasteld.vcxproj
+++ b/build-aux/vs2022/pasteld/pasteld.vcxproj
@@ -83,6 +83,9 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Link>
+      <Profile>true</Profile>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>

--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 // Copyright (c) 2017 The Zcash developers
 // Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
@@ -7,9 +8,9 @@
 // Deprecation policy:
 // * Shut down WEEKS_UNTIL_DEPRECATION weeks' worth of blocks after the estimated release block height.
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
-static constexpr unsigned int APPROX_RELEASE_HEIGHT = 500'000;
+static constexpr uint32_t APPROX_RELEASE_HEIGHT = 500'000;
 static constexpr int WEEKS_UNTIL_DEPRECATION = 2 * 52; // 2 years
-static constexpr unsigned int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
+static constexpr uint32_t DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
 
 // Number of blocks before deprecation to warn users
 static constexpr int DEPRECATION_WARN_LIMIT = 14 * 24 * 24; // 2 weeks

--- a/src/gtest/test_coins.cpp
+++ b/src/gtest/test_coins.cpp
@@ -135,35 +135,39 @@ public:
 
     void BatchWriteNullifiers(CNullifiersMap& mapNullifiers, map<uint256, bool>& cacheNullifiers)
     {
-        for (CNullifiersMap::iterator it = mapNullifiers.begin(); it != mapNullifiers.end(); ) {
-            if (it->second.flags & CNullifiersCacheEntry::DIRTY) {
+        for (auto it = mapNullifiers.begin(); it != mapNullifiers.end(); )
+        {
+            if (it->second.flags & CNullifiersCacheEntry::DIRTY)
+            {
                 // Same optimization used in CCoinsViewDB is to only write dirty entries.
-                if (it->second.entered) {
+                if (it->second.entered)
                     cacheNullifiers[it->first] = true;
-                } else {
+                else
                     cacheNullifiers.erase(it->first);
-                }
             }
-            mapNullifiers.erase(it++);
+            it = mapNullifiers.erase(it);
         }
     }
 
     template<typename Tree, typename Map, typename MapEntry>
     void BatchWriteAnchors(Map& mapAnchors, map<uint256, Tree>& cacheAnchors)
     {
-        for (auto it = mapAnchors.begin(); it != mapAnchors.end(); ) {
-            if (it->second.flags & MapEntry::DIRTY) {
+        for (auto it = mapAnchors.begin(); it != mapAnchors.end(); )
+        {
+            if (it->second.flags & MapEntry::DIRTY)
+            {
                 // Same optimization used in CCoinsViewDB is to only write dirty entries.
-                if (it->second.entered) {
-                    if (it->first != Tree::empty_root()) {
+                if (it->second.entered)
+                {
+                    if (it->first != Tree::empty_root())
+                    {
                         auto ret = cacheAnchors.insert(make_pair(it->first, Tree())).first;
                         ret->second = it->second.tree;
                     }
-                } else {
+                } else
                     cacheAnchors.erase(it->first);
-                }
             }
-            mapAnchors.erase(it++);
+            it = mapAnchors.erase(it);
         }
     }
 
@@ -176,16 +180,17 @@ public:
                     CNullifiersMap& mapSproutNullifiers,
                     CNullifiersMap& mapSaplingNullifiers)
     {
-        for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end(); ) {
-            if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+        for (auto it = mapCoins.begin(); it != mapCoins.end(); )
+        {
+            if (it->second.flags & CCoinsCacheEntry::DIRTY)
+            {
                 // Same optimization used in CCoinsViewDB is to only write dirty entries.
                 map_[it->first] = it->second.coins;
-                if (it->second.coins.IsPruned() && insecure_rand() % 3 == 0) {
+                if (it->second.coins.IsPruned() && insecure_rand() % 3 == 0)
                     // Randomly delete empty entries on write.
                     map_.erase(it->first);
-                }
             }
-            mapCoins.erase(it++);
+            it = mapCoins.erase(it);
         }
 
         BatchWriteAnchors<SproutMerkleTree, CAnchorsSproutMap, CAnchorsSproutCacheEntry>(mapSproutAnchors, mapSproutAnchors_);

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -1,12 +1,12 @@
 // Copyright (c) 2016 The Zcash developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-#include "uint256.h"
-
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <atomic>
 #include <mutex>
 #include <string>
+
+#include <uint256.h>
 
 struct AtomicCounter
 {

--- a/src/mnode/mnode-controller.cpp
+++ b/src/mnode/mnode-controller.cpp
@@ -633,8 +633,12 @@ CAmount CMasterNodeController::GetNetworkMedianMNFee(const MN_FEE mnFee) const n
         {
             v_amounts vFee(mapMasternodes.size());
             size_t cnt = 0;
-            for (const auto& [op, mn] : mapMasternodes)
-                vFee[cnt++] = mn.GetMNFee(mnFee);
+            for (const auto& [op, pmn] : mapMasternodes)
+            {
+                if (!pmn)
+                    continue;
+                vFee[cnt++] = pmn->GetMNFee(mnFee);
+            }
             // Use trimmean to calculate the value with fixed 25% percentage
             nFee = static_cast<CAmount>(ceil(TRIMMEAN(vFee, 0.25)));
         }

--- a/src/mnode/mnode-messageproc.cpp
+++ b/src/mnode/mnode-messageproc.cpp
@@ -150,9 +150,11 @@ void CMasternodeMessageProcessor::BroadcastNewFee(const MN_FEE mnFeeType, const 
         sMessage = to_string(to_integral_type(mnFeeType)) + " " + to_string(newFee);
     }
     
-    for (const auto& [op, mn] : mapMasternodes)
+    for (const auto& [op, pmn] : mapMasternodes)
     {
-        masterNodeCtrl.masternodeMessages.SendMessage(mn.pubKeyMasternode, msgType, sMessage);
+        if (!pmn)
+            continue;
+        masterNodeCtrl.masternodeMessages.SendMessage(pmn->pubKeyMasternode, msgType, sMessage);
     }
 }
 
@@ -276,8 +278,8 @@ void CMasternodeMessageProcessor::ProcessMessage(node_t& pFrom, string& strComma
             }
             if (bSetFee && mnFeeType != MN_FEE::COUNT)
             {
-                CMasternode masternode;
-                if (!masterNodeCtrl.masternodeManager.Get(masterNodeCtrl.activeMasternode.outpoint, masternode))
+                masternode_t pmn = masterNodeCtrl.masternodeManager.Get(masterNodeCtrl.activeMasternode.outpoint);
+                if (!pmn)
                     throw runtime_error("Unknown Masternode");
 
                 // Update masternode fee

--- a/src/mnode/mnode-payments.h
+++ b/src/mnode/mnode-payments.h
@@ -245,7 +245,7 @@ public:
 
     bool GetBlockPayee(int nBlockHeight, CScript& payee);
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
-    bool IsScheduled(const CMasternode& mn, const int nNotBlockHeight);
+    bool IsScheduled(const masternode_t& pmn, const int nNotBlockHeight) const;
 
     bool CanVote(COutPoint outMasternode, int nBlockHeight);
 

--- a/src/mnode/mnode-requesttracker.cpp
+++ b/src/mnode/mnode-requesttracker.cpp
@@ -60,12 +60,12 @@ void CMasternodeRequestTracker::CheckAndRemove()
         while(it_entry != it->second.end())
         {
             if (now > it_entry->second)
-                it->second.erase(it_entry++);
+                it_entry = it->second.erase(it_entry);
             else
                 ++it_entry;
         }
         if (it->second.empty())
-            mapFulfilledRequests.erase(it++);
+            it = mapFulfilledRequests.erase(it);
         else
             ++it;
     }

--- a/src/mnode/mnode-sync.cpp
+++ b/src/mnode/mnode-sync.cpp
@@ -40,7 +40,7 @@ void CMasternodeSync::Reset()
 
 void CMasternodeSync::BumpAssetLastTime(const std::string &strMethodName, const std::string &strFuncName)
 {
-    if(IsSynced() || IsFailed())
+    if (IsSynced() || IsFailed())
         return;
     nTimeLastBumped = GetTime();
     LogFnPrint("mnsync", "[%s] %s", strMethodName, strFuncName);

--- a/src/mnode/mnode-sync.h
+++ b/src/mnode/mnode-sync.h
@@ -7,6 +7,7 @@
 
 #include <univalue.h>
 
+#include <enum_util.h>
 #include <chain.h>
 #include <net.h>
 #include <netmsg/node.h>
@@ -24,7 +25,7 @@ public:
         Remote  = 1
     };
 
-    enum class MasternodeSyncState
+    enum class MasternodeSyncState : int
     {
         Failed          = -1,
         Initial         = 0,    // sync just started, was reset recently or still in IDB
@@ -76,7 +77,7 @@ public:
     bool IsGovernanceSynced() const noexcept { return syncState > MasternodeSyncState::Governance; }
     bool IsSynced() const noexcept { return syncState == MasternodeSyncState::Finished; }
 
-    int GetAssetID() const noexcept { return (int)syncState; }
+    int GetAssetID() const noexcept { return to_integral_type(syncState); }
     int GetAttempt() const noexcept { return nRequestedMasternodeAttempt; }
     void BumpAssetLastTime(const std::string &strMethodName, const std::string &strFuncName = "");
     int64_t GetAssetStartTime() const noexcept { return nTimeAssetSyncStarted; }

--- a/src/mnode/p2fms-txbuilder.cpp
+++ b/src/mnode/p2fms-txbuilder.cpp
@@ -157,10 +157,14 @@ bool CP2FMS_TX_Builder::BuildTransaction(CMutableTransaction& tx_out)
     // total amount to spend in patoshis
     CAmount nAllSpentAmountInPat = nPriceInPat + m_nExtraAmountInPat;
 
-    auto nActiveChainHeight = gl_nChainHeight + 1;
-    if (!m_chainParams.IsRegTest())
-        nActiveChainHeight = min(nActiveChainHeight, APPROX_RELEASE_HEIGHT);
-    m_consensusBranchId = CurrentEpochBranchId(nActiveChainHeight, m_chainParams.GetConsensus());
+    uint32_t nActiveChainHeight = gl_nChainHeight + 1;
+    // Use the approximate release height if it is greater so offline nodes 
+    // have a better estimation of the current height and will be more likely to
+    // determine the correct consensus branch ID.  Regtest & Testnet modes ignore release height.
+    uint32_t nChainHeightToGetBranchId = nActiveChainHeight;
+    if (m_chainParams.IsMainNet())
+        nChainHeightToGetBranchId = max(nChainHeightToGetBranchId, APPROX_RELEASE_HEIGHT);
+    m_consensusBranchId = CurrentEpochBranchId(nChainHeightToGetBranchId, m_chainParams.GetConsensus());
 
     // Create empty transaction
     tx_out = CreateNewContextualCMutableTransaction(m_chainParams.GetConsensus(), nActiveChainHeight);

--- a/src/mnode/ticket-mempool-processor.cpp
+++ b/src/mnode/ticket-mempool-processor.cpp
@@ -18,7 +18,7 @@ CPastelTicketMemPoolProcessor::CPastelTicketMemPoolProcessor(const TicketID tick
  * \param pool - transaction memory pool (you can pass default global mempool)
  * \param pMemPoolTracker - memory pool tracker, if not passed - default one is used from CPastelTicketProcessor class
  */
-void CPastelTicketMemPoolProcessor::Initialize(const CTxMemPool& pool, std::shared_ptr<ITxMemPoolTracker> pMemPoolTracker)
+void CPastelTicketMemPoolProcessor::Initialize(const CTxMemPool& pool, tx_mempool_tracker_t pMemPoolTracker)
 {
     auto pTracker = dynamic_pointer_cast<CTicketTxMemPoolTracker>(pMemPoolTracker ? pMemPoolTracker : CPastelTicketProcessor::GetTxMemPoolTracker());
     if (!pTracker)

--- a/src/mnode/ticket-mempool-processor.h
+++ b/src/mnode/ticket-mempool-processor.h
@@ -1,5 +1,5 @@
 #pragma once
-// Copyright (c) 2018-2021 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -11,7 +11,7 @@ class CPastelTicketMemPoolProcessor
 public:
     CPastelTicketMemPoolProcessor(const TicketID ticket_id);
 
-    virtual void Initialize(const CTxMemPool &pool, std::shared_ptr<ITxMemPoolTracker> pMemPoolTracker = nullptr);
+    virtual void Initialize(const CTxMemPool &pool, tx_mempool_tracker_t pMemPoolTracker = nullptr);
 
     /**
      * Find Pastel ticket by primary key.

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -28,7 +28,7 @@
 using json = nlohmann::json;
 using namespace std;
 
-static shared_ptr<ITxMemPoolTracker> TicketTxMemPoolTracker;
+static tx_mempool_tracker_t TicketTxMemPoolTracker;
 
 void CPastelTicketProcessor::InitTicketDB()
 {
@@ -595,11 +595,11 @@ string CPastelTicketProcessor::GetTicketJSON(const uint256& txid, const bool bDe
     return "";
 }
 
-bool CPastelTicketProcessor::GetTicketToStream(const uint256& txid, string &error, ticket_parse_data_t &data, const bool bUncompressData)
+bool CPastelTicketProcessor::SerializeTicketToStream(const uint256& txid, string &error, ticket_parse_data_t &data, const bool bUncompressData)
 {
     // get ticket transaction by txid, also may return ticket height
     if (!GetTransaction(txid, data.tx, Params().GetConsensus(), data.hashBlock, true, &data.nTicketHeight))
-    {
+    {   
         error = "No information available about transaction";
         return false;
     }
@@ -629,7 +629,7 @@ unique_ptr<CPastelTicket> CPastelTicketProcessor::GetTicket(const uint256 &txid)
 {
     string error;
     ticket_parse_data_t data;
-    if (!GetTicketToStream(txid, error, data, true))
+    if (!SerializeTicketToStream(txid, error, data, true))
 		throw runtime_error(error);
 
     unique_ptr<CPastelTicket> ticket;
@@ -1911,7 +1911,7 @@ string CPastelTicketProcessor::CreateFakeTransaction(CPastelTicket& ticket, cons
 }
 #endif // FAKE_TICKET
 
-shared_ptr<ITxMemPoolTracker> CPastelTicketProcessor::GetTxMemPoolTracker()
+tx_mempool_tracker_t CPastelTicketProcessor::GetTxMemPoolTracker()
 {
     if (!TicketTxMemPoolTracker)
         TicketTxMemPoolTracker = make_shared<CTicketTxMemPoolTracker>();

--- a/src/mnode/ticket-processor.h
+++ b/src/mnode/ticket-processor.h
@@ -208,7 +208,7 @@ public:
         const std::vector<std::pair<std::string, CAmount>>& extraPayments, const std::string& strVerb, bool bSend);
 #endif // FAKE_TICKET
 
-    static bool GetTicketToStream(const uint256& txid, std::string& error,
+    static bool SerializeTicketToStream(const uint256& txid, std::string& error,
         ticket_parse_data_t &data, const bool bUncompressData = true);
 
     // Reads P2FMS (Pay-to-Fake-Multisig) transaction into CCompressedDataStream object.
@@ -216,7 +216,7 @@ public:
         TicketID& ticket_id, std::string& error, const bool bLog = true, const bool bUncompressData = true);
 
     // Get mempool tracker for ticket transactions
-    static std::shared_ptr<ITxMemPoolTracker> GetTxMemPoolTracker();
+    static tx_mempool_tracker_t GetTxMemPoolTracker();
 
 protected:
     static ticket_validation_t ValidateTicketFees(const uint32_t nHeight, const CTransaction& tx, std::unique_ptr<CPastelTicket>&& ticket) noexcept;

--- a/src/mnode/tickets/collection-item.cpp
+++ b/src/mnode/tickets/collection-item.cpp
@@ -139,7 +139,7 @@ ticket_validation_t CollectionItem::IsValidCollection(const bool bPreReg) const 
         if (!bPreReg && (collectionRegTicket->GetBlock() > GetBlock()))
         {
             tv.errorMsg = strprintf(
-                "The collection '%s' registration ticket [txid=%s] referred by this %s ticket [txid=%s] has invalid height (%u > %u)",
+                "The collection '%s' registration ticket [txid=%s] referred by this %s ticket [txid=%s] has invalid height (%u -> %u)",
                 pCollRegTicket->getName(), m_sCollectionActTxid, ::GetTicketDescription(ID()),
                 GetTxId(), collectionRegTicket->GetBlock(), GetBlock());
             break;

--- a/src/mnode/tickets/ticket-utils.h
+++ b/src/mnode/tickets/ticket-utils.h
@@ -99,7 +99,7 @@ ticket_validation_t common_ticket_validation(
         if (!bPreReg && (referredItemTicket->GetBlock() > ticket.GetBlock()))
         {
             tv.errorMsg = strprintf(
-                "The %s ticket with this txid [%s] referred by this %s ticket [txid=%s] has invalid height %u > %u",
+                "The %s ticket with this txid [%s] referred by this %s ticket [txid=%s] has invalid height (%u -> %u)",
                 sReferredItemTicketDescription, strReferredItemTxId, sThisTicketDescription, ticket.GetTxId(), 
                 referredItemTicket->GetBlock(), ticket.GetBlock());
             break;

--- a/src/mnode/tickets/ticket_signing.cpp
+++ b/src/mnode/tickets/ticket_signing.cpp
@@ -213,7 +213,7 @@ ticket_validation_t CTicketSigning::validate_signatures(const TxOrigin txOrigin,
             if (masterNodeCtrl.masternodeSync.IsSynced() &&
                 masterNodeCtrl.masternodeManager.HasEnoughEnabled() ) // ticket needs synced AND correct list of MNs
             {
-                vector<CMasternode> topBlockMNs;
+                masternode_vector_t topBlockMNs;
                 string error;
                 const auto status = masterNodeCtrl.masternodeManager.GetTopMNsForBlock(error, topBlockMNs, nCreatorHeight, true);
                 if (status != GetTopMasterNodeStatus::SUCCEEDED && status != GetTopMasterNodeStatus::SUCCEEDED_FROM_HISTORY)
@@ -224,9 +224,9 @@ ticket_validation_t CTicketSigning::validate_signatures(const TxOrigin txOrigin,
 						nCreatorHeight, error);
 					break;
 				}
-                const auto foundIt = find_if(topBlockMNs.cbegin(), topBlockMNs.cend(), [&](CMasternode const& mn)
+                const auto foundIt = find_if(topBlockMNs.cbegin(), topBlockMNs.cend(), [&](const masternode_t & pmn)
                     {
-                        return mn.getOutPoint() == outpoint;
+                        return pmn && (pmn->getOutPoint() == outpoint);
                     });
 
                 if (foundIt == topBlockMNs.cend()) //not found

--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -9,8 +9,8 @@ using namespace std;
 
 CNetManagerThread gl_NetMgr;
 
-constexpr chrono::seconds ACTIVE_CHECK_PERIOD_SECS = 5s;
-constexpr chrono::seconds INACTIVE_CHECK_PERIOD_SECS = 1s;
+constexpr chrono::seconds ACTIVE_CHECK_PERIOD_SECS = 10s;
+constexpr chrono::seconds INACTIVE_CHECK_PERIOD_SECS = 2s;
 constexpr  int64_t INACTIVITY_CHECK_GRACE_PERIOD_SECS = 30;
 
 CNetManagerThread::CNetManagerThread() : 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -753,7 +753,8 @@ struct CMutableTransaction
     }
 
     template <typename Stream>
-    CMutableTransaction(deserialize_type, Stream& s) {
+    CMutableTransaction(deserialize_type, Stream& s)
+    {
         Unserialize(s);
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -1,7 +1,7 @@
 #pragma once
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2013 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -171,7 +171,7 @@ namespace NetMsgType
     constexpr auto MNANNOUNCE               = "mnb";    // MasterNode Announce
     constexpr auto MNPING                   = "mnp";    // MasterNode Ping
     constexpr auto MNVERIFY                 = "mnv";    // MasterNode Verify
-    constexpr auto DSEG                     = "dseg";   // MasterNode Sync request
+    constexpr auto DSEG                     = "dseg";   // MasterNode Sync request (Masternode list or specific entry)
     constexpr auto SYNCSTATUSCOUNT          = "ssc";    // MasterNode Sync status
 
     // const char *TXLOCKREQUEST="ix";

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -587,6 +587,9 @@ template<typename Stream, typename T, typename A> void Unserialize(Stream& is, s
 template<typename Stream, typename T> void Serialize(Stream& os, const std::shared_ptr<const T>& p);
 template<typename Stream, typename T> void Unserialize(Stream& os, std::shared_ptr<const T>& p);
 
+template<typename Stream, typename T> void Serialize(Stream& os, const std::shared_ptr<T>& p);
+template<typename Stream, typename T> void Unserialize(Stream& os, std::shared_ptr<T>& p);
+
 /**
  * unique_ptr
  */
@@ -704,6 +707,13 @@ void Serialize_impl(Stream& os, const std::vector<T, A>& v, const unsigned char&
         os.write((char*)&v[0], v.size() * sizeof(T));
 }
 
+template<typename Stream, typename T, typename A>
+void Serialize_impl(Stream& os, const std::vector<T, A>& v, const std::shared_ptr<T>&)
+{
+    WriteCompactSize(os, v.size());
+    for (typename std::vector<T, A>::const_iterator vi = v.begin(); vi != v.end(); ++vi)
+        ::Serialize(os, (*vi));
+}
 template<typename Stream, typename T, typename A, typename V>
 void Serialize_impl(Stream& os, const std::vector<T, A>& v, const V&)
 {
@@ -1188,8 +1198,8 @@ void Unserialize(Stream& is, std::unique_ptr<const T>& p)
 /**
  * shared_ptr
  */
-template<typename Stream, typename T> void
-Serialize(Stream& os, const std::shared_ptr<const T>& p)
+template<typename Stream, typename T>
+void Serialize(Stream& os, const std::shared_ptr<const T>& p)
 {
     Serialize(os, *p);
 }
@@ -1198,6 +1208,18 @@ template<typename Stream, typename T>
 void Unserialize(Stream& is, std::shared_ptr<const T>& p)
 {
     p = std::make_shared<const T>(deserialize, is);
+}
+
+template<typename Stream, typename T>
+void Serialize(Stream& os, const std::shared_ptr<T>& p)
+{
+    Serialize(os, *p);
+}
+
+template<typename Stream, typename T>
+void Unserialize(Stream& is, std::shared_ptr<T>& p)
+{
+    p = std::make_shared<T>(deserialize, is);
 }
 
 /**

--- a/src/sync.h
+++ b/src/sync.h
@@ -142,6 +142,7 @@ void EnterCritical(const char* szLockName, const char* szFile, const size_t nLin
 void EnterSharedCritical(const char* szLockName, const char* szFile, const size_t nLine, void* cs, const bool fTry = false);
 void EnterExclusiveCritical(const char* szLockName, const char* szFile, const size_t nLine, void* cs, const bool fTry = false);
 void LeaveCritical();
+void CleanupLockOrders(const void* lock);
 std::string LocksHeld();
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, const size_t nLine, void* cs, LockType type);
 void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, const size_t nLine, void* cs, LockType type);
@@ -220,7 +221,10 @@ public:
     ~CMutexLock() UNLOCK_FUNCTION()
     {
         if (lock.owns_lock())
+        {
             LeaveCritical();
+            CleanupLockOrders((void*)(lock.mutex()));
+        }
     }
 
     operator bool()
@@ -322,7 +326,10 @@ public:
     ~CSharedMutexLock() UNLOCK_FUNCTION()
     {
         if (lock.owns_lock())
+        {
             LeaveCritical();
+            CleanupLockOrders((void*)(lock.mutex()));
+        }
     }
 
     operator bool()
@@ -426,7 +433,10 @@ public:
     ~CSharedMutexExclusiveLock() UNLOCK_FUNCTION()
     {
         if (lock.owns_lock())
+        {
             LeaveCritical();
+            CleanupLockOrders((void*)(lock.mutex()));
+        }
     }
 
     operator bool()

--- a/src/txmempool_entry.h
+++ b/src/txmempool_entry.h
@@ -105,3 +105,5 @@ public:
 
     virtual ~ITxMemPoolTracker() noexcept {}
 };
+
+using tx_mempool_tracker_t = std::shared_ptr<ITxMemPoolTracker>;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -725,6 +725,8 @@ bool TryCreateDirectory(const fs::path& p)
 
 void FileCommit(FILE *fileout)
 {
+    if (!fileout)
+        return;
     fflush(fileout); // harmless if redundantly called
 #ifdef WIN32
     HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fileout));
@@ -739,6 +741,11 @@ void FileCommit(FILE *fileout)
     #endif
 #endif
 }
+
+void LogFlush()
+{
+    FileCommit(fileout);
+}   
 
 bool TruncateFile(FILE *file, unsigned int length) {
 #if defined(WIN32)

--- a/src/util.h
+++ b/src/util.h
@@ -150,9 +150,11 @@ bool error(const char* fmt, const Args&... args)
 }
 
 template<typename... Args>
-bool errorFn(const char* fmt, const Args&... args)
+bool errorFn(const char *szMethodName, const char* fmt, const Args&... args)
 {
-    LogPrintStr(tfm::format("[%s] ", __METHOD_NAME__) + "ERROR: " + tfm::format(fmt, args...) + "\n");
+    if (!szMethodName || !*szMethodName)
+        szMethodName = __METHOD_NAME__;
+    LogPrintStr(tfm::format("[%s] ", szMethodName) + "ERROR: " + tfm::format(fmt, args...) + "\n");
     return false;
 }
 
@@ -164,11 +166,14 @@ bool warning_msg(const char* fmt, const Args&... args)
 }
 
 template <typename... Args>
-bool warning_msgFn(const char* fmt, const Args&... args)
+bool warning_msgFn(const char *szMethodName, const char* fmt, const Args&... args)
 {
-    LogPrintStr(tfm::format("[%s] ", __METHOD_NAME__) + "WARNING: " + tfm::format(fmt, args...) + "\n");
+    if (!szMethodName || !*szMethodName)
+        szMethodName = __METHOD_NAME__;
+    LogPrintStr(tfm::format("[%s] ", szMethodName) + "WARNING: " + tfm::format(fmt, args...) + "\n");
     return false;
 }
+
 
 const fs::path& ZC_GetParamsDir();
 
@@ -178,6 +183,7 @@ std::string GetErrorString(const int err);
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
 void ParseParameters(int argc, const char*const argv[]);
 void FileCommit(FILE *fileout);
+void LogFlush();
 bool TruncateFile(FILE *file, unsigned int length);
 size_t RaiseFileDescriptorLimit(const size_t nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -425,12 +425,14 @@ void CDBEnv::Flush(bool fShutdown)
         return;
     {
         LOCK(cs_db);
-        map<string, int>::iterator mi = mapFileUseCount.begin();
-        while (mi != mapFileUseCount.end()) {
-            string strFile = (*mi).first;
-            int nRefCount = (*mi).second;
+        auto mi = mapFileUseCount.begin();
+        while (mi != mapFileUseCount.end())
+        {
+            const auto &strFile = mi->first;
+            const auto nRefCount = mi->second;
             LogPrint("db", "CDBEnv::Flush: Flushing %s (refcount = %d)...\n", strFile, nRefCount);
-            if (nRefCount == 0) {
+            if (nRefCount == 0)
+            {
                 // Move log data to the dat file
                 CloseDb(strFile);
                 LogPrint("db", "CDBEnv::Flush: %s checkpoint\n", strFile);
@@ -439,7 +441,7 @@ void CDBEnv::Flush(bool fShutdown)
                 if (!fMockDb)
                     dbenv->lsn_reset(strFile.c_str(), 0);
                 LogPrint("db", "CDBEnv::Flush: %s closed\n", strFile);
-                mapFileUseCount.erase(mi++);
+                mi = mapFileUseCount.erase(mi);
             } else
                 mi++;
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3777,7 +3777,7 @@ Examples:
         nTotalOut += nAmount;
     }
 
-    int nextBlockHeight = chainActive.Height() + 1;
+    int nextBlockHeight = gl_nChainHeight + 1;
     CMutableTransaction mtx;
     mtx.fOverwintered = true;
     mtx.nVersionGroupId = SAPLING_VERSION_GROUP_ID;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1038,7 +1038,7 @@ void CFlushWalletDBThread::execute()
                         bitdb.CloseDb(m_sWalletFile);
                         bitdb.CheckpointLSN(m_sWalletFile);
 
-                        bitdb.mapFileUseCount.erase(mi++);
+                        mi = bitdb.mapFileUseCount.erase(mi);
                         LogPrint("db", "Flushed wallet.dat %dms\n", GetTimeMillis() - nStart);
                     }
                 }


### PR DESCRIPTION
- converted CMasternode* to masternode_t (shared_ptr<CMasternode>)
- refactored CMasternodeMan::CheckAndRemove
- other changes:
  - fixed an issue in potential deadlock detection system. Lock orders are saved in the global map, if lock was going out of scope if was not erased from this global map. So, another lock could have been created exactly with the same address and cause false positive potential deadlock detection.
  - fixed all places in the code that erase items from map like this: myMap.erase(it++) map iterator is invalidated after erase call and post-increment on invalid iterator can lean to unpredictable results. Changed to: it = myMap.erase(it). refactored all functions and templates that used map erase like this
  - fixed an issue with internet connectivity check on Windows version. It was executing system command to check internet connectivity (ping -c 1 hostname >/dev/null 2>&1). This command is not valid for Windows and messing up metrics console output. Changed command for Windows to (ping -n 1 hostname > nul 2>&1). Shuffle hostnames in the list used by ping to avoid pinging same host all the time. Changed active check period 5s->10s, inactive 1s->2s.
  - enhanced "masternode" category logs to include additional information about reason for state changes, etc...
  - changed the logic in CMasternodeMan::GetTopMNsForBlock on getting historical top MNs from map: instead of checking for empty top MNs list, added a check that is should be >= masterNodeCtrl.getMasternodeTopMNsNumberMin(). So it must have at least 3 top MNs, if not - it will passthrough to the top MNs calculation.