### PR TITLE
Vermeer mining options changes

### DIFF
--- a/qa/rpc-tests/mn_common.py
+++ b/qa/rpc-tests/mn_common.py
@@ -191,9 +191,7 @@ class MasterNodeCommon (PastelTestFramework):
                 datadir.mkdir()
             conf_file = Path(datadir, "pastel.conf")
             with conf_file.open('a') as f:
-                f.write(f"genpastelid={self.mnid}\n")
                 f.write(f"genpassphrase={self.passphrase}\n")
-                f.write("genenablemnmining=1\n")
         
 
         def create_masternode_conf(self, dirname: str, node_index: int):
@@ -230,6 +228,7 @@ class MasterNodeCommon (PastelTestFramework):
             config[name]["extCfg"] = {}
             config[name]["extCfg"]["param1"] = str(random.randint(0, 9))
             config[name]["extCfg"]["param2"] = str(random.randint(0, 9))
+            config[name]["enableMnMining"] = True
 
             print(f"Creating masternode.conf for node {name}...")
             with cfg_file.open('w') as f:

--- a/qa/rpc-tests/mn_main.py
+++ b/qa/rpc-tests/mn_main.py
@@ -161,7 +161,7 @@ class MasterNodeMainTest (MasterNodeCommon):
             self.sync_all()
 
             print(f"Waiting for {mn.alias} ENABLED state...")
-            self.wait_for_mn_state(80, 40, "ENABLED", mn_id, 8)
+            self.wait_for_mn_state(80, 40, "ENABLED", mn_id, 12)
 
         # tests = ['cache', 'sync', 'ping', 'restart', 'spent', "fee"]
         if 'restart' in tests:

--- a/qa/rpc-tests/mn_tickets_validation.py
+++ b/qa/rpc-tests/mn_tickets_validation.py
@@ -341,7 +341,7 @@ class MasterNodeTicketsTest(MasterNodeCommon):
                 print(f'{test_desс}: {self.errorString}')
                 if 'messageDetails' in e.error:
                     print(f"{test_desс}: {e.error['messageDetails']}")
-            assert_equal("bad-tx-invalid-ticket" in self.errorString, True)
+            assert_true("bad-tx-invalid-ticket" in self.errorString or "tx-missing-inputs" in self.errorString)
 
         print("== NFT Registration Activation ticket transaction validation tested ==")
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -52,7 +52,7 @@ constexpr uint32_t MAINNET_OVERWINTER_STARTING_BLOCK = 10;
 constexpr uint32_t MAINNET_SAPLING_STARTING_BLOCK = 20;
 constexpr uint32_t MAINNET_CEZANNE_UPGRADE_STARTING_BLOCK = 337'800;
 constexpr uint32_t MAINNET_MONET_UPGRADE_STARTING_BLOCK = 575'000;
-constexpr uint32_t MAINNET_VERMEER_UPGRADE_STARTING_BLOCK = 647'500;
+constexpr uint32_t MAINNET_VERMEER_UPGRADE_STARTING_BLOCK = 648'500;
 
 // testnet upgrades activation heights
 constexpr uint32_t TESTNET_OVERWINTER_STARTING_BLOCK = 10;
@@ -594,7 +594,7 @@ public:
         consensus.nPowMaxAdjustDown = 32; // 32% adjustment down
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
         consensus.nPowTargetSpacing = static_cast<int64_t>(2.5 * 60);
-        consensus.nPowAllowMinDifficultyBlocksAfterHeight = 299'187;
+        consensus.nPowAllowMinDifficultyBlocksAfterHeight = DEVNET_VERMEER_UPGRADE_STARTING_BLOCK;
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::BASE_SPROUT, 170002, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_TESTDUMMY, 170002, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
         consensus.AddNetworkUpgrade(Consensus::UpgradeIndex::UPGRADE_OVERWINTER, 170005, DEVNET_OVERWINTER_STARTING_BLOCK);

--- a/src/mining/miner.h
+++ b/src/mining/miner.h
@@ -30,13 +30,13 @@ struct CBlockTemplate
 };
 
 /** Generate a new block, without valid proof-of-work */
-CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn, const std::string& sEligiblePastelID);
+CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn, const bool v5Block, const std::string& sEligiblePastelID);
 #ifdef ENABLE_WALLET
 std::optional<CScript> GetMinerScriptPubKey(CReserveKey& reservekey, const CChainParams& chainparams);
-CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, const CChainParams& chainparams, const std::string& sEligiblePastelID);
+CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, const CChainParams& chainparams, const bool v5Block, const std::string& sEligiblePastelID);
 #else
 std::optional<CScript> GetMinerScriptPubKey(const CChainParams& chainparams);
-CBlockTemplate* CreateNewBlockWithKey(const CChainParams& chainparams, const std::string& sEligiblePastelID);
+CBlockTemplate* CreateNewBlockWithKey(const CChainParams& chainparams, const bool v5Block, const std::string& sEligiblePastelID);
 #endif
 
 #ifdef ENABLE_MINING

--- a/src/mining/mining-settings.h
+++ b/src/mining/mining-settings.h
@@ -33,11 +33,12 @@ public:
     uint32_t getBlockMinSize() const noexcept { return m_nBlockMinSize; }
     EquihashSolver getEquihashSolver() const noexcept { return m_equihashSolver; }
     std::string getEquihashSolverName() const noexcept;
-    bool isEligibleForMining() const noexcept { return m_bEligibleForMining; }
+    bool isEligibleForMining() const noexcept;
 
-    std::string getGenId() const noexcept { return m_sGenId; }
-    bool getGenIdInfo(const std::string &sMnId, SecureString& sPassPhrase) const noexcept;
+    std::string getGenId() const noexcept;
+    bool getGenInfo(SecureString& sPassPhrase) const noexcept;
     bool refreshMnIdInfo(std::string& error, const bool bRefreshConfig);
+	bool CheckMNSettingsForLocalMining(std::string &error);
 
 private:
     bool m_bInitialized;
@@ -47,12 +48,9 @@ private:
     uint32_t m_nBlockPrioritySize;
     uint32_t m_nBlockMinSize;
     EquihashSolver m_equihashSolver;
-    bool m_bEligibleForMining; // genenablemnmining option
 
     std::mutex m_mutexGenIds;
-    std::string m_sGenId; // current masternode's mnid used for mining
     SecureString m_sGenPassPhrase; // current masternode's passphrase used for mining
-    std::atomic_size_t m_nGenIdIndex; // index of the current PastelID in the m_mapGenIds
 };
 
 extern CMinerSettings gl_MiningSettings;

--- a/src/mnode/mnode-active.cpp
+++ b/src/mnode/mnode-active.cpp
@@ -239,8 +239,9 @@ bool CActiveMasternode::CheckMnId(const COutPoint& outPoint)
         nState = ActiveMasternodeState::NeedMnId;
         return false;
     }
+    m_sMNPastelID = mnidTicket.getPastelID();
     LogFnPrint("masternode", "Masternode '%s' has registered Pastel ID (mnid): %s",
-        outPoint.ToStringShort(), mnidTicket.getPastelID());
+        outPoint.ToStringShort(), m_sMNPastelID);
     return true;
 }
 
@@ -249,10 +250,11 @@ void CActiveMasternode::ManageStateRemote()
     LogFnPrint("masternode", "Start status = %s, type = %s, pinger %s, pubKeyMasternode.GetID() = %s",
         GetStatus(), GetTypeString(), m_bPingerEnabled ? "enabled" : "disabled", pubKeyMasternode.GetID().ToString());
 
-    masterNodeCtrl.masternodeManager.CheckMasternode(pubKeyMasternode, true);
-    masternode_info_t infoMn;
     const auto& chainparams = Params();
     const auto& consensusParams = chainparams.GetConsensus();
+    masternode_info_t infoMn;
+
+    masterNodeCtrl.masternodeManager.CheckMasternode(pubKeyMasternode, true);
     const auto lastNetworkUpgrade = consensusParams.GetLastNetworkUpgrade();
     if (masterNodeCtrl.masternodeManager.GetMasternodeInfo(pubKeyMasternode, infoMn))
     {
@@ -299,6 +301,7 @@ void CActiveMasternode::ManageStateRemote()
             LogFnPrintf("*** MasterNode '%s' has been STARTED! *** ", outpoint.ToStringShort());
             service = infoMn.get_addr();
             m_bPingerEnabled = true;
+            m_bEligibleForMining = infoMn.IsEligibleForMining();
             nState = ActiveMasternodeState::Started;
             // relay mnb
             auto pmn = masterNodeCtrl.masternodeManager.Get(USE_LOCK, outpoint);

--- a/src/mnode/mnode-active.cpp
+++ b/src/mnode/mnode-active.cpp
@@ -282,6 +282,13 @@ void CActiveMasternode::ManageStateRemote()
             LogFnPrintf("%s: %s", GetStateString(), strNotCapableReason);
             return;
         }
+        // check if masternode mining eligibility flag has changed
+        if (m_bEligibleForMining != infoMn.IsEligibleForMining())
+        {
+			m_bEligibleForMining = infoMn.IsEligibleForMining();
+            LogFnPrintf("Masternode '%s' mining eligibility flag is %s",
+                outpoint.ToStringShort(), m_bEligibleForMining ? "ON" : "OFF");
+        }
         if (!IsStarted())
         {
             // can assign outpoint - will be used to register mnid
@@ -301,14 +308,12 @@ void CActiveMasternode::ManageStateRemote()
             LogFnPrintf("*** MasterNode '%s' has been STARTED! *** ", outpoint.ToStringShort());
             service = infoMn.get_addr();
             m_bPingerEnabled = true;
-            m_bEligibleForMining = infoMn.IsEligibleForMining();
             nState = ActiveMasternodeState::Started;
             // relay mnb
             auto pmn = masterNodeCtrl.masternodeManager.Get(USE_LOCK, outpoint);
             if (pmn)
             {
-                if (str_icmp(pmn->getMNPastelID(), gl_MiningSettings.getGenId()))
-                    pmn->SetEligibleForMining(gl_MiningSettings.isEligibleForMining());
+                pmn->SetEligibleForMining(m_bEligibleForMining);
                 LogFnPrint("masternode", "Masternode '%s' was started % " PRId64 " mins ago (eligibleForMining=%d)",
                     pmn->GetDesc(), pmn->GetLastBroadcastAge() / 60, pmn->IsEligibleForMining());
                 CMasterNodePing mnp(outpoint);

--- a/src/mnode/mnode-config.h
+++ b/src/mnode/mnode-config.h
@@ -1,6 +1,6 @@
 #pragma once
 // Copyright (c) 2014-2017 The Dash Core developers
-// Copyright (c) 2019-2023 The Pastel Core developers
+// Copyright (c) 2019-2024 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <vector>
@@ -24,11 +24,12 @@ public:
             std::string extAddress;
             std::string extP2P;
             std::string extCfg;
+            bool bEligibleForMining;
 
         public:
             CMasternodeEntry() noexcept = default;
             CMasternodeEntry(const std::string &alias, std::string &&mnAddress, std::string &&mnPrivKey, std::string &&txHash, 
-                std::string &&outputIndex, std::string &&extAddress, std::string &&extP2P, std::string &&extCfg) noexcept
+                std::string &&outputIndex, std::string &&extAddress, std::string &&extP2P, std::string &&extCfg, bool bEligibleForMining) noexcept
             {
                 this->alias = alias;
                 this->mnAddress = std::move(mnAddress);
@@ -38,6 +39,7 @@ public:
                 this->extAddress = std::move(extAddress);
                 this->extP2P = std::move(extP2P);
                 this->extCfg = std::move(extCfg);
+                this->bEligibleForMining = bEligibleForMining;
             }
 
             const std::string& getAlias() const noexcept { return alias; }
@@ -48,6 +50,7 @@ public:
             const std::string& getExtIp() const noexcept { return extAddress; }
             const std::string& getExtP2P() const noexcept { return extP2P; }
             const std::string& getExtCfg() const noexcept { return extCfg; }
+            bool isEligibleForMining() const noexcept { return bEligibleForMining; }
 
             COutPoint getOutPoint() const noexcept;
     };

--- a/src/mnode/mnode-masternode.cpp
+++ b/src/mnode/mnode-masternode.cpp
@@ -1099,8 +1099,8 @@ bool CMasternodeBroadcast::InitFromConfig(string &error, const CMasternodeConfig
         // MNID is not registered on first run, will be checked later on
         if (!CheckAndUpdateMNID(error))
             m_ActiveState = MASTERNODE_STATE::PRE_ENABLED;
-        else if (str_icmp(gl_MiningSettings.getGenId(), m_sMNPastelID))
-            SetEligibleForMining(gl_MiningSettings.isEligibleForMining());
+        else if (!m_sMNPastelID.empty())
+            SetEligibleForMining(mne.isEligibleForMining());
         m_nVersion = CMasternode::MASTERNODE_VERSION;
 
         bRet = true;

--- a/src/mnode/mnode-masternode.cpp
+++ b/src/mnode/mnode-masternode.cpp
@@ -1190,7 +1190,8 @@ CMasternodeBroadcast::MNB_UPDATE_RESULT CMasternodeBroadcast::Update(string& err
         return MNB_UPDATE_RESULT::NOT_FOUND;
     }
     const bool bVersionUpdate = pmn->GetVersion() < GetVersion();
-    const bool bHashUpdate = pmn->GetHash() != GetHash();
+    const auto& hashMNB = GetHash();
+    const bool bHashUpdate = pmn->GetHash() != hashMNB;
     if (pmn->sigTime == sigTime && !fRecovery && !bVersionUpdate && !bHashUpdate)
     {
         // mapSeenMasternodeBroadcast in CMasternodeMan::CheckMnbAndUpdateMasternodeList should filter legit duplicates
@@ -1239,7 +1240,8 @@ CMasternodeBroadcast::MNB_UPDATE_RESULT CMasternodeBroadcast::Update(string& err
     if (!pmn->IsBroadcastedWithin(masterNodeCtrl.MasternodeMinMNBSeconds) || masterNodeCtrl.IsOurMasterNode(pubKeyMasternode))
     {
         // take the newest entry
-        LogFnPrintf("Got UPDATED Masternode '%s' entry: addr=%s (v%hd)", pmn->GetDesc(), m_addr.ToString(), GetVersion());
+        LogFnPrintf("Got UPDATED Masternode '%s' entry: addr=%s (v%hd, mnb '%s')", pmn->GetDesc(), 
+            m_addr.ToString(), GetVersion(), hashMNB.ToString());
         if (pmn->UpdateFromNewBroadcast(*this))
             pmn->Check(true, SKIP_LOCK);
         masterNodeCtrl.masternodeSync.BumpAssetLastTime(__METHOD_NAME__);

--- a/src/mnode/rpc/masternode.h
+++ b/src/mnode/rpc/masternode.h
@@ -1,5 +1,5 @@
 #pragma once
-// Copyright (c) 2018-2023 The Pastel Core developers
+// Copyright (c) 2018-2024 The Pastel Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -638,7 +638,7 @@ Examples:
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Masternode is not eligible for mining next block");
 
     SecureString sPassPhrase;
-    if (!gl_MiningSettings.getGenIdInfo(sGenId, sPassPhrase))
+    if (!gl_MiningSettings.getGenInfo(sPassPhrase))
     {
 		LogPrintf("ERROR: PastelMiner: failed to get passphrase for PastelID '%s'\n", sGenId);
 		throw runtime_error(strprintf("PastelMiner: failed to access secure container for Pastel ID '%s'", sGenId));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -249,12 +249,17 @@ Generate 11 blocks
     UniValue blockHashes(UniValue::VARR);
     unsigned int n = consensusParams.nEquihashN;
     unsigned int k = consensusParams.nEquihashK;
+    const size_t nNewMiningAllowedHeight = consensusParams.GetNetworkUpgradeActivationHeight(Consensus::UpgradeIndex::UPGRADE_VERMEER);
+
     while (nHeight < nHeightEnd)
     {
+        const bool bV5Block = (nNewMiningAllowedHeight == Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) || 
+			(gl_nChainHeight >= nNewMiningAllowedHeight);
+
 #ifdef ENABLE_WALLET
-        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey, chainparams, sEligiblePastelID));
+        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey, chainparams, bV5Block, sEligiblePastelID));
 #else
-        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(chainparams, sEligiblePastelID));
+        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(chainparams, bV5Block, sEligiblePastelID));
 #endif
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Wallet keypool empty");
@@ -923,11 +928,15 @@ Examples:
 
         // Create new block
         safe_delete_obj(pblocktemplate);
+
+        const size_t nNewMiningAllowedHeight = consensusParams.GetNetworkUpgradeActivationHeight(Consensus::UpgradeIndex::UPGRADE_VERMEER);
+        const bool bV5Block = chainparams.IsTestNet() || (nNewMiningAllowedHeight == Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) || 
+			(gl_nChainHeight >= nNewMiningAllowedHeight);
 #ifdef ENABLE_WALLET
         CReserveKey reservekey(pwalletMain);
-        pblocktemplate = CreateNewBlockWithKey(reservekey, chainparams, "");
+        pblocktemplate = CreateNewBlockWithKey(reservekey, chainparams, bV5Block, "");
 #else
-        pblocktemplate = CreateNewBlockWithKey(chainparams, "");
+        pblocktemplate = CreateNewBlockWithKey(chainparams, bV5Block, "");
 #endif
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");


### PR DESCRIPTION
- changed Vermeer upgrade height to 648'500
- changed min difficulty filter for devnet to 29'000 (same as upgrade height)
- moved genenablemnmining option to masternode.conf: new option name: "enableMnMining"
- changes in CMinerSettings class: - read only "genpassphrase" option from pastel.conf, don't read options -genpastelid or -genenablemnmining - get GenId from local active masternode
- PastelMiner thread:
   - check for valid mn mining settings (check is activated only after Vermeer upgrade): - MN has registered MNID (locally) - passphrase is defined in pastel.conf - secure container can be accessed using passphrase - enableMnMining option is enabled
- set eligibleForMining flag in mnb (masternode broadcast) from MasterNode config entry