### PR TITLE
 [PSL-1229] pasteld: handle keep-alive connections

### DIFF
--- a/.circleci/DockerBuild.bat
+++ b/.circleci/DockerBuild.bat
@@ -1,4 +1,4 @@
-docker build -t akobrin/pastel:0.0.8 .
+docker build -t akobrin/pastel:0.0.9 .
 
 rem docker run -it akobrin/pastel:0.0.3 /bin/bash
 rem git clone https://github.com/pastelnetwork/pastel.git .

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV TZ=America/New_York
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
@@ -6,12 +6,12 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
   && apt install -y --no-install-recommends \
      pkg-config tzdata make automake cmake libtool patch \
      bsdmainutils curl wget zip unzip lbzip2 xz-utils zlib1g-dev git openssh-client \
-     g++-10-multilib mingw-w64 python3-dev python3-pip gnupg2 iputils-ping \
-  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave \
-     /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
+     g++-11-multilib mingw-w64 python3-dev python3-pip gnupg2 iputils-ping \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave \
+     /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11 \
   && update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix \
   && update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix \
-  && ln -fs /usr/bin/x86_64-linux-gnu-gcc-10 /usr/bin/x86_64-linux-gnu-gcc \
+  && ln -fs /usr/bin/x86_64-linux-gnu-gcc-11 /usr/bin/x86_64-linux-gnu-gcc \
   && ln -fs /usr/bin/gcc /usr/bin/cc \
   && pip3 install pyblake2 simplejson \
   && apt clean \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 executors:
   pastel-builder:
     docker:
-      - image: akobrin/pastel:0.0.8
+      - image: akobrin/pastel:0.0.9
 commands:
   upload-s3:
     parameters:

--- a/build-aux/vs2022/pasteld/pasteld.vcxproj
+++ b/build-aux/vs2022/pasteld/pasteld.vcxproj
@@ -98,6 +98,7 @@
     <ClCompile Include="..\..\vs\port\unistd.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\src\clientversion.h" />
     <ClInclude Include="..\..\..\src\version.h" />
     <ClInclude Include="..\..\vs\port\unistd.h" />
   </ItemGroup>

--- a/build-aux/vs2022/pasteld/pasteld.vcxproj.filters
+++ b/build-aux/vs2022/pasteld/pasteld.vcxproj.filters
@@ -31,6 +31,9 @@
     <ClInclude Include="..\..\..\src\version.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\clientversion.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\..\src\pasteld-res.rc">

--- a/configure.ac
+++ b/configure.ac
@@ -2,8 +2,8 @@ dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
 AC_PREREQ([2.60])
 define(_CLIENT_VERSION_MAJOR, 2)
 define(_CLIENT_VERSION_MINOR, 2)
-define(_CLIENT_VERSION_REVISION, 5)
-define(_CLIENT_VERSION_BUILD, 1)
+define(_CLIENT_VERSION_REVISION, 6)
+define(_CLIENT_VERSION_BUILD, 0)
 define(_ZC_BUILD_VAL,
     m4_if(m4_eval(_CLIENT_VERSION_BUILD < 25), 1, m4_incr(_CLIENT_VERSION_BUILD),
         m4_eval(_CLIENT_VERSION_BUILD < 50), 1, 
@@ -78,8 +78,8 @@ case "${host}" in
      AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory], [nodefault])
      ;;
   *)
-    dnl Require C++17 compiler (no GNU extensions)
-    AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory], [nodefault])
+    dnl Require C++20 compiler (no GNU extensions)
+    AX_CXX_COMPILE_STDCXX([20], [noext], [mandatory], [nodefault])
 esac
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -11,7 +11,7 @@ $(package)_config_opts=--disable-shared --enable-cxx --disable-replication --ena
 $(package)_config_opts_mingw32=--enable-mingw --with-mutex=POSIX/pthreads/library/x86_64/gcc-assembly
 $(package)_config_opts_linux=--with-pic
 $(package)_config_opts_debug=--enable-debug
-$(package)_cxxflags+=-std=c++17
+$(package)_cxxflags+=-std=c++20
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -19,7 +19,7 @@ $(package)_config_opts_i686=architecture=x86 address-model=32
 $(package)_config_opts_aarch64=address-model=64
 $(package)_config_opts_armv7a=address-model=32
 $(package)_config_libraries=filesystem,program_options,system
-$(package)_cxxflags+=-std=c++17 -fvisibility=hidden
+$(package)_cxxflags+=-std=c++20 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_toolset_linux=gcc
 $(package)_toolset_mingw32=gcc

--- a/depends/packages/googletest.mk
+++ b/depends/packages/googletest.mk
@@ -6,9 +6,9 @@ $(package)_download_file=v$($(package)_version).tar.gz
 $(package)_sha256_hash=8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
 
 define $(package)_set_vars
-$(package)_cxxflags+= -std=c++17
+$(package)_cxxflags+= -std=c++20
 $(package)_cxxflags_linux= -fPIC
-$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD=17
+$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD=20
 $(package)_cmake_opts+= -DCMAKE_CXX_STANDARD_REQUIRED=ON
 $(package)_cmake_opts+= -DCMAKE_CXX_EXTENSIONS=OFF
 $(package)_cmake_opts+= -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/depends/packages/zstd.mk
+++ b/depends/packages/zstd.mk
@@ -9,9 +9,9 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_set_vars
-$(package)_cxxflags+=-std=c++17
+$(package)_cxxflags+=-std=c++20
 $(package)_cxxflags_linux=-fPIC
-$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD=17
+$(package)_cmake_opts+= -DCMAKE_CXX_STANDARD=20
 $(package)_cmake_opts+= -DCMAKE_CXX_STANDARD_REQUIRED=ON
 $(package)_cmake_opts+= -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 $(package)_cmake_opts+= -DZSTD_BUILD_SHARED=OFF

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -16,8 +16,8 @@
 //! These need to be macros, as clientversion.cpp's and pastel*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 2
 #define CLIENT_VERSION_MINOR 2
-#define CLIENT_VERSION_REVISION 5
-#define CLIENT_VERSION_BUILD 1
+#define CLIENT_VERSION_REVISION 6
+#define CLIENT_VERSION_BUILD 0
 
 //! Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE true

--- a/src/gtest/test_httprpc.cpp
+++ b/src/gtest/test_httprpc.cpp
@@ -12,14 +12,14 @@ using namespace testing;
 class MockHTTPRequest : public HTTPRequest
 {
 public:
-    MOCK_METHOD(const CService&, GetPeer, (), (const, noexcept, override));
+    MOCK_METHOD(const string, GetPeerStr, (), (const, noexcept, override));
     MOCK_METHOD(RequestMethod, GetRequestMethod, (), (const, noexcept, override));
     MOCK_METHOD((std::pair<bool, std::string>), GetHeader, (const std::string& hdr), (const, noexcept, override));
     MOCK_METHOD(void, WriteHeader, (const std::string& hdr, const std::string& value), (override));
     MOCK_METHOD(void, WriteReply, (HTTPStatusCode status, const std::string& strReply), (override));
 
     MockHTTPRequest() : 
-        HTTPRequest(-1, nullptr, 0)
+        HTTPRequest(nullptr, nullptr)
     {}
 
     void CleanUp()
@@ -55,15 +55,14 @@ TEST(HTTPRPC, FailsWithoutAuthHeader) {
 
 TEST(HTTPRPC, FailsWithBadAuth)
 {
-    const CService mockService("127.0.0.1", 1337);
     MockHTTPRequest req;
 
     EXPECT_CALL(req, GetRequestMethod())
         .WillRepeatedly(Return(RequestMethod::POST));
     EXPECT_CALL(req, GetHeader("authorization"))
         .WillRepeatedly(Return(std::make_pair(true, "Basic spam:eggs")));
-    EXPECT_CALL(req, GetPeer())
-        .WillRepeatedly(ReturnRef(mockService));
+    EXPECT_CALL(req, GetPeerStr())
+        .WillRepeatedly(Return(""));
     EXPECT_CALL(req, WriteHeader("WWW-Authenticate", "Basic realm=\"jsonrpc\""))
         .Times(1);
     EXPECT_CALL(req, WriteReply(HTTPStatusCode::UNAUTHORIZED, ""))

--- a/src/gtest/test_rpc_wallet.cpp
+++ b/src/gtest/test_rpc_wallet.cpp
@@ -1153,7 +1153,7 @@ TEST_F(TestRpcWallet2, rpc_z_mergetoaddress_parameters)
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     CheckRPCThrows("z_mergetoaddress", "1 2",
-        "Error: z_mergetoaddress is disabled. Run './pascal-cli help z_mergetoaddress' for instructions on how to enable this feature.");
+        "Error: z_mergetoaddress is disabled. Run './pastel-cli help z_mergetoaddress' for instructions on how to enable this feature.");
 
     // Set global state required for z_mergetoaddress
     fExperimentalMode = true;

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -113,7 +113,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const string &)
 
     if (!RPCAuthorized(authHeader.second))
     {
-        LogPrintf("ThreadRPCServer incorrect password attempt from %s\n", req->GetPeer().ToString());
+        LogPrintf("ThreadRPCServer incorrect password attempt from %s\n", req->GetPeerStr());
 
         /* Deter brute-forcing
            If this results in a DoS the user really

--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -543,7 +543,7 @@ void ThreadShowMetricsScreen()
             // Explain how to exit
             cout << "[";
 #ifdef WIN32
-            cout << translate("'pascal-cli.exe stop' to exit");
+            cout << translate("'pastel-cli.exe stop' to exit");
 #else
             cout << translate("Press Ctrl+C to exit");
 #endif

--- a/src/mining/miner.cpp
+++ b/src/mining/miner.cpp
@@ -5,7 +5,7 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include <tuple>
 #include <atomic>
-#if defined(__MINGW64__) || defined(__linux__)
+#if defined(__MINGW64__)
 #include <pthread.h>
 #elif defined(__APPLE__)
 #include <mining/pow/tromp/osx_barrier.h>
@@ -15,7 +15,7 @@
 #ifdef ENABLE_MINING
 #include <functional>
 #endif
-#if defined(__MINGW64__) || defined(__APPLE__) || defined(__linux__)
+#if defined(__MINGW64__) || defined(__APPLE__)
 #define USE_PTHREAD_BARRIER
 #endif
 

--- a/src/mining/pow/tromp/equi_miner.h
+++ b/src/mining/pow/tromp/equi_miner.h
@@ -21,7 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cassert>
-#if defined(__MINGW64__) || defined(__linux__)
+#if defined(__MINGW64__)
 #include <pthread.h>
 #elif defined(__APPLE__)
 #include <mining/pow/tromp/osx_barrier.h>
@@ -29,7 +29,7 @@
 #include <barrier>
 #endif
 
-#if defined(__MINGW64__) || defined(__APPLE__) || defined(__linux__)
+#if defined(__MINGW64__) || defined(__APPLE__)
 #define USE_PTHREAD_BARRIER
 #endif
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4265,7 +4265,7 @@ Examples:
         );
 
     if (!fEnableMergeToAddress) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Error: z_mergetoaddress is disabled. Run './pascal-cli help z_mergetoaddress' for instructions on how to enable this feature.");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error: z_mergetoaddress is disabled. Run './pastel-cli help z_mergetoaddress' for instructions on how to enable this feature.");
     }
 
     LOCK2(cs_main, pwalletMain->cs_wallet);


### PR DESCRIPTION
 pasteld v2.2.6
 Added separate class to keep information about HTTP Connection.
 Now requests coming from the existing keep-alive http connection create
 only HTTPRequest object without connection info.
 HTTPRequest object lifetime is now limited to http_request_cb callback.
 Save http connections only in unordered_map with client socket as a key (CHttpWorkerContext).
 - added accept error handler.
 - improved logging

 other changes:
  - returned c++20/gcc-11 changes for Linux
  - added Ctrl-C console handler for Windows to shutdown pasteld
  - improved shutdown when pasteld is still in initialization mode (added some checks to exit earlier)