### PR TITLE
[PSL-1101] pasteld: add API to get total coin supply for the current height

### DIFF
--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="..\..\..\src\pow.cpp" />
     <ClCompile Include="..\..\..\src\rest.cpp" />
     <ClCompile Include="..\..\..\src\rpc\blockchain.cpp" />
+    <ClCompile Include="..\..\..\src\rpc\coin-supply.cpp" />
     <ClCompile Include="..\..\..\src\rpc\mining.cpp" />
     <ClCompile Include="..\..\..\src\rpc\misc.cpp" />
     <ClCompile Include="..\..\..\src\rpc\net.cpp">
@@ -305,6 +306,7 @@
     <ClInclude Include="..\..\..\src\policy\fees.h" />
     <ClInclude Include="..\..\..\src\pow.h" />
     <ClInclude Include="..\..\..\src\reverselock.h" />
+    <ClInclude Include="..\..\..\src\rpc\coin-supply.h" />
     <ClInclude Include="..\..\..\src\rpc\rpc_consts.h" />
     <ClInclude Include="..\..\..\src\rpc\server.h" />
     <ClInclude Include="..\..\..\src\script_check.h" />

--- a/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
+++ b/build-aux/vs2022/libbitcoin_server/libbitcoin_server.vcxproj.filters
@@ -343,6 +343,9 @@
     <ClCompile Include="..\..\..\src\mnode\rpc\generate-report.cpp">
       <Filter>Source Files\mnode\rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\rpc\coin-supply.cpp">
+      <Filter>Source Files\rpc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\addrman.h">
@@ -710,6 +713,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\src\mnode\rpc\generate-report.h">
       <Filter>Source Files\mnode\rpc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\rpc\coin-supply.h">
+      <Filter>Source Files\rpc</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/qa/rpc-tests/mn_main.py
+++ b/qa/rpc-tests/mn_main.py
@@ -154,7 +154,7 @@ class MasterNodeMainTest (MasterNodeCommon):
             stop_node(self.nodes[self.cold_node_num])
 
             print(f"Waiting for {mn.alias} EXPIRED state on all other nodes...")
-            self.wait_for_mn_state(30, 20, "EXPIRED", mn_id, 8, self.nodes[1:])
+            self.wait_for_mn_state(50, 30, "EXPIRED", mn_id, 8, self.nodes[1:])
 
             print(f"Starting node {self.cold_node_num} as Masternode again...")
             self.nodes[self.cold_node_num] = start_node(self.cold_node_num, self.options.tmpdir, mn_params)
@@ -162,7 +162,7 @@ class MasterNodeMainTest (MasterNodeCommon):
             self.sync_all()
 
             print(f"Waiting for {mn.alias} ENABLED state...")
-            self.wait_for_mn_state(30, 20, "ENABLED", mn_id, 8)
+            self.wait_for_mn_state(50, 30, "ENABLED", mn_id, 8)
 
         # tests = ['cache', 'sync', 'ping', 'restart', 'spent', "fee"]
         if 'restart' in tests:
@@ -171,7 +171,7 @@ class MasterNodeMainTest (MasterNodeCommon):
             stop_node(self.nodes[self.cold_node_num])
 
             print(f"Waiting for {mn.alias} EXPIRED state on all other nodes...")
-            self.wait_for_mn_state(30, 20, "EXPIRED", mn_id, 15, self.nodes[1:])
+            self.wait_for_mn_state(50, 30, "EXPIRED", mn_id, 15, self.nodes[1:])
             
             print(f"Waiting for {mn.alias} NEW_START_REQUIRED state on all other nodes...")
             self.wait_for_mn_state(60, 30, "NEW_START_REQUIRED", mn_id, 15, self.nodes[1:])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -363,6 +363,7 @@ BITCOIN_CORE_H = \
   pubkey.h \
   random.h \
   rpc/client.h \
+  rpc/coin-supply.h \
   rpc/protocol.h \
   rpc/server.h \
   rpc/register.h \
@@ -456,6 +457,7 @@ libbitcoin_server_a_SOURCES = \
   pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
+  rpc/coin-supply.cpp \
   rpc/mining.cpp \
   rpc/misc.cpp \
   rpc/net.cpp \

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -20,6 +20,7 @@
 #include <main.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
+#include <rpc/coin-supply.h>
 
 using namespace std;
 
@@ -1301,6 +1302,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               true  },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
     { "blockchain",         "verifychain",            &verifychain,            true  },
+    { "blockchain",         "get-total-coin-supply",  &getTotalCoinSupply,     true  },
 
     // insightexplorer
     { "blockchain",         "getblockdeltas",         &getblockdeltas,         false },    

--- a/src/rpc/coin-supply.cpp
+++ b/src/rpc/coin-supply.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2023 The Pastel Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <stdexcept>
+#include <atomic>
+
+#include <utils/sync.h>
+#include <utils/svc_thread.h>
+#include <main.h>
+#include <rpc/protocol.h>
+#include <rpc/coin-supply.h>
+
+using namespace std;
+
+void ProcessBlockFile(int nFile, v_uint32& vOffsets, atomic<CAmount> &totalCoinSupplyRef)
+{
+    const auto& consensusParams = Params().GetConsensus();
+    CAmount nTotalCoinSupply = 0;
+
+    // sort offsets in ascending order
+    std::sort(vOffsets.begin(), vOffsets.end());
+
+    // read blocks from disk and process
+    for (const auto& nOffset : vOffsets)
+    {
+        CDiskBlockPos blockPos(nFile, nOffset);
+        CBlock block;
+        if (!ReadBlockFromDisk(block, blockPos, consensusParams))
+            throw JSONRPCError(RPC_MISC_ERROR, "Failed to get total coin supply. ReadBlockFromDisk failed");
+
+        if (block.vtx.empty())
+			continue;
+        const auto &tx = block.vtx[0];
+        if (!tx.IsCoinBase())
+            continue;
+
+        for (const auto &out : tx.vout)
+            nTotalCoinSupply += out.nValue;
+    }
+    vOffsets.clear();
+    totalCoinSupplyRef.fetch_add(nTotalCoinSupply, memory_order_relaxed);
+}
+
+UniValue getTotalCoinSupply(const UniValue& params, bool fHelp)
+{
+    if (fHelp || !params.empty())
+        throw runtime_error(
+R"(get-total-coin-supply
+
+Returns the total supply of coins as of current active chain height.
+)");
+
+    static constexpr auto MSG_GET_TOTAL_SUPPLY_FAILED = "Failed to get total coin supply.";
+    static constexpr auto MAX_THREADS = 5U;
+
+    uint32_t nCurrentHeight = gl_nChainHeight;
+    LogFnPrintf("Calculating total coin supply for the height=%d...", nCurrentHeight);
+   
+    static constexpr auto VOFFSET_VECTOR_RESERVE = 2000U;
+    unordered_map<int, v_uint32> mapBlockFiles;
+
+    {
+        LOCK(cs_main);
+
+        auto pindex = chainActive.Tip();
+        while (pindex)
+        {
+            const auto &diskBlockPos = pindex->GetBlockPos();
+            auto it = mapBlockFiles.find(diskBlockPos.nFile);
+            if (it == mapBlockFiles.end())
+			{
+                mapBlockFiles[diskBlockPos.nFile] = v_uint32();
+
+                auto &vOffsets = mapBlockFiles[diskBlockPos.nFile];
+                vOffsets.reserve(VOFFSET_VECTOR_RESERVE);
+                vOffsets.push_back(diskBlockPos.nPos);
+			}
+            else
+            {
+                auto &vOffsets = it->second;
+                if (vOffsets.capacity() - vOffsets.size() == 0)
+                    vOffsets.reserve(vOffsets.capacity() + VOFFSET_VECTOR_RESERVE);
+				vOffsets.push_back(diskBlockPos.nPos);
+			}
+
+            pindex = pindex->pprev;
+        }
+    }
+
+    atomic<CAmount> nTotalCoinSupply = 0;
+    CServiceThreadGroup threadGroup;
+    for (auto &[nFile, vOffsets] : mapBlockFiles)
+	{
+        if (threadGroup.size() >= MAX_THREADS)
+            threadGroup.join_all();
+
+        threadGroup.add_func_thread(strprintf("coin-supply-%d", nFile).c_str(),
+            bind(&ProcessBlockFile, nFile, ref(vOffsets), ref(nTotalCoinSupply)));
+	}
+    threadGroup.join_all();
+    LogFnPrintf("Total coin supply for the height=%d is %.5f", nCurrentHeight, GetTruncatedPSLAmount(nTotalCoinSupply));
+
+    UniValue retObj(UniValue::VOBJ);
+    retObj.pushKV("totalCoinSupply", GetTruncatedPSLAmount(nTotalCoinSupply.load()));
+    retObj.pushKV("totalCoinSupplyPat", nTotalCoinSupply.load());
+    retObj.pushKV("height", static_cast<uint64_t>(nCurrentHeight));
+    return retObj;
+}

--- a/src/rpc/coin-supply.h
+++ b/src/rpc/coin-supply.h
@@ -1,0 +1,7 @@
+#pragma once
+// Copyright (c) 2023 The Pastel Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+#include <univalue.h>
+
+UniValue getTotalCoinSupply(const UniValue& params, bool fHelp);


### PR DESCRIPTION
- added new RPC API to calculate total coin supply for the current height get-total-coin-supply
{
    "result": {
        "totalCoinSupplyPat": 1449125105336874,
        "totalCoinSupply": 14491251053.36874,
        "height": 597645
    },
    "error": null,
    "id": "1"
}
The initial implementation was traversing the whole blockchain and summing up coinbase transactions. It was slow (12 mins) and held cs_main lock for the whole duration of the calculation. 

Changed implementation:
 - collect under cs_main all information about block data location in the block db: block location is identified by block file number and offset. Block location info is stored into the map: <file_no, offsets_vector>.
 - sort offsets in the vectors in ascending order to access block data in the file sequentially (improves speed)
 - all offset vectors are processed in the thread pool (max 5 threads) concurrently accumulating total coin supply 
 - this implementation reduced execution time to 2.5 mins. 
 - cs_main lock is held only for a few seconds for block offset collection.