### PR TITLE
[PSL-1021] pasteld: Monet release

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -46,12 +46,13 @@ using namespace std;
 constexpr uint32_t MAINNET_OVERWINTER_STARTING_BLOCK = 10;
 constexpr uint32_t MAINNET_SAPLING_STARTING_BLOCK = 20;
 constexpr uint32_t MAINNET_CEZANNE_UPGRADE_STARTING_BLOCK = 337'800;
+constexpr uint32_t MAINNET_MONET_UPGRADE_STARTING_BLOCK = 575'000;
 
 // testnet upgrades activation heights
 constexpr uint32_t TESTNET_OVERWINTER_STARTING_BLOCK = 10;
 constexpr uint32_t TESTNET_SAPLING_STARTING_BLOCK = 20;
 constexpr uint32_t TESTNET_CEZANNE_UPGRADE_STARTING_BLOCK = 158'530;
-
+constexpr uint32_t TESTNET_MONET_UPGRADE_STARTING_BLOCK = 367'000;
 
 static CBlock CreateGenesisBlock(const char* pszTimestamp, 
                                  const v_uint8 &genesisPubKey, 
@@ -337,6 +338,7 @@ public:
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170005, MAINNET_OVERWINTER_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170007, MAINNET_SAPLING_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, MAINNET_CEZANNE_UPGRADE_STARTING_BLOCK);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_MONET, 170010, MAINNET_MONET_UPGRADE_STARTING_BLOCK);
         // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
         consensus.nNetworkUpgradePeerPreferenceBlockPeriod = MAINNET_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD;
         consensus.nMaxGovernanceAmount = 100'000'000 * COIN;
@@ -447,6 +449,7 @@ public:
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170005, TESTNET_OVERWINTER_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170007, TESTNET_SAPLING_STARTING_BLOCK);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, TESTNET_CEZANNE_UPGRADE_STARTING_BLOCK);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_MONET, 170010, TESTNET_MONET_UPGRADE_STARTING_BLOCK);
         // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
         consensus.nNetworkUpgradePeerPreferenceBlockPeriod = TESTNET_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD;
         consensus.nMaxGovernanceAmount = 1'000'000 * COIN;
@@ -552,6 +555,7 @@ public:
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170003, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_SAPLING, 170008, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_CEZANNE, 170009, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+        consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_MONET, 170010, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
         // The period before a network upgrade activates, where connections to upgrading peers are preferred (in blocks).
         consensus.nNetworkUpgradePeerPreferenceBlockPeriod = REGTEST_NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD;
         consensus.nMaxGovernanceAmount = 1'000'000 * COIN;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -31,6 +31,7 @@ enum class UpgradeIndex : int
     UPGRADE_OVERWINTER,
     UPGRADE_SAPLING,
     UPGRADE_CEZANNE,
+    UPGRADE_MONET,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES
 };

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -35,6 +35,11 @@ const struct NUInfo NetworkUpgradeInfo[to_integral_type(Consensus::UpgradeIndex:
         /*.nBranchId =*/ 0x26ab2455,
         /*.strName =*/ "Cezanne",
         /*.strInfo =*/ "See https://pastel.network/cezanne-mainnet-release/ for details.",
+    },
+    {
+        /*.nBranchId =*/ 0x017014e2,
+        /*.strName =*/ "Monet",
+        /*.strInfo =*/ "See https://pastel.network/monet-mainnet-release/ for details.",
     }
 };
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright (c) 2012-2014 The Bitcoin Core developers
-// Copyright (c) 2018-2022 The Pastel Core developers
+// Copyright (c) 2018-2023 The Pastel Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -8,10 +8,10 @@
  * network protocol versioning
  */
 
-inline constexpr int PROTOCOL_VERSION = 170009;
+inline constexpr int PROTOCOL_VERSION = 170010;
 
-// min MasterNodes protocol version before Cezanne upgrade
-inline constexpr int MN_MIN_PROTOCOL_VERSION = 170008;
+// min MasterNodes protocol version before Monet upgrade
+inline constexpr int MN_MIN_PROTOCOL_VERSION = 170009;
 
 //! initial proto version, to be increased after version/verack negotiation
 inline constexpr int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
pasteld v2.0.0.0
- added new Monet upgrade with release height 575'000 (mainnet), 367'000 (testnet)
- protocol version changed to 170010, min supported MN protocol version 170009