### PR TITLE
[PSL-971] cNode: IBD stalls when revalidation from block cache bans all peers

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -179,7 +179,6 @@ bool CBlockIndex::UpdateChainValues()
 
 /**
  * Update tx count, chain values for this block and all descendants.
- * 
  */
 void CBlockIndex::UpdateChainTx()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2757,7 +2757,7 @@ bool AcceptBlockHeader(
             return state.Invalid(error("%s: block (height=%d) is marked invalid", __func__, pindex->nHeight), 0, "duplicate");
         // if previous block has failed contextual validation - add it to unlinked block map as well
         if (gl_BlockCache.check_prev_block(pindex))
-            LogPrint("net", "block %s (height=%d) added to cached unlinked map\n", hash.ToString(), pindex->nHeight);
+            LogFnPrint("net", "block %s (height=%d) added to cached unlinked map", hash.ToString(), pindex->nHeight);
         return true;
     }
 
@@ -4893,13 +4893,8 @@ static bool ProcessMessage(const CChainParams& chainparams, node_t pfrom, string
         // some input transactions may be missing for this block, in this case ProcessNewBlock 
         // will set rejection code REJECT_MISSING_INPUTS.
         if (state.IsRejectCode(REJECT_MISSING_INPUTS))
-        {
             // add block to cache to revalidate later on periodically
-            if (gl_BlockCache.add_block(inv.hash, pfrom->id, state.getTxOrigin(), move(block)))
-                LogFnPrintf("block %s cached for revalidation, peer=%d", inv.hash.ToString(), pfrom->id);
-            else
-                LogFnPrint("net", "block %s already exists in a revalidation cache, peer=%d", inv.hash.ToString(), pfrom->id);
-        }
+            gl_BlockCache.add_block(inv.hash, pfrom->id, state.getTxOrigin(), move(block));
         else
         {
             int nDoS = 0; // denial-of-service code

--- a/src/mnode/mnode-active.cpp
+++ b/src/mnode/mnode-active.cpp
@@ -109,7 +109,7 @@ bool CActiveMasternode::SendMasternodePing()
     // Update lastPing for our masternode in Masternode list
     if (masterNodeCtrl.masternodeManager.IsMasternodePingedWithin(outpoint, masterNodeCtrl.MasternodeMinMNPSeconds, mnp.getSigTime()))
     {
-        LogFnPrintf("Too early to send Masternode Ping");
+        LogFnPrintf("Too early to send Masternode Ping - last ping within %d secs", masterNodeCtrl.MasternodeMinMNPSeconds);
         return false;
     }
 

--- a/src/mnode/mnode-manager.cpp
+++ b/src/mnode/mnode-manager.cpp
@@ -1884,12 +1884,16 @@ void CMasternodeMan::CheckMasternode(const CPubKey& pubKeyMasternode, bool fForc
     }
 }
 
-bool CMasternodeMan::IsMasternodePingedWithin(const COutPoint& outpoint, int nSeconds, int64_t nTimeToCheckAt)
+bool CMasternodeMan::IsMasternodePingedWithin(const COutPoint& outpoint, int nSeconds, int64_t nTimeToCheckAt, string *psReason)
 {
     LOCK(cs_mnMgr);
 
-    auto pmn = Find(outpoint);
-    return pmn ? pmn->IsPingedWithin(nSeconds, nTimeToCheckAt) : false;
+    const auto pmn = Find(outpoint);
+    if (pmn)
+        return pmn->IsPingedWithin(nSeconds, nTimeToCheckAt, psReason);
+    if (psReason)
+        *psReason = strprintf("masternode not found by outpoint %s", outpoint.ToStringShort());
+    return false;
 }
 
 void CMasternodeMan::SetMasternodeLastPing(const COutPoint& outpoint, const CMasterNodePing& mnp)

--- a/src/mnode/mnode-manager.cpp
+++ b/src/mnode/mnode-manager.cpp
@@ -346,29 +346,62 @@ void CMasternodeMan::CheckAndRemove(bool bCheckAndRemove)
     }
 }
 
-void CMasternodeMan::ClearCache(bool clearMnList, bool clearSeenLists, bool clearRecoveryLists, bool clearAskedLists)
+set<MNCacheItem> getAllMNCacheItems() noexcept
 {
-    LOCK_COND(clearMnList || clearSeenLists || clearRecoveryLists || clearAskedLists, cs_mnMgr);
-    if (clearMnList)
-        mapMasternodes.clear();
+    set<MNCacheItem> setCacheItems;
+    for (int i = 0; i < to_integral_type(MNCacheItem::COUNT); ++i)
+		setCacheItems.insert(static_cast<MNCacheItem>(i));
+    return setCacheItems;
+}
 
-    if (clearSeenLists)
+void CMasternodeMan::ClearCache(const std::set<MNCacheItem> &setCacheItems)
+{
+    LOCK_COND(!setCacheItems.empty(), cs_mnMgr);
+
+    if (setCacheItems.count(MNCacheItem::MN_LIST))
+    {
+        mapMasternodes.clear();
+        LogFnPrintf("Cleared Masternode list cache");
+    }
+    if (setCacheItems.count(MNCacheItem::SEEN_MN_BROADCAST))
     {
         mapSeenMasternodeBroadcast.clear();
-        mapSeenMasternodePing.clear();
+        LogFnPrintf("Cleared Masternode broadcast cache");
     }
-
-    if (clearRecoveryLists)
+    if (setCacheItems.count(MNCacheItem::SEEN_MN_PING))
+    {
+        mapSeenMasternodePing.clear();
+        LogFnPrintf("Cleared Masternode ping cache");
+    }
+    if (setCacheItems.count(MNCacheItem::RECOVERY_REQUESTS))
     {
         mMnbRecoveryRequests.clear();
-        mMnbRecoveryGoodReplies.clear();
+        LogFnPrintf("Cleared Masternode recovery requests cache");
     }
-
-    if (clearAskedLists)
+    if (setCacheItems.count(MNCacheItem::RECOVERY_GOOD_REPLIES))
+    {
+        mMnbRecoveryGoodReplies.clear();
+        LogFnPrintf("Cleared Masternode recovery good replies cache");
+    }
+    if (setCacheItems.count(MNCacheItem::ASKED_US_FOR_MN_LIST))
     {
         mAskedUsForMasternodeList.clear();
+        LogFnPrintf("Cleared Masternode asked us for list cache");
+    }
+    if (setCacheItems.count(MNCacheItem::WE_ASKED_FOR_MN_LIST))
+    {
         mWeAskedForMasternodeList.clear();
+        LogFnPrintf("Cleared Masternode we asked for list cache");
+    }
+    if (setCacheItems.count(MNCacheItem::WE_ASKED_FOR_MN_LIST_ENTRY))
+    {
         mWeAskedForMasternodeListEntry.clear();
+        LogFnPrintf("Cleared Masternode we asked for list entry cache");
+    }
+    if (setCacheItems.count(MNCacheItem::HISTORICAL_TOP_MNS))
+    {
+        mapHistoricalTopMNs.clear();
+        LogFnPrintf("Cleared Masternode historical top MNs cache");
     }
 }
 
@@ -1928,6 +1961,7 @@ void CMasternodeMan::UpdatedBlockTip(const CBlockIndex *pindex)
  * \param error - error message
  * \param topMNs - vector of top masternodes
  * \param nBlockHeight - block height
+ * \param bSkipValidCheck - skip masternode valid for payment check
  * \return - status of the operation
  */
 GetTopMasterNodeStatus CMasternodeMan::CalculateTopMNsForBlock(string &error, masternode_vector_t &topMNs, int nBlockHeight, bool bSkipValidCheck)

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -281,7 +281,8 @@ public:
 
     void CheckMasternode(const CPubKey& pubKeyMasternode, bool fForce);
 
-    bool IsMasternodePingedWithin(const COutPoint& outpoint, int nSeconds, int64_t nTimeToCheckAt = -1);
+    bool IsMasternodePingedWithin(const COutPoint& outpoint, const int nSeconds, 
+        int64_t nTimeToCheckAt = -1, std::string *psReason = nullptr);
     void SetMasternodeLastPing(const COutPoint& outpoint, const CMasterNodePing& mnp);
 
     void SetMasternodeFee(const COutPoint& outpoint, const MN_FEE mnFeeType, const CAmount newFee);

--- a/src/mnode/mnode-manager.h
+++ b/src/mnode/mnode-manager.h
@@ -30,6 +30,23 @@ enum class GetTopMasterNodeStatus: int
     HISTORY_NOT_FOUND = -5,	    // historical top mn data not found
 };
 
+enum class MNCacheItem : uint8_t
+{
+    MN_LIST = 0,
+    SEEN_MN_BROADCAST,
+    SEEN_MN_PING,
+    RECOVERY_REQUESTS,
+    RECOVERY_GOOD_REPLIES,
+    ASKED_US_FOR_MN_LIST,
+    WE_ASKED_FOR_MN_LIST,
+    WE_ASKED_FOR_MN_LIST_ENTRY,
+    HISTORICAL_TOP_MNS,
+
+    COUNT
+};
+
+std::set<MNCacheItem> getAllMNCacheItems() noexcept;
+
 class CMasternodeMan
 {
 public:
@@ -249,7 +266,7 @@ public:
     std::string ToString() const;
     std::string ToJSON() const;
 
-    void ClearCache(bool clearMnList, bool clearSeenLists, bool clearRecoveryLists, bool clearAskedLists);
+    void ClearCache(const std::set<MNCacheItem> &setCacheItems);
 
     /// Update masternode list and maps using provided CMasternodeBroadcast
     void UpdateMasternodeList(CMasternodeBroadcast &mnb);

--- a/src/mnode/mnode-sync.cpp
+++ b/src/mnode/mnode-sync.cpp
@@ -8,7 +8,7 @@
 #include <main.h>
 #include <netmsg/nodemanager.h>
 
-#include "accept_to_mempool.h"
+#include <accept_to_mempool.h>
 
 #include <mnode/mnode-sync.h>
 #include <mnode/mnode-manager.h>
@@ -220,19 +220,30 @@ void CMasternodeSync::ProcessTick()
     if (IsSynced())
         return;
 
-    if (IsInitial()) {
+    if (IsInitial())
+    {
         const auto& chainparams = Params();
         const auto& consensusParams = chainparams.GetConsensus();
         const bool fInitialDownload = fnIsInitialBlockDownload(consensusParams);
-        if (!fInitialDownload) {
-            if (nTimeIBDDone == 0) {
+        if (!fInitialDownload)
+        {
+            if (nTimeIBDDone == 0)
+            {
                 nTimeIBDDone = GetTime();
-            } else if (nTimeIBDDone + (10*60) > GetTime()){
-                LogFnPrintf(
-                        "WARNING: Stuck in Initial state for too long (10min) after Initial Block Download done, restarting sync...");
-                Reset();
-                SwitchToNextAsset();
-                return;
+                LogFnPrintf("MN Sync initial state - %" PRId64, nTimeIBDDone );
+            }
+            else
+            {
+                const time_t nCurrentTime = GetTime();
+                if (nCurrentTime > nTimeIBDDone + (10 * 60))
+                {
+                    LogFnPrintf(
+                        "WARNING: Stuck in Initial state for too long (%" PRId64 " secs) after Initial Block Download done, restarting sync...",
+                        nCurrentTime - nTimeIBDDone + (10 * 60));
+                    Reset();
+                    SwitchToNextAsset();
+                    return;
+                }
             }
         }
     }

--- a/src/mnode/rpc/masternode.cpp
+++ b/src/mnode/rpc/masternode.cpp
@@ -961,7 +961,7 @@ UniValue masternode_pose_ban_score(const UniValue& params, const bool fHelp)
 
     if (fHelp || params.size() != 4 || !SCORE.IsCmdSupported())
         throw JSONRPCError(RPC_INVALID_PARAMETER,
-            R"(masternode pose-ban-score "command" "txid" index
+R"(masternode pose-ban-score "command" "txid" index
 
 Set of commands to manage PoSe (Proof-Of-Service) ban score for the local Node.
 
@@ -1139,25 +1139,58 @@ UniValue masternode_print_cache(const UniValue& params)
 
 UniValue masternode_clear_cache(const UniValue& params)
 {
+    RPC_CMD_PARSER2(MN_CLEAR_CACHE, params, all, mns, seen, recovery, asked, top__mns);
 
-    RPC_CMD_PARSER2(MN_CLEAR_CACHE, params, all, mns, seen, recovery, asked);
+    if (params.size() < 2 || !MN_CLEAR_CACHE.IsCmdSupported())
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+R"(masternode clear-cache "cache-item"
 
-    switch (MN_CLEAR_CACHE.cmd()) {
+Clear MasterNode cache items.
+
+Arguments:
+   "cache-item"   (string)  (required) The cache item to clear
+ 
+Available cache items:
+  all      - Clear all cache items
+  mns      - Clear masternode list cache
+  seen     - Clear seen masternode cache (broadcasts and pings)
+  recovery - Clear recovery cache (requests and good replies)
+  asked    - Clear asked masternode cache
+  top-mns  - Clear historical top masternodes cache
+
+Examples:
+Clear MasterNode list cache item:
+)" + HelpExampleCli("masternode clear-cache", "mns") + R"(
+As json rpc:
+)" + HelpExampleRpc("masternode clear-cache", "mns")
+);
+
+    switch (MN_CLEAR_CACHE.cmd())
+    {
         case RPC_CMD_MN_CLEAR_CACHE::all:
-            masterNodeCtrl.masternodeManager.ClearCache(true, true, true, true);
+            masterNodeCtrl.masternodeManager.ClearCache(getAllMNCacheItems());
             break;
+
         case RPC_CMD_MN_CLEAR_CACHE::mns:
-            masterNodeCtrl.masternodeManager.ClearCache(true, false, false, false);
+            masterNodeCtrl.masternodeManager.ClearCache({MNCacheItem::MN_LIST});
             break;
+
         case RPC_CMD_MN_CLEAR_CACHE::seen:
-            masterNodeCtrl.masternodeManager.ClearCache(false, true, false, false);
+            masterNodeCtrl.masternodeManager.ClearCache({MNCacheItem::SEEN_MN_BROADCAST, MNCacheItem::SEEN_MN_PING});
             break;
+
         case RPC_CMD_MN_CLEAR_CACHE::recovery:
-            masterNodeCtrl.masternodeManager.ClearCache(false, false, true, false);
+            masterNodeCtrl.masternodeManager.ClearCache({MNCacheItem::RECOVERY_REQUESTS, MNCacheItem::RECOVERY_GOOD_REPLIES});
             break;
+
         case RPC_CMD_MN_CLEAR_CACHE::asked:
-            masterNodeCtrl.masternodeManager.ClearCache(false, false, false, true);
+            masterNodeCtrl.masternodeManager.ClearCache({MNCacheItem::ASKED_US_FOR_MN_LIST, 
+                                                        MNCacheItem::WE_ASKED_FOR_MN_LIST, MNCacheItem::WE_ASKED_FOR_MN_LIST_ENTRY});
             break;
+
+        case RPC_CMD_MN_CLEAR_CACHE::top__mns:
+            masterNodeCtrl.masternodeManager.ClearCache({MNCacheItem::HISTORICAL_TOP_MNS});
+
         default:
             break;
     }

--- a/src/netmsg/block-cache.cpp
+++ b/src/netmsg/block-cache.cpp
@@ -12,8 +12,6 @@
 
 using namespace std;
 
-// max number of attempts to revalidate cached block
-constexpr uint32_t MAX_REVALIDATION_COUNT = 20;
 // min time in secs cached block should wait in a cache for the revalidation attempt
 constexpr time_t MIN_BLOCK_REVALIDATION_WAIT_TIME_SECS = 3;
 // max time in secs cached block should wait in a cache for the revalidation attempt
@@ -49,7 +47,6 @@ void CBlockCache::add_block(const uint256& hash, const NodeId& nodeId, const TxO
     if (it != m_BlockCacheMap.end())
     {
         // we have already this block in a cache
-        // just reset revalidation counter
         it->second.Added();
         LogFnPrint("net", "block %s already exists in a revalidation cache, peer=%d", hash.ToString(), nodeId);
         return;

--- a/src/netmsg/block-cache.cpp
+++ b/src/netmsg/block-cache.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2022-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <cinttypes>
+
 #include <consensus/validation.h>
 #include <scope_guard.hpp>
 #include <main.h>
@@ -10,19 +12,37 @@
 
 using namespace std;
 
+// max number of attempts to revalidate cached block
+constexpr uint32_t MAX_REVALIDATION_COUNT = 20;
+// min time in secs cached block should wait in a cache for the revalidation attempt
+constexpr time_t MIN_BLOCK_REVALIDATION_WAIT_TIME_SECS = 3;
+// max time in secs cached block should wait in a cache for the revalidation attempt
+constexpr time_t MAX_BLOCK_REVALIDATION_WAIT_TIME_SECS = 21;
+// current wait time delta in secs for the cached block revalidation attempt
+constexpr time_t DELTA_BLOCK_REVALIDATION_WAIT_TIME_SECS = 3;
+// default interval in secs to monitor cached blocks for revalidation
+constexpr time_t DEFAULT_REVALIDATION_MONITOR_INTERVAL = 30;
+// block in cache expiration time in secs
+constexpr time_t BLOCK_IN_CACHE_EXPIRATION_TIME_IN_SECS = 60 * 60; // 1 hour
+
 CBlockCache::CBlockCache() noexcept : 
-    m_bProcessing(false)
+    m_bProcessing(false),
+    m_nBlockRevalidationWaitTime(MIN_BLOCK_REVALIDATION_WAIT_TIME_SECS),
+    m_nRevalidationMonitorInterval(DEFAULT_REVALIDATION_MONITOR_INTERVAL),
+    m_nLastCheckedCacheSize(0),
+    m_nLastCacheAdjustmentTime(0)
 {}
 
 /**
  * Add block to the cache.
+ * Monitor cache size and adjust revalidation wait time if needed.
  * 
  * \param nodeId - id of the node the block was received from
  * \param block that failed validation and has to be revalidated later
  * \return true if block was added to the cache map
  *         false if block already exists in a map
   */
-bool CBlockCache::add_block(const uint256& hash, const NodeId& nodeId, const TxOrigin txOrigin, CBlock&& block) noexcept
+void CBlockCache::add_block(const uint256& hash, const NodeId& nodeId, const TxOrigin txOrigin, CBlock&& block) noexcept
 {
     unique_lock<mutex> lck(m_CacheMapLock);
     auto it = m_BlockCacheMap.find(hash);
@@ -31,7 +51,8 @@ bool CBlockCache::add_block(const uint256& hash, const NodeId& nodeId, const TxO
         // we have already this block in a cache
         // just reset revalidation counter
         it->second.Added();
-        return false;
+        LogFnPrint("net", "block %s already exists in a revalidation cache, peer=%d", hash.ToString(), nodeId);
+        return;
     }
     uint32_t nBlockHeight = 0;
     {
@@ -48,7 +69,53 @@ bool CBlockCache::add_block(const uint256& hash, const NodeId& nodeId, const TxO
         }
     }
     m_BlockCacheMap.emplace(hash, BLOCK_CACHE_ITEM(nodeId, nBlockHeight, txOrigin, move(block)));
-    return true;
+
+    // monitor cache size and adjust revalidation wait time if needed
+    time_t nCurrentTime = time(nullptr);
+    if (!m_nLastCacheAdjustmentTime)
+        m_nLastCacheAdjustmentTime = nCurrentTime;
+    else if (difftime(nCurrentTime, m_nLastCacheAdjustmentTime) > m_nRevalidationMonitorInterval)
+    {
+        AdjustBlockRevalidationWaitTime();
+        m_nLastCacheAdjustmentTime = nCurrentTime;
+    }
+                
+    LogFnPrintf("block %s cached for revalidation, peer=%d", hash.ToString(), nodeId);
+}
+
+/**
+ * Adjust block revalidation wait time.
+ * Should be called under m_CacheMapLock.
+ */
+void CBlockCache::AdjustBlockRevalidationWaitTime()
+{
+    const size_t nCurrentCacheSize = m_BlockCacheMap.size();
+    const int nRateOfCacheSizeChange = static_cast<int>(nCurrentCacheSize - m_nLastCheckedCacheSize);
+
+    const time_t nPrevBlockRevalidationWaitTime = m_nBlockRevalidationWaitTime;
+    if (nRateOfCacheSizeChange > 20) // rapid growth of cache size
+    {
+        m_nBlockRevalidationWaitTime += DELTA_BLOCK_REVALIDATION_WAIT_TIME_SECS * 2;
+        m_nRevalidationMonitorInterval = DEFAULT_REVALIDATION_MONITOR_INTERVAL / 6; // fast reaction time
+    }
+    else if (nRateOfCacheSizeChange > 5 && nRateOfCacheSizeChange <= 20) // moderate growth
+    {
+        m_nBlockRevalidationWaitTime += DELTA_BLOCK_REVALIDATION_WAIT_TIME_SECS;
+        m_nRevalidationMonitorInterval = DEFAULT_REVALIDATION_MONITOR_INTERVAL / 2;
+    }
+    else if (nRateOfCacheSizeChange < 0) // decrease of cache size
+    {
+        m_nBlockRevalidationWaitTime -= DELTA_BLOCK_REVALIDATION_WAIT_TIME_SECS;
+        m_nRevalidationMonitorInterval = DEFAULT_REVALIDATION_MONITOR_INTERVAL;
+    }
+
+    if (m_nBlockRevalidationWaitTime > MAX_BLOCK_REVALIDATION_WAIT_TIME_SECS)
+        m_nBlockRevalidationWaitTime = MAX_BLOCK_REVALIDATION_WAIT_TIME_SECS;
+    else if (m_nBlockRevalidationWaitTime < MIN_BLOCK_REVALIDATION_WAIT_TIME_SECS)
+        m_nBlockRevalidationWaitTime = MIN_BLOCK_REVALIDATION_WAIT_TIME_SECS;
+    if (nPrevBlockRevalidationWaitTime != m_nBlockRevalidationWaitTime )
+        LogFnPrint("net", "block revalidation wait time adjusted to %" PRId64 " secs", m_nBlockRevalidationWaitTime);
+    m_nLastCheckedCacheSize = nCurrentCacheSize;
 }
 
 /**
@@ -86,16 +153,44 @@ bool CBlockCache::ProcessNextBlock(const uint256 &hash)
 }
 
 /**
- * Try to revalidate cached blocks from m_BlockCacheMap.
- * Blocks are revalidated only after waiting BLOCK_REVALIDATION_WAIT_TIME secs in a cache.
+ * Erase from m_UnlinkedMap all blocks that are linked to the gived block with hash.
+ * Should be called under m_CacheMapLock.
  * 
- * \param chainparams
- * \return 
+ * \param hash - hash of the block to erase
+ */
+void CBlockCache::CleanupUnlinkedMap(const uint256& hash)
+{
+    for (auto it = m_UnlinkedMap.begin(); it != m_UnlinkedMap.end(); )
+    {
+        if (it->second == hash)
+            it = m_UnlinkedMap.erase(it);
+        else
+            ++it;
+    }
+}
+
+/**
+ * Try to revalidate cached blocks from m_BlockCacheMap.
+ * Blocks are revalidated only after waiting m_nBlockRevalidationWaitTime secs in a cache.
+ * 
+ * \param chainparams - chain parameters
+ * \return number of blocks successfully revalidated
  */
 size_t CBlockCache::revalidate_blocks(const CChainParams& chainparams)
 {
     if (m_bProcessing)
         return 0;
+
+    const auto fnDeleteCacheItems = [this](const char *szFuncName, const v_uint256& vToDelete, const char *szDesc = nullptr)
+    {
+        for (const auto &hash: vToDelete)
+        {
+            m_BlockCacheMap.erase(hash);
+            CleanupUnlinkedMap(hash);
+            if (LogAcceptCategory("net"))
+                LogPrintf("[%s] %sblock %s removed from revalidation cache", SAFE_SZ(szFuncName), SAFE_SZ(szDesc), hash.ToString());
+        }
+	};
     unique_lock<mutex> lck(m_CacheMapLock);
     // make sure this function is called only from one thread
     if (m_bProcessing)
@@ -110,7 +205,7 @@ size_t CBlockCache::revalidate_blocks(const CChainParams& chainparams)
     // also added blocks without defined node.
     v_uint256 vToDelete;
     // blocks for which revalidation failed with the status other that REJECT_MISSING_INPUTS
-    v_uint256 vRejected; 
+    v_uint256 vRejected;
     static const string strCommand("block"); // for PushMessage serialization
     string sHash; // block hash
     time_t nNow = time(nullptr);
@@ -122,16 +217,18 @@ size_t CBlockCache::revalidate_blocks(const CChainParams& chainparams)
         // skip items that being processed
         if (item.bRevalidating)
             continue;
-        // block should be revalidated only after BLOCK_REVALIDATION_WAIT_TIME secs
+        // block should be revalidated only after m_nBlockRevalidationWaitTime secs
         // from either last revalidation attempt or time the block was cached
-        if (difftime(nNow, item.GetLastUpdateTime()) < BLOCK_REVALIDATION_WAIT_TIME)
+        // this wait time is adjusted dynamically based on the cache size change rate
+        if (difftime(nNow, item.GetLastUpdateTime()) < m_nBlockRevalidationWaitTime)
             continue;
 
         // get the node from which the cached block was downloaded
         const node_t pfrom = gl_NodeManager.FindNode(item.nodeId);
         if (!pfrom)
         {
-            LogFnPrintf("could not find node by peer id=%d for block %s", item.nodeId, hash.ToString());
+            LogFnPrintf("could not find node by peer id=%d for block %s (height=%u)",
+                item.nodeId, hash.ToString(), item.nBlockHeight);
             vToDelete.push_back(hash);
             continue;
         }
@@ -149,14 +246,51 @@ size_t CBlockCache::revalidate_blocks(const CChainParams& chainparams)
         // insert the tuple at the correct position
         vToRevalidate.insert(insertionPoint, blockTuple);
     }
+    // blocks in vToRevalidate are sorted by height in ascending order
+    // if height of the first block is greater than current chain height by more than 1
+    // then this block and all subsequent blocks have no chance to be revalidated
+    uint32_t nCurrentHeight = gl_nChainHeight;
+    if (!vToRevalidate.empty() && get<2>(vToRevalidate.front())->nBlockHeight > nCurrentHeight + 1)
+    {
+        fnDeleteCacheItems(__METHOD_NAME__, vToDelete, "orphan ");
+        return 0;
+    }
+
     // try to revalidate blocks
     for (auto& [hash, pfrom, pItem] : vToRevalidate)
     {
         sHash = hash.ToString();
         CValidationState state(pItem->txOrigin);
+        uint32_t nBlockHeight = pItem->nBlockHeight;
+        nCurrentHeight = gl_nChainHeight;
+
         // revalidation attempt counter
         ++pItem->nValidationCounter;
-        uint32_t nBlockHeight = pItem->nBlockHeight;
+        // chain can be rolled back and this block become obsolete
+        // so check if block height is less than the current chain height
+        if (nBlockHeight < nCurrentHeight)
+        {
+			LogFnPrintf("block %s height %u is less than current chain height %u",
+				sHash, nBlockHeight, nCurrentHeight);
+			vToDelete.push_back(hash);
+			continue;
+		}
+        if (nBlockHeight == nCurrentHeight)
+        {
+            // block is at the tip of the chain, so it is probably downloaded from another peer
+            // and we should not revalidate it
+            LogFnPrintf("block %s (height=%u) is at the tip of the chain, skip revalidation", sHash, nBlockHeight);
+            vToDelete.push_back(hash);
+            // process next potential blocks to be included into blockchain
+            // blocks with prevBlockHash==hash are added to the multimap cache
+            if (ProcessNextBlock(hash))
+            {
+                reverse_lock<unique_lock<mutex> > rlock(lck);
+                CValidationState state1(state.getTxOrigin());
+                ActivateBestChain(state1, chainparams);
+            }
+            continue;
+        }
         {
             LOCK(cs_main);
             // reconsider this block
@@ -186,25 +320,27 @@ size_t CBlockCache::revalidate_blocks(const CChainParams& chainparams)
         }
         int nDoS = 0; // denial-of-service code
         bool bReject = false;
-        if (state.IsRejectCode(REJECT_MISSING_INPUTS))
+        const bool bIsMissingInputs = state.IsRejectCode(REJECT_MISSING_INPUTS);
+        if (bIsMissingInputs) // block failed revalidation
         {
-            // block failed revalidation again
-            // increase revalidation counter and try again after some time
-            if (pItem->nValidationCounter < MAX_REVALIDATION_COUNT)
+            // update time of the last revalidation attempt
+            pItem->nTimeValidated = time(nullptr);
+            // clear revalidating flag for this item to be processed again
+            pItem->bRevalidating = false;
+
+            // check if the block is expired - then we have to reject it
+            const double fBlockInCacheTime = difftime(nNow, pItem->nTimeAdded);
+            if (fBlockInCacheTime >= BLOCK_IN_CACHE_EXPIRATION_TIME_IN_SECS)
             {
-                pItem->nTimeValidated = time(nullptr);
-                // clear revalidating flag for this item to be processed again
-                pItem->bRevalidating = false;
-                continue;
+                LogFnPrintf("block %s (height %u) from peer=%d expired in revalidation cache (%zu secs)",
+                    sHash, nBlockHeight, pItem->nodeId, static_cast<size_t>(fBlockInCacheTime));
+                nDoS = 10;
+                bReject = true;
             }
-            LogFnPrintf("max revalidation attempts reached (%u) for block %s (height %u) from peer=%d",
-                MAX_REVALIDATION_COUNT, sHash, nBlockHeight, pItem->nodeId);
-            nDoS = 10;
-            // we have to reject the block - max number of revalidation attempts has been reached
-            bReject = true;
         } 
         else
             bReject = state.IsInvalid(nDoS);
+
         if (bReject)
         {
             // send rejection message to the same peer
@@ -215,12 +351,10 @@ size_t CBlockCache::revalidate_blocks(const CChainParams& chainparams)
             // add block hash to rejected array to be removed later from the cached map
             vRejected.push_back(hash);
         }
-        else
+        else if (!bIsMissingInputs)
         {
-            LogFnPrintf("block %s revalidated at height %u, peer=%d", sHash, nBlockHeight, pItem->nodeId);
-            // we have successfully processed this block and can safely remove it from the cache map
-            vToDelete.push_back(hash);
-            ++nCount;
+            // we have successfully revalidated this block
+            LogFnPrintf("block %s (height=%u) revalidated, peer=%d", sHash, nBlockHeight, pItem->nodeId);
 
             // process next potential blocks to be included into blockchain
             // blocks with prevBlockHash==hash are added to the multimap cache
@@ -230,20 +364,29 @@ size_t CBlockCache::revalidate_blocks(const CChainParams& chainparams)
                 CValidationState state1(state.getTxOrigin());
                 ActivateBestChain(state1, chainparams);
             }
+            if (gl_nChainHeight >= nBlockHeight)
+            {
+                // chain tip height is greater than or equal to the revalidated block height
+                // that means the block was included into the blockchain
+                // and we can safely remove it from the cache map
+                LogFnPrintf("block %s (height=%u) was included into the blockchain, removing from cache",
+                    sHash, nBlockHeight);
+                vToDelete.push_back(hash);
+                ++nCount;
+            }
+            else
+            {
+                LogFnPrintf("block %s (height=%u) was revalidated, but not included yet into the blockchain, keeping in cache");
+                // update time of the last revalidation attempt
+                pItem->nTimeValidated = time(nullptr);
+                // clear revalidating flag for this item to be processed again
+                pItem->bRevalidating = false;
+            }
         } 
     }
-    // delete processed blocks
-    for (const auto &hash: vToDelete)
-    {
-        m_BlockCacheMap.erase(hash);
-        LogFnPrint("net", "block %s removed from revalidation cache", hash.ToString());
-    }
-    // delete rejected blocks
-    for (const auto &hash : vRejected)
-    {
-        m_BlockCacheMap.erase(hash);
-        LogFnPrint("net", "rejected block %s removed from revalidation cache", hash.ToString());
-    }
+
+    fnDeleteCacheItems(__METHOD_NAME__, vToDelete);  // delete processed blocks
+    fnDeleteCacheItems(__METHOD_NAME__, vRejected, "rejected "); // delete rejected blocks
     return nCount;
 }
 

--- a/src/reverselock.h
+++ b/src/reverselock.h
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright (c) 2015 The Bitcoin Core developers
-// Copyright (c) 2022 The Pastel Core developers
+// Copyright (c) 2022-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -12,7 +12,8 @@ class reverse_lock
 {
 public:
 
-    explicit reverse_lock(Lock& lock) : lock(lock)
+    explicit reverse_lock(Lock& lock) : 
+        lock(lock)
     {
         lock.unlock();
         lock.swap(templock);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -352,12 +352,12 @@ Examples:
 + HelpExampleRpc("getblockhash", "1000")
 );
 
-    LOCK(cs_main);
-
+    uint32_t nCurrentHeight = gl_nChainHeight;
     int nHeight = params[0].get_int();
-    if (nHeight < 0 || nHeight > chainActive.Height())
+    if (nHeight < 0 || nHeight > nCurrentHeight)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Block height out of range");
 
+    LOCK(cs_main);
     CBlockIndex* pblockindex = chainActive[nHeight];
     return pblockindex->GetBlockHash().GetHex();
 }


### PR DESCRIPTION
When block is missing dependencies - it is placed into block cache for revalidation and then it tries 
to revalidate it up to 20 times with 3 secs interval (TTL=20*3 = 60 secs). After max attempts are reached - 
block is rejected and the ban score is increased by 10 points for that node. If download is too slow -
nodes become blocked sooner than blocks can be revalidated. Eventually, all the nodes are getting banned 
and download stalls.
- removed check for max revalidation attempts counter
- block cached for revalidation can stay in the cache until:
   - blockchain tip advanced already beyound that block height
   - it is successfully revalidated
   - fails on revalidation with the error other than REJECT_MISSING_INPUTS (missing dependent transactions)
   - expires after BLOCK_IN_CACHE_EXPIRATION_TIME_IN_SECS (1 hour)
- monitor revalidation cache size and adjust revalidation wait time if needed
   - revalidation time is adjusted every 30 secs (DEFAULT_REVALIDATION_MONITOR_INTERVAL)
  Initially block revalidation time is 3 secs (MIN_BLOCK_REVALIDATION_WAIT_TIME_SECS). Then we check rate of change for the cache size for the period of monitor interval:
   - If it is > 20 (rapid growth) - it increases block revalidation time to 3 + 3*2 = 9 secs (+= DELTA_BLOCK_REVALIDATION_WAIT_TIME_SECS*2) to reduce the overhead of
checking for revalidation and give more time to download actual blocks. Also, the monitor interval is decreased to 5 secs 
for the fast reaction to the rapid cache size growth.
   - If rate of change is 5..20 (moderate growth) - it increases wait time to 3 + 3 = 6 secs (+= DELTA_BLOCK_REVALIDATION_WAIT_TIME_SECS). The monitor interval is reduced to 15 secs.
   - If the rate of change < 0 (cache size is decreasing) - it sets wait time to initial 3 secs. Monitor interval is set back to default 30 secs.
   - max block revalidation time is capped at 21 secs (MAX_BLOCK_REVALIDATION_WAIT_TIME_SECS)
- added cleanup for the unlinked blocks map on removing block from cache
- remove block from cache if the chain has passed beyound that block height
- increase node ban score (+10) only when block expires in cache (after 1hr), send "reject" msg
