### PR TITLE
[PSL-961]  cNode: printtoconsole feature enhancement

### DIFF
--- a/src/mnode/mnode-manager.cpp
+++ b/src/mnode/mnode-manager.cpp
@@ -909,7 +909,8 @@ void CMasternodeMan::ProcessMessage(node_t& pfrom, string& strCommand, CDataStre
         if (!masterNodeCtrl.masternodeSync.IsBlockchainSynced())
             return;
 
-        LogFnPrint("masternode", "MNANNOUNCE -- Masternode announce (%s), masternode=%s", strCommand, mnb.GetDesc());
+        LogFnPrint("masternode", "MNANNOUNCE -- Masternode announce (%s), masternode=%s, peer=%d",
+            strCommand, mnb.GetDesc(), pfrom->id);
 
         int nDos = 0;
         if (CheckMnbAndUpdateMasternodeList(pfrom, mnb, nDos))
@@ -931,7 +932,8 @@ void CMasternodeMan::ProcessMessage(node_t& pfrom, string& strCommand, CDataStre
         if (!masterNodeCtrl.masternodeSync.IsBlockchainSynced())
             return;
 
-        LogFnPrint("masternode", "MNPING -- Masternode ping (%s), masternode=%s", strCommand, mnp.GetDesc());
+        LogFnPrint("masternode", "MNPING -- Masternode ping (%s), masternode=%s (%" PRId64 " secs old), peer=%d",
+            strCommand, mnp.GetDesc(), mnp.getAgeInSecs(), pfrom->id);
 
         // Need LOCK2 here to ensure consistent locking order because the CheckAndUpdate call below locks cs_main
         LOCK2(cs_main, cs_mnMgr);
@@ -973,7 +975,8 @@ void CMasternodeMan::ProcessMessage(node_t& pfrom, string& strCommand, CDataStre
         CTxIn vin;
         vRecv >> vin;
 
-        LogFnPrint("masternode", "DSEG -- Masternode list (%s), masternode=%s", strCommand, vin.prevout.ToStringShort());
+        LogFnPrint("masternode", "DSEG -- Masternode list (%s), masternode=%s, peer=%d",
+            strCommand, vin.prevout.ToStringShort(), pfrom->id);
 
         LOCK(cs_mnMgr);
 

--- a/src/mnode/mnode-masternode.h
+++ b/src/mnode/mnode-masternode.h
@@ -112,8 +112,7 @@ public:
     // Check that MN was pinged within nSeconds
     bool IsPingedWithin(const int nSeconds, const int64_t nTimeToCheckAt) const noexcept
     {
-        return nTimeToCheckAt >= m_sigTime ?
-            nTimeToCheckAt - m_sigTime < nSeconds : false;
+        return abs(nTimeToCheckAt - m_sigTime) < nSeconds;
     }
     bool IsPingedAfter(const int64_t nSigTime) const noexcept
     {

--- a/src/util.h
+++ b/src/util.h
@@ -45,7 +45,6 @@ public:
 extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;
 extern bool fDebug;
-extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;
 extern bool fServer;
 extern std::string strMiscWarning;
@@ -323,6 +322,9 @@ public:
         return ((static_cast<int64_t>(nRw) << 16) + nRz) % nMax;
     }
 };
+
+bool SetPrintToConsoleMode(std::string &error);
+bool IsPrintToConsole() noexcept;
 
 template <typename _T>
 inline void safe_delete_obj(_T*& obj)


### PR DESCRIPTION
[PSL-961]  cNode: printtoconsole feature enhancement
Enhanced printtocaonsole option to support few modes:
 0 - do not output any messages to console, log only to debug.log file
 1 - output debug messages only to console
 2 - output debug messages to both console and debug.log
 printtoconsole modes 1 & 2 disable showmetrics

- fixed MN ping time check function IsPingedWithin - responsible for bad MN state changes

[PSL-961]: https://pastel-network.atlassian.net/browse/PSL-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ