### PR TITLE
[PSL-1134] Failed MN Eligibility block revalidation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2939,8 +2939,10 @@ bool CheckBlock(
         // to mine this block and receive rewards
         uint32_t nMinedBlocks = 0;
         if (gl_pMiningEligibilityManager && 
-            !gl_pMiningEligibilityManager->IsMnEligibleForBlockReward(pindexPrev, block.sPastelID, nMinedBlocks))
+            !gl_pMiningEligibilityManager->IsMnEligibleForBlockReward(pindexPrev, 
+                block.sPastelID, block.GetBlockTime(), nMinedBlocks))
 		{
+            gl_pMiningEligibilityManager->SetInvalidEligibilityBlock(hashBlock, static_cast<uint32_t>(pindexPrev->nHeight + 1), state.getTxOrigin());
             strRejectReasonDetails = strprintf("MasterNode '%s' (mnid: %s) is not eligible to mine this block %s (mined blocks: %u)",
                 				mnInfo.GetDesc(), block.sPastelID, hashBlock.ToString(), nMinedBlocks);
 			return state.DoS(10, error("%s: %s", __func__, strRejectReasonDetails),

--- a/src/mining/eligibility-mgr.h
+++ b/src/mining/eligibility-mgr.h
@@ -7,10 +7,13 @@
 #include <optional>
 #include <mutex>
 #include <vector>
+#include <chrono>
 
 #include <utils/set_types.h>
 #include <chain.h>
 #include <mnode/mnode-masternode.h>
+
+constexpr uint32_t MAX_ELIGIBILITY_REVALIDATION_RETRIES = 3;
 
 struct CMnMiningEligibility
 {
@@ -37,17 +40,70 @@ struct CMnMiningEligibility
 
 using mining_eligibility_vector_t = std::vector<CMnMiningEligibility>;
 
+// block with failed eligibility check
+class CInvalidEligibilityBlock
+{
+public:
+	CInvalidEligibilityBlock() noexcept
+	{
+        Clear();
+    }
+
+    void Set(const uint256& hash, const uint32_t nHeight, const TxOrigin txOrigin) noexcept;
+
+    void Check();
+
+private:
+	uint256 m_hash;       // hash of the block
+	uint32_t m_nHeight;   // height of the block
+	TxOrigin m_txOrigin;  // origin of the block
+	uint32_t m_nRetries;  // number of retries to revalidate the block
+    std::chrono::system_clock::time_point m_time; // time when the block was added to the cache
+    std::chrono::system_clock::time_point m_NextRevalidationTime; // time of the next revalidation attempt
+
+    enum class STATE
+    {
+		NOT_SET = 0,
+        EXPIRED_BY_HEIGHT,
+        EXCEEDED_RETRIES,
+        NOT_READY_FOR_NEXT_REVALIDATION,
+        READY_FOR_NEXT_REVALIDATION
+	};
+
+    void Clear() noexcept;
+
+    bool IsSet() const noexcept
+    {
+		return !m_hash.IsNull() && (m_nHeight > 0);
+	}
+
+    bool IsExpiredByHeight() const noexcept
+    {
+        return (m_nHeight > 0) && (m_nHeight <= gl_nChainHeight);
+    }
+
+    bool IsExceededRetries() const noexcept
+    {
+		return m_nRetries >= MAX_ELIGIBILITY_REVALIDATION_RETRIES;
+	}
+
+    void SetNextRevalidationTime() noexcept;
+    STATE IsReadyForNextRevalidation() const noexcept;
+    bool CanTryToRevalidate() noexcept;
+};
+
 class CMiningEligibilityManager : public CStoppableServiceThread
 {
 public:
-	CMiningEligibilityManager();
+	CMiningEligibilityManager() noexcept;
 
-    bool IsMnEligibleForBlockReward(const CBlockIndex *pindex, const std::string &sGenId,
-        uint32_t &nMinedBlocks) const noexcept;
-    bool IsCurrentMnEligibleForBlockReward(const CBlockIndex *pindex) noexcept;
+    bool IsMnEligibleForBlockReward(const CBlockIndex *pindexPrev, const std::string &sGenId,
+        const int64_t nCurBlockTime, uint32_t &nMinedBlocks) const noexcept;
+    bool IsCurrentMnEligibleForBlockReward(const CBlockIndex *pindexPrev, const int64_t nCurBlockTime) noexcept;
     mining_eligibility_vector_t GetMnEligibilityInfo(uint64_t &nMiningEnabledCount, uint32_t &nHeight,
         const std::optional<bool> &eligibilityFilter = std::nullopt) noexcept;
     void UpdatedBlockTip(const CBlockIndex* pindexNew);
+    void SetInvalidEligibilityBlock(const uint256 &hash, const uint32_t nHeight, const TxOrigin txOrigin);
 
     void execute() override;
 
@@ -58,10 +114,11 @@ private:
     std::atomic_bool m_bAllMasterNodesAreEligibleForMining;
     std::atomic_bool m_bIsCurrentMnEligibleForMining;
     uint32_t m_nLastBlockHeight;
-    uint256 m_hashCheckBlock; // block hash to check for eligibility (used for caching eligibility for multiple miner threads)
+    uint256 m_hashCheckBlock; // hash of the block to check for eligibility (used for caching eligibility for multiple miner threads)
+    CInvalidEligibilityBlock m_invalidEligibilityBlock;
 
     void execute_internal();
-	std::unordered_map<std::string, uint32_t> GetLastMnIdsWithBlockReward(const CBlockIndex* pindex) const noexcept;
+	std::unordered_map<std::string, uint32_t> GetLastMnIdsWithBlockReward(const CBlockIndex* pindexPrev) const noexcept;
     std::unordered_map<std::string, std::pair<uint32_t, uint256>> GetUniqueMnIdsWithBlockReward(const CBlockIndex* pindex, const uint32_t nBlocksToScan) noexcept;
     void ChangeMiningEligibility(const bool bSet);
 };

--- a/src/mining/miner.cpp
+++ b/src/mining/miner.cpp
@@ -654,7 +654,8 @@ void static PastelMiner(const int nThreadNo)
                         break;
                     {
 						LOCK(cs_main);
-                        if (gl_pMiningEligibilityManager && gl_pMiningEligibilityManager->IsCurrentMnEligibleForBlockReward(chainActive.Tip()))
+                        if (gl_pMiningEligibilityManager && 
+                            gl_pMiningEligibilityManager->IsCurrentMnEligibleForBlockReward(chainActive.Tip(), GetTime()))
 						    sEligiblePastelID = gl_MiningSettings.getGenId();
                         else
                             sEligiblePastelID= nullopt;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -634,7 +634,7 @@ Examples:
     if (mnInfo.getOutPoint() != masterNodeCtrl.activeMasternode.outpoint)
         throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("current masternode info does not match mnid '%s'", sGenId));
 
-    if (gl_pMiningEligibilityManager && !gl_pMiningEligibilityManager->IsCurrentMnEligibleForBlockReward(pChainTip))
+    if (gl_pMiningEligibilityManager && !gl_pMiningEligibilityManager->IsCurrentMnEligibleForBlockReward(pChainTip, GetTime()))
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Masternode is not eligible for mining next block");
 
     SecureString sPassPhrase;
@@ -1105,7 +1105,8 @@ Examples:
     if (!DecodeHexBlk(block, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-    if (!masterNodeCtrl.IsSynced())
+    const auto& chainparams = Params();
+    if (!chainparams.IsRegTest() && !masterNodeCtrl.IsSynced())
         throw JSONRPCError(RPC_INTERNAL_ERROR, 
             "Your masternode list is not synced yet! Cannot submit a block to the network until the mnsync status (IsSynced=true) shows full sync!");
 
@@ -1132,7 +1133,7 @@ Examples:
     RegisterValidationInterface(&sc);
     {
         auto guard = sg::make_scope_guard([&]() noexcept { UnregisterValidationInterface(&sc); });
-        fAccepted = ProcessNewBlock(state, Params(), nullptr, &block, true, nullptr);
+        fAccepted = ProcessNewBlock(state, chainparams, nullptr, &block, true, nullptr);
     }
     if (fBlockPresent)
     {

--- a/src/utils/svc_thread.h
+++ b/src/utils/svc_thread.h
@@ -34,7 +34,7 @@ extern thread_local CServiceThread *funcThreadObj;
 class CServiceThread
 {
 public:
-    CServiceThread(const char *szThreadName) : 
+    CServiceThread(const char *szThreadName) noexcept: 
         m_bTrace(true),
         m_bRunning(false),
         m_bStopRequested(false)
@@ -181,7 +181,7 @@ private:
 class CStoppableServiceThread : public CServiceThread
 {
 public:
-    CStoppableServiceThread(const char *szThreadName) : 
+    CStoppableServiceThread(const char *szThreadName) noexcept: 
         CServiceThread(szThreadName)
     {}
 


### PR DESCRIPTION
If MN eligibility validation fails on one block - this block is marked invalid and the chain stalls.

Cache this block info to eligibility manager to revalidate later. This invalid block is revalidated in eligibility manager thread up to 3 times: at 6,16 and 31 mins after it was cached. Block revalidation does the following:
- checks if active chain has already passed that block height - cached block info cleared in this case
- finds block index by hash
- calls reconsiderblock and then ActivateBestChain
- checks if the active chain passed cached block height after ActivateBestChain call - clears invalid cached block info