### PR TITLE
[PSL-960] pasteld: pastel-cli help

### DIFF
--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -8,7 +8,7 @@
 // Deprecation policy:
 // * Shut down WEEKS_UNTIL_DEPRECATION weeks' worth of blocks after the estimated release block height.
 // * A warning is shown during the 2 weeks' worth of blocks prior to shut down.
-static constexpr uint32_t APPROX_RELEASE_HEIGHT = 500'000;
+static constexpr uint32_t APPROX_RELEASE_HEIGHT = 600'000;
 static constexpr int WEEKS_UNTIL_DEPRECATION = 2 * 52; // 2 years
 static constexpr uint32_t DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 24);
 

--- a/src/gtest/test_coins.cpp
+++ b/src/gtest/test_coins.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2014 The Bitcoin Core developers
-// Copyright (c) 2021 The Pastel developers
+// Copyright (c) 2021-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/gtest/test_rpc.cpp
+++ b/src/gtest/test_rpc.cpp
@@ -171,7 +171,8 @@ TEST_F(TestRpc, rpc_rawsign)
 
 TEST_F(TestRpc, help)
 {
-    EXPECT_THROW(CallRPC("help"), runtime_error);
+    UniValue r = CallRPC("help");
+    EXPECT_TRUE(r.isStr() && !r.getValStr().empty());
 }
 
 class PTestRpc : public TestWithParam<tuple<CAmount, string>>

--- a/src/gtest/test_rpc_wallet.cpp
+++ b/src/gtest/test_rpc_wallet.cpp
@@ -131,7 +131,7 @@ TEST_F(TestRpcWallet1, rpc_wallet)
     CPubKey demoPubkey = pwalletMain->GenerateNewKey();
     CTxDestination demoAddress(CTxDestination(demoPubkey.GetID()));
     UniValue retValue;
-    string strAccount = "";
+    string strAccount;
     string strPurpose = "receive";
     EXPECT_NO_THROW({ /*Initialize Wallet with an account */
         CWalletDB walletdb(pwalletMain->strWalletFile);

--- a/src/mnode/rpc/tickets-list.cpp
+++ b/src/mnode/rpc/tickets-list.cpp
@@ -11,6 +11,8 @@
 
 using namespace std;
 
+constexpr uint32_t TESTNET_CUTOFF_MINHEIGHT = 265'000;
+
 UniValue tickets_list(const UniValue& params)
 {
     RPC_CMD_PARSER2(LIST, params, id, nft, collection, collection__act, act, 
@@ -111,11 +113,22 @@ As json rpc
     if (params.size() > 3 && !bSpecialParsingLogic)
         minheight = get_number(params[3]);
 
-    // limit minheight for testnet for NFT & Action tickets
+    // limit minheight for testnet for NFT, Action, Collection & Offer/Accept/Transfer tickets
     if (Params().IsTestNet() && !minheight && 
-        is_enum_any_of(LIST.cmd(), RPC_CMD_LIST::nft, RPC_CMD_LIST::act,
-            RPC_CMD_LIST::action, RPC_CMD_LIST::action__act))
-        minheight = 265'000;
+        is_enum_any_of(LIST.cmd(), 
+            RPC_CMD_LIST::nft,
+            RPC_CMD_LIST::act,
+            RPC_CMD_LIST::action,
+            RPC_CMD_LIST::action__act,
+            RPC_CMD_LIST::collection,
+            RPC_CMD_LIST::collection__act,
+            RPC_CMD_LIST::offer,
+            RPC_CMD_LIST::sell,
+            RPC_CMD_LIST::accept,
+            RPC_CMD_LIST::buy,
+            RPC_CMD_LIST::transfer,
+            RPC_CMD_LIST::trade))
+        minheight = TESTNET_CUTOFF_MINHEIGHT;
 
     UniValue obj(UniValue::VARR);
     switch (LIST.cmd())

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -1436,7 +1436,7 @@ bool isValuePassFuzzyFilter(const json &jProp, const string &sPropFilterValue) n
                 sPropValue = to_string(jProp);
                 if (sPropValue != sPropFilterValue)
                     break;
-            } catch ([[maybe_unused]] const std::bad_alloc& ex)
+            } catch ([[maybe_unused]] const bad_alloc& ex)
             {
                 break;
             }
@@ -1920,8 +1920,9 @@ tx_mempool_tracker_t CPastelTicketProcessor::GetTxMemPoolTracker()
 }
 
 bool CPastelTicketProcessor::FindAndValidateTicketTransaction(const CPastelTicket& ticket,
-                                                              const std::string& new_txid, uint32_t new_height,
-                                                              bool bPreReg, std::string &message) {
+                                                              const string& new_txid, uint32_t new_height,
+                                                              bool bPreReg, string &message)
+{
     bool bFound= true;
     const uint256 txid = uint256S(ticket.GetTxId());
     const auto pTicket = CPastelTicketProcessor::GetTicket(txid);
@@ -1931,29 +1932,29 @@ bool CPastelTicketProcessor::FindAndValidateTicketTransaction(const CPastelTicke
         {
             CTransaction tx;
             if (mempool.lookup(txid, tx))
-                message = strprintf("%sfound in mempool. ", message);
+                message += " found in mempool.";
             else
             {
                 bFound = false;
                 bool ok = masterNodeCtrl.masternodeTickets.EraseTicketFromDB(ticket);
-                message = strprintf("%sfound in stale block. %s removed from TicketDB", message,
+                message += strprintf(" found in stale block. %s removed from TicketDB", 
                                     ok ? "Successfully" : "Failed to be");
             }
         } else {
-            message = strprintf("%salready exists in blockchain.", message);
+            message += " already exists in blockchain.";
             CTransaction new_tx;
             if (mempool.lookup(uint256S(new_txid), new_tx)) {
-                message = strprintf("%s Removing new [%s] from mempool.", message, new_txid);
+                message += strprintf(" Removing new[% s] from mempool.", new_txid);
                 mempool.remove(new_tx, false);
             }
         }
     } else {
         bFound = false;
         bool ok = masterNodeCtrl.masternodeTickets.EraseTicketFromDB(ticket);
-        message = strprintf("%sfound in Ticket DB, but not in blockchain. %s removed from TicketDB", message,
+        message += strprintf(" found in Ticket DB, but not in blockchain. %s removed from TicketDB",
                             ok ? "Successfully" : "Failed to be");
     }
-    message = strprintf("%s [%sfound ticket block=%u, txid=%s]", message,
+    message += strprintf(" [%sfound ticket block=%u, txid=%s]",
                         bPreReg ? "" : strprintf("this ticket block=%u txid=%s; ", new_height, new_txid),
                         ticket.GetBlock(), ticket.GetTxId());
     if (!bFound) {

--- a/src/mnode/ticket-processor.cpp
+++ b/src/mnode/ticket-processor.cpp
@@ -600,7 +600,7 @@ bool CPastelTicketProcessor::SerializeTicketToStream(const uint256& txid, string
 {
     // get ticket transaction by txid, also may return ticket height
     if (!GetTransaction(txid, data.tx, Params().GetConsensus(), data.hashBlock, true, &data.nTicketHeight))
-    {   
+    {
         error = "No information available about transaction";
         return false;
     }

--- a/src/mnode/tickets/action-act.cpp
+++ b/src/mnode/tickets/action-act.cpp
@@ -130,7 +130,7 @@ ticket_validation_t CActionActivateTicket::IsValid(const TxOrigin txOrigin, cons
                 !existingTicket.IsBlock(m_nBlock) ||
                 !existingTicket.IsTxId(m_txid))
             {
-                string message = strprintf( "The Activation ticket for the Registration ticket with txid [%s] ", m_regTicketTxId);
+                string message = strprintf( "The Activation ticket for the Registration ticket with txid [%s]", m_regTicketTxId);
                 bool bFound = CPastelTicketProcessor::FindAndValidateTicketTransaction(existingTicket,
                                                                                        m_txid, m_nBlock,
                                                                                        bPreReg, message);

--- a/src/mnode/tickets/collection-act.cpp
+++ b/src/mnode/tickets/collection-act.cpp
@@ -100,7 +100,7 @@ ticket_validation_t CollectionActivateTicket::IsValid(const TxOrigin txOrigin, c
                 !existingTicket.IsBlock(m_nBlock) ||
                 !existingTicket.IsTxId(m_txid))
             {
-                string message = strprintf( "The Activation ticket for the Collection Registration ticket with txid [%s] ", m_regTicketTxId);
+                string message = strprintf( "The Activation ticket for the Collection Registration ticket with txid [%s]", m_regTicketTxId);
                 bool bFound = CPastelTicketProcessor::FindAndValidateTicketTransaction(existingTicket,
                                                                                        m_txid, m_nBlock,
                                                                                        bPreReg, message);

--- a/src/mnode/tickets/nft-act.cpp
+++ b/src/mnode/tickets/nft-act.cpp
@@ -97,7 +97,7 @@ ticket_validation_t CNFTActivateTicket::IsValid(const TxOrigin txOrigin, const u
                 !existingTicket.IsBlock(m_nBlock) ||
                 !existingTicket.IsTxId(m_txid))
             {
-                string message = strprintf( "The Activation ticket for the Registration ticket with txid [%s] ", m_regTicketTxId);
+                string message = strprintf( "The Activation ticket for the Registration ticket with txid [%s]", m_regTicketTxId);
                 bool bFound = CPastelTicketProcessor::FindAndValidateTicketTransaction(existingTicket,
                                                                                        m_txid, m_nBlock,
                                                                                        bPreReg, message);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4568,8 +4568,8 @@ bool GetWalletTransaction(const uint256 &txid, CTransaction &tx, uint256& hashBl
 UniValue gettxfee(const UniValue& params, bool fHelp)
 {
     UniValue resultObj(UniValue::VOBJ);
-    if (params.empty() || fHelp)
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
+    if (fHelp || params.empty())
+        throw runtime_error(
 R"(gettxfee "txid"
 Get transaction fee by txid.
 
@@ -4645,9 +4645,9 @@ UniValue scanForMissingTransactions(const UniValue& params, bool fHelp)
 {
     UniValue resultObj(UniValue::VARR);
 
-    if (params.empty() || fHelp)
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-            R"(scanformissingtxs <starting_height>
+    if (fHelp || params.empty())
+        throw runtime_error(
+R"(scanformissingtxs <starting_height>
 Scan for missing transactions in the wallet starting from the given height.
 
 Arguments:
@@ -4683,9 +4683,9 @@ UniValue fixMissingTransactions(const UniValue& params, bool fHelp)
 {
     UniValue resultObj(UniValue::VARR);
 
-    if (params.empty() || fHelp)
-        throw JSONRPCError(RPC_INVALID_PARAMETER,
-            R"(fixmissingtxs <starting_height>
+    if (fHelp || params.empty())
+        throw runtime_error(
+R"(fixmissingtxs <starting_height>
 Scan for missing transactions in the wallet starting from the given height.
 Add to wallet all the missing transactions found in the blockchain.
 


### PR DESCRIPTION
[PSL-960] pasteld: pastel-cli help
 - fixed help rpc command without parameters - should return a list of all available RPC commands sorted by categories

[PSL-924] pasteld: filter offer/accept/transfer tickets as well using the same cutoff (block 265,000 in testnet) so things are consistent
 - set default minheight to 265'000 when listing tickets of the following types in testnet: action-reg, action-act, nft-reg, nft-act, offer(sell), accept(buy), transfer(trade), collection-reg, collection-act

[PSL-960]: https://pastel-network.atlassian.net/browse/PSL-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSL-924]: https://pastel-network.atlassian.net/browse/PSL-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ